### PR TITLE
Compact GLOBAL PARAMETERS and OPTIONS in help output

### DIFF
--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -62,17 +62,19 @@ function formatSynopsis(path: string, cmd: Command): string {
   return parts.join(" ");
 }
 
+function formatOptionList(options: readonly Option[]): string[] {
+  const maxLen = Math.max(...options.map((o) => o.flags.length));
+  return options.map((opt) => {
+    const flags = opt.flags.padEnd(maxLen + 2);
+    return `  ${chalk.green(flags)}${opt.description ?? ""}`;
+  });
+}
+
 function formatGlobalParameters(program: Command): string {
   const lines: string[] = [];
   lines.push(header("GLOBAL PARAMETERS"));
   lines.push("");
-  for (const opt of program.options) {
-    lines.push(`  ${chalk.green(opt.flags)}`);
-    if (opt.description) {
-      lines.push(`      ${opt.description}`);
-    }
-    lines.push("");
-  }
+  lines.push(...formatOptionList(program.options));
   return lines.join("\n");
 }
 
@@ -162,13 +164,7 @@ export function formatCommandDetails(
       lines.push("");
       lines.push(header("OPTIONS"));
       lines.push("");
-      for (const opt of options) {
-        lines.push(`  ${chalk.green(opt.flags)}`);
-        if (opt.description) {
-          lines.push(`      ${opt.description}`);
-        }
-        lines.push("");
-      }
+      lines.push(...formatOptionList(options));
     }
   }
 


### PR DESCRIPTION
## Summary

- Render flags and description on a single aligned line instead of 3 lines (flags / description / blank)
- Applies to both GLOBAL PARAMETERS and per-command OPTIONS sections
- Shared `formatOptionList()` helper aligns columns like SUBCOMMANDS already does

**Before** (25 lines for GLOBAL PARAMETERS):
```
GLOBAL PARAMETERS

  -u, --url <url>
      Base URL of the GeonicDB server

  -s, --service <name>
      NGSILD-Tenant header
  ...
```

**After** (10 lines):
```
GLOBAL PARAMETERS

  -u, --url <url>       Base URL of the GeonicDB server
  -s, --service <name>  NGSILD-Tenant header
  ...
```

## Test plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` — all 124 tests pass
- [x] `npm run build && node dist/index.js help` — output verified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * ヘルプコマンドのオプション表示がより見やすく整理されました。フラグの配置とフォーマットが統一されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->