### PR TITLE
Change default port from 1026 to 3000 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The CLI is available as `geonic`.
 
 ```bash
 # Set the server URL
-geonic config set url http://localhost:1026
+geonic config set url http://localhost:3000
 
 # Create an entity
 geonic entities create '{"id":"Room1","type":"Room","temperature":{"value":23,"type":"Number"}}'
@@ -349,7 +349,7 @@ The CLI stores configuration in `~/.config/geonic/config.json`.
 
 ```bash
 # Set the default server
-geonic config set url http://localhost:1026
+geonic config set url http://localhost:3000
 
 # Use NGSI-LD by default
 geonic config set api ld


### PR DESCRIPTION
## Summary
- READMEの Quick Start および Configuration セクションのデフォルトポート番号を `1026` から `3000` に変更

## Test plan
- [ ] README の該当箇所が正しく `localhost:3000` になっていることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * READMEのサンプルコマンドに記載されているサーバーURL参照を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->