### PR TITLE
Expand test coverage: helpers unit test + E2E for core commands

### DIFF
--- a/features/entities/entities.feature
+++ b/features/entities/entities.feature
@@ -1,0 +1,71 @@
+Feature: Entity management
+  As a CLI user
+  I want to manage context entities
+  So that I can create, read, update, and delete IoT data
+
+  Scenario: List entities when none exist
+    Given I am logged in
+    When I run "geonic entities list"
+    Then the exit code should be 0
+    And stdout should contain "[]"
+
+  Scenario: Create an entity
+    Given I am logged in
+    When I create entity "Room:001" of type "Room"
+    Then the exit code should be 0
+    And the output should contain "Entity created."
+
+  Scenario: Get an entity by ID
+    Given I am logged in
+    And I create entity "Room:002" of type "Room"
+    When I run "geonic entities get Room:002"
+    Then the exit code should be 0
+    And stdout should be valid JSON
+    And the JSON output should have key "id"
+
+  Scenario: List shows created entities
+    Given I am logged in
+    And I create entity "Room:003" of type "Room"
+    When I run "geonic entities list"
+    Then the exit code should be 0
+    And the output should contain "Room:003"
+
+  Scenario: Filter entities by type
+    Given I am logged in
+    And I create entity "Room:010" of type "Room"
+    And I create entity "Car:010" of type "Car"
+    When I run "geonic entities list --type Room"
+    Then the exit code should be 0
+    And the output should contain "Room:010"
+    And the output should not contain "Car:010"
+
+  Scenario: List entities with count
+    Given I am logged in
+    And I create entity "Room:020" of type "Room"
+    When I run "geonic entities list --count"
+    Then the exit code should be 0
+    And the output should contain "Count:"
+
+  Scenario: Update an entity
+    Given I am logged in
+    And I create entity "Room:030" of type "Room"
+    When I update entity "Room:030" with '{"temperature":{"value":25,"type":"Number"}}'
+    Then the exit code should be 0
+    And the output should contain "Entity updated."
+
+  Scenario: Delete an entity
+    Given I am logged in
+    And I create entity "Room:040" of type "Room"
+    When I run "geonic entities delete Room:040"
+    Then the exit code should be 0
+    And the output should contain "Entity deleted."
+
+  Scenario: Get non-existent entity returns error
+    Given I am logged in
+    When I run "geonic entities get NonExistent:999"
+    Then the exit code should be 1
+
+  Scenario: List entities without authentication
+    Given I am not logged in
+    When I run "geonic entities list"
+    Then the exit code should be 1

--- a/features/health/health.feature
+++ b/features/health/health.feature
@@ -1,0 +1,22 @@
+Feature: Health and version
+  As a CLI user
+  I want to check server health and version
+  So that I can verify connectivity and compatibility
+
+  Scenario: Health check returns valid JSON
+    Given I am logged in
+    When I run "geonic health"
+    Then the exit code should be 0
+    And stdout should be valid JSON
+
+  Scenario: Health check without URL configured
+    Given no config file exists
+    When I run "geonic health"
+    Then the exit code should be 1
+    And the output should contain "No URL configured"
+
+  Scenario: Version displays CLI version
+    Given I am logged in
+    When I run "geonic version"
+    Then the exit code should be 0
+    And the output should contain "CLI version:"

--- a/features/step_definitions/entities.steps.ts
+++ b/features/step_definitions/entities.steps.ts
@@ -1,0 +1,17 @@
+import { When } from "@cucumber/cucumber";
+import type { GdbWorld } from "../support/world.js";
+
+When(
+  "I create entity {string} of type {string}",
+  async function (this: GdbWorld, id: string, type: string) {
+    const entity = JSON.stringify({ id, type });
+    await this.run(["entities", "create", entity]);
+  },
+);
+
+When(
+  "I update entity {string} with {string}",
+  async function (this: GdbWorld, id: string, json: string) {
+    await this.run(["entities", "update", id, json]);
+  },
+);

--- a/features/step_definitions/subscriptions.steps.ts
+++ b/features/step_definitions/subscriptions.steps.ts
@@ -1,0 +1,32 @@
+import { Given, When } from "@cucumber/cucumber";
+import { strict as assert } from "node:assert";
+import type { GdbWorld } from "../support/world.js";
+
+When("I create a subscription for type {string}", async function (this: GdbWorld, type: string) {
+  const sub = JSON.stringify({
+    description: `Notify on ${type} changes`,
+    subject: {
+      entities: [{ type }],
+      condition: { attrs: ["temperature"] },
+    },
+    notification: {
+      http: { url: "http://localhost:9999/notify" },
+      attrs: ["temperature"],
+    },
+  });
+  await this.run(["subscriptions", "create", sub]);
+});
+
+Given("I get the subscription ID from the list", async function (this: GdbWorld) {
+  await this.run(["subscriptions", "list", "--format", "json"]);
+  assert.equal(this.lastResult.exitCode, 0, `Failed to list subscriptions: ${this.lastResult.stderr}`);
+  const subs = JSON.parse(this.lastResult.stdout);
+  assert.ok(Array.isArray(subs) && subs.length > 0, "No subscriptions found");
+  (this as Record<string, unknown>).subscriptionId = subs[0].id;
+});
+
+When("I delete the subscription", async function (this: GdbWorld) {
+  const id = (this as Record<string, unknown>).subscriptionId as string;
+  assert.ok(id, "No subscription ID saved");
+  await this.run(["subscriptions", "delete", id]);
+});

--- a/features/subscriptions/subscriptions.feature
+++ b/features/subscriptions/subscriptions.feature
@@ -1,0 +1,25 @@
+Feature: Subscription management
+  As a CLI user
+  I want to manage context subscriptions
+  So that I can receive notifications about entity changes
+
+  Scenario: Create a subscription
+    Given I am logged in
+    When I create a subscription for type "Room"
+    Then the exit code should be 0
+    And the output should contain "Subscription created."
+
+  Scenario: List subscriptions
+    Given I am logged in
+    And I create a subscription for type "Room"
+    When I run "geonic subscriptions list"
+    Then the exit code should be 0
+    And the output should contain "Room"
+
+  Scenario: Delete a subscription
+    Given I am logged in
+    And I create a subscription for type "Room"
+    And I get the subscription ID from the list
+    When I delete the subscription
+    Then the exit code should be 0
+    And the output should contain "Subscription deleted."

--- a/features/types/types.feature
+++ b/features/types/types.feature
@@ -1,0 +1,18 @@
+Feature: Entity types
+  As a CLI user
+  I want to browse entity types
+  So that I can discover what data is available
+
+  Scenario: List entity types
+    Given I am logged in
+    And I create entity "Room:100" of type "Room"
+    When I run "geonic types list"
+    Then the exit code should be 0
+    And the output should contain "Room"
+
+  Scenario: Get entity type details
+    Given I am logged in
+    And I create entity "Room:101" of type "Room"
+    When I run "geonic types get Room"
+    Then the exit code should be 0
+    And stdout should be valid JSON

--- a/src/client.ts
+++ b/src/client.ts
@@ -188,10 +188,10 @@ export class GdbClient {
 
     let data: T;
     const contentType = response.headers.get("content-type") ?? "";
-    if (contentType.includes("json") || contentType.includes("ld+json")) {
-      data = (await response.json()) as T;
+    const text = await response.text();
+    if (text && (contentType.includes("json") || contentType.includes("ld+json"))) {
+      data = JSON.parse(text) as T;
     } else {
-      const text = await response.text();
       data = text as unknown as T;
     }
 
@@ -224,10 +224,10 @@ export class GdbClient {
 
     let data: T;
     const contentType = response.headers.get("content-type") ?? "";
-    if (contentType.includes("json") || contentType.includes("ld+json")) {
-      data = (await response.json()) as T;
+    const text = await response.text();
+    if (text && (contentType.includes("json") || contentType.includes("ld+json"))) {
+      data = JSON.parse(text) as T;
     } else {
-      const text = await response.text();
       data = text as unknown as T;
     }
 

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -30,7 +30,7 @@ export function registerVersionCommand(program: Command): void {
     .action(
       withErrorHandler(async (_opts: unknown, cmd: Command) => {
         const require = createRequire(import.meta.url);
-        const pkg = require("../../package.json") as { version: string };
+        const pkg = require("../package.json") as { version: string };
         const cliVersion = pkg.version;
 
         printInfo(`CLI version: ${cliVersion}`);

--- a/tests/helpers.test.ts
+++ b/tests/helpers.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { Command } from "commander";
+import type { GlobalOptions, ClientResponse } from "../src/types.js";
+
+vi.mock("../src/output.js", () => ({
+  printError: vi.fn(),
+  printOutput: vi.fn(),
+  printCount: vi.fn(),
+}));
+
+import { printError, printOutput, printCount } from "../src/output.js";
+import { saveConfig } from "../src/config.js";
+import { GdbClientError, GdbClient } from "../src/client.js";
+import {
+  resolveOptions,
+  createClient,
+  getFormat,
+  outputResponse,
+  withErrorHandler,
+} from "../src/helpers.js";
+
+function fakeCmd(cliOpts: Partial<GlobalOptions> = {}): Command {
+  return { optsWithGlobals: () => ({ ...cliOpts }) } as unknown as Command;
+}
+
+describe("helpers", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "geonic-test-"));
+    process.env.GEONIC_CONFIG_DIR = join(tempDir, "geonic");
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    delete process.env.GEONIC_CONFIG_DIR;
+    delete process.env.GDB_API_KEY;
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  describe("resolveOptions", () => {
+    it("CLI flag takes priority over config value", () => {
+      saveConfig({ url: "http://config.example.com" });
+      const opts = resolveOptions(fakeCmd({ url: "http://cli.example.com" }));
+      expect(opts.url).toBe("http://cli.example.com");
+    });
+
+    it("config value used when CLI flag not set", () => {
+      saveConfig({ url: "http://config.example.com", service: "tenant-a" });
+      const opts = resolveOptions(fakeCmd());
+      expect(opts.url).toBe("http://config.example.com");
+      expect(opts.service).toBe("tenant-a");
+    });
+
+    it("defaults api to v2 and format to json", () => {
+      const opts = resolveOptions(fakeCmd());
+      expect(opts.api).toBe("v2");
+      expect(opts.format).toBe("json");
+    });
+
+    it("apiKey falls back: CLI -> env (GDB_API_KEY) -> config", () => {
+      saveConfig({ apiKey: "config-key" });
+
+      // CLI wins
+      const opts1 = resolveOptions(fakeCmd({ apiKey: "cli-key" }));
+      expect(opts1.apiKey).toBe("cli-key");
+
+      // env wins over config
+      process.env.GDB_API_KEY = "env-key";
+      const opts2 = resolveOptions(fakeCmd());
+      expect(opts2.apiKey).toBe("env-key");
+
+      // config used as last fallback
+      delete process.env.GDB_API_KEY;
+      const opts3 = resolveOptions(fakeCmd());
+      expect(opts3.apiKey).toBe("config-key");
+    });
+
+    it("loads profile-specific config", () => {
+      saveConfig({ url: "http://default.example.com" });
+      saveConfig({ url: "http://staging.example.com" }, "staging");
+      const opts = resolveOptions(fakeCmd({ profile: "staging" }));
+      expect(opts.url).toBe("http://staging.example.com");
+    });
+
+    it("returns defaults when all options are empty", () => {
+      const opts = resolveOptions(fakeCmd());
+      expect(opts.url).toBeUndefined();
+      expect(opts.service).toBeUndefined();
+      expect(opts.servicePath).toBeUndefined();
+      expect(opts.api).toBe("v2");
+      expect(opts.format).toBe("json");
+      expect(opts.token).toBeUndefined();
+      expect(opts.apiKey).toBeUndefined();
+    });
+  });
+
+  describe("createClient", () => {
+    it("exits with code 1 when no URL is configured", () => {
+      const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+        throw new Error("process.exit");
+      });
+      expect(() => createClient(fakeCmd())).toThrow("process.exit");
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(printError).toHaveBeenCalledWith(
+        expect.stringContaining("No URL configured"),
+      );
+      exitSpy.mockRestore();
+    });
+
+    it("creates GdbClient with correct options when URL is configured", () => {
+      saveConfig({ url: "http://localhost:1026", service: "myTenant" });
+      const client = createClient(fakeCmd());
+      expect(client).toBeInstanceOf(GdbClient);
+    });
+
+    it("sets refreshToken to undefined when CLI --token is passed", () => {
+      saveConfig({
+        url: "http://localhost:1026",
+        token: "config-token",
+        refreshToken: "config-refresh",
+      });
+      const client = createClient(fakeCmd({ token: "cli-token" }));
+      // The client is created; we verify that usingCliToken path is taken
+      // by checking that onTokenRefresh is not set — we can't inspect private fields
+      // but we can verify the client was created successfully
+      expect(client).toBeInstanceOf(GdbClient);
+    });
+
+    it("sets onTokenRefresh callback when token comes from config", () => {
+      saveConfig({
+        url: "http://localhost:1026",
+        token: "config-token",
+        refreshToken: "config-refresh",
+      });
+      // No CLI token — token comes from config, so onTokenRefresh should be set
+      const client = createClient(fakeCmd());
+      expect(client).toBeInstanceOf(GdbClient);
+    });
+  });
+
+  describe("getFormat", () => {
+    it("returns format from CLI options", () => {
+      const format = getFormat(fakeCmd({ format: "table" }));
+      expect(format).toBe("table");
+    });
+
+    it("returns json as default when no format is set", () => {
+      const format = getFormat(fakeCmd());
+      expect(format).toBe("json");
+    });
+  });
+
+  describe("outputResponse", () => {
+    it("prints count when showCount is true and response.count is defined", () => {
+      const response: ClientResponse = {
+        status: 200,
+        headers: new Headers(),
+        data: [{ id: "e1" }],
+        count: 42,
+      };
+      outputResponse(response, "json", true);
+      expect(printCount).toHaveBeenCalledWith(42);
+      expect(printOutput).toHaveBeenCalledWith([{ id: "e1" }], "json");
+    });
+
+    it("does NOT print count when showCount is false", () => {
+      const response: ClientResponse = {
+        status: 200,
+        headers: new Headers(),
+        data: [{ id: "e1" }],
+        count: 42,
+      };
+      outputResponse(response, "json", false);
+      expect(printCount).not.toHaveBeenCalled();
+    });
+
+    it("prints data when response.data is defined and not empty string", () => {
+      const response: ClientResponse = {
+        status: 200,
+        headers: new Headers(),
+        data: { id: "Room:001" },
+      };
+      outputResponse(response, "table");
+      expect(printOutput).toHaveBeenCalledWith({ id: "Room:001" }, "table");
+    });
+
+    it("does NOT print data when response.data is undefined", () => {
+      const response: ClientResponse = {
+        status: 204,
+        headers: new Headers(),
+        data: undefined,
+      };
+      outputResponse(response, "json");
+      expect(printOutput).not.toHaveBeenCalled();
+    });
+
+    it("does NOT print data when response.data is empty string", () => {
+      const response: ClientResponse = {
+        status: 200,
+        headers: new Headers(),
+        data: "",
+      };
+      outputResponse(response, "json");
+      expect(printOutput).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("withErrorHandler", () => {
+    let exitSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+        throw new Error("process.exit");
+      });
+    });
+
+    afterEach(() => {
+      exitSpy.mockRestore();
+    });
+
+    it("completes normally when no error is thrown", async () => {
+      const fn = vi.fn().mockResolvedValue(undefined);
+      const wrapped = withErrorHandler(fn);
+      await wrapped("arg1", "arg2");
+      expect(fn).toHaveBeenCalledWith("arg1", "arg2");
+      expect(exitSpy).not.toHaveBeenCalled();
+    });
+
+    it("prints auth message and exits on 401 GdbClientError", async () => {
+      const fn = vi.fn().mockRejectedValue(new GdbClientError("Unauthorized", 401));
+      const wrapped = withErrorHandler(fn);
+      await expect(wrapped()).rejects.toThrow("process.exit");
+      expect(printError).toHaveBeenCalledWith(
+        expect.stringContaining("Authentication failed"),
+      );
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it("prints error message and exits on generic Error", async () => {
+      const fn = vi.fn().mockRejectedValue(new Error("something broke"));
+      const wrapped = withErrorHandler(fn);
+      await expect(wrapped()).rejects.toThrow("process.exit");
+      expect(printError).toHaveBeenCalledWith("something broke");
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it("prints String(err) and exits on non-Error throw", async () => {
+      const fn = vi.fn().mockRejectedValue("raw string error");
+      const wrapped = withErrorHandler(fn);
+      await expect(wrapped()).rejects.toThrow("process.exit");
+      expect(printError).toHaveBeenCalledWith("raw string error");
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `tests/helpers.test.ts` with 21 unit test cases covering all 5 exported functions (`resolveOptions`, `createClient`, `getFormat`, `outputResponse`, `withErrorHandler`)
- Add E2E feature files and step definitions for entities (10 scenarios), health/version (3), subscriptions (3), and types (2) — 18 new scenarios total
- Fix client crash on empty-body JSON responses (e.g., 201 Created) by reading response as text first
- Fix `version` command `package.json` path resolution for bundled dist output

## Test plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` — 85/85 unit tests pass
- [x] `npm run test:e2e` — 51/51 scenarios, 221/221 steps pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * エンティティ管理、ヘルスチェック、サブスクリプション、タイプ探索に関する新しいテストシナリオを追加しました。
  * ヘルパー関数の包括的なテストスイートを追加し、オプション解決、クライアント作成、エラーハンドリングをカバーしています。

* **Bug Fixes**
  * JSON応答の解析ロジックを改善し、より安全な処理を実現しました。
  * バージョン情報の取得パスを修正しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->