### PR TITLE
Standardize command descriptions to start with verbs

### DIFF
--- a/src/commands/admin/index.ts
+++ b/src/commands/admin/index.ts
@@ -7,7 +7,7 @@ import { registerOAuthClientsCommand, registerCaddeCommand } from "./oauth-clien
 export function registerAdminCommand(program: Command): void {
   const admin = program
     .command("admin")
-    .description("Admin management commands");
+    .description("Manage admin resources");
 
   registerTenantsCommand(admin);
   registerUsersCommand(admin);

--- a/src/commands/admin/oauth-clients.ts
+++ b/src/commands/admin/oauth-clients.ts
@@ -6,7 +6,7 @@ import { printSuccess } from "../../output.js";
 export function registerOAuthClientsCommand(parent: Command): void {
   const oauthClients = parent
     .command("oauth-clients")
-    .description("Admin OAuth client management");
+    .description("Manage OAuth clients");
 
   // oauth-clients list
   oauthClients
@@ -94,7 +94,7 @@ export function registerOAuthClientsCommand(parent: Command): void {
 export function registerCaddeCommand(parent: Command): void {
   const cadde = parent
     .command("cadde")
-    .description("Admin CADDE configuration");
+    .description("Manage CADDE configuration");
 
   // cadde get
   cadde

--- a/src/commands/admin/policies.ts
+++ b/src/commands/admin/policies.ts
@@ -6,7 +6,7 @@ import { printSuccess } from "../../output.js";
 export function registerPoliciesCommand(parent: Command): void {
   const policies = parent
     .command("policies")
-    .description("Admin policy management");
+    .description("Manage policies");
 
   // policies list
   policies

--- a/src/commands/admin/tenants.ts
+++ b/src/commands/admin/tenants.ts
@@ -6,7 +6,7 @@ import { printSuccess } from "../../output.js";
 export function registerTenantsCommand(parent: Command): void {
   const tenants = parent
     .command("tenants")
-    .description("Admin tenant management");
+    .description("Manage tenants");
 
   // tenants list
   tenants

--- a/src/commands/admin/users.ts
+++ b/src/commands/admin/users.ts
@@ -6,7 +6,7 @@ import { printSuccess } from "../../output.js";
 export function registerUsersCommand(parent: Command): void {
   const users = parent
     .command("users")
-    .description("Admin user management");
+    .description("Manage users");
 
   // users list
   users

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -188,7 +188,7 @@ export function registerAuthCommands(program: Command): void {
   // auth command group with login/logout subcommands
   const auth = program
     .command("auth")
-    .description("Authentication commands");
+    .description("Manage authentication");
 
   auth.addCommand(createLoginCommand());
   auth.addCommand(createLogoutCommand());

--- a/src/commands/batch.ts
+++ b/src/commands/batch.ts
@@ -11,7 +11,7 @@ export function registerBatchCommand(program: Command): void {
   const batch = program
     .command("entityOperations")
     .alias("batch")
-    .description("Batch operations on entities");
+    .description("Perform batch operations on entities");
 
   // batch create
   batch

--- a/src/commands/catalog.ts
+++ b/src/commands/catalog.ts
@@ -4,7 +4,7 @@ import { withErrorHandler, createClient, getFormat, outputResponse } from "../he
 export function registerCatalogCommand(program: Command): void {
   const catalog = program
     .command("catalog")
-    .description("DCAT-AP catalog");
+    .description("Browse DCAT-AP catalog");
 
   // catalog get
   catalog

--- a/src/commands/models.ts
+++ b/src/commands/models.ts
@@ -7,7 +7,7 @@ export function registerModelsCommand(program: Command): void {
   const models = program
     .command("custom-data-models")
     .alias("models")
-    .description("Custom data model management");
+    .description("Manage custom data models");
 
   // models list
   models

--- a/src/commands/rules.ts
+++ b/src/commands/rules.ts
@@ -6,7 +6,7 @@ import { printSuccess } from "../output.js";
 export function registerRulesCommand(program: Command): void {
   const rules = program
     .command("rules")
-    .description("Rule engine management");
+    .description("Manage rule engine");
 
   // rules list
   rules

--- a/src/commands/snapshots.ts
+++ b/src/commands/snapshots.ts
@@ -10,7 +10,7 @@ import { printSuccess } from "../output.js";
 export function registerSnapshotsCommand(program: Command): void {
   const snapshots = program
     .command("snapshots")
-    .description("Snapshot operations");
+    .description("Manage snapshots");
 
   // snapshots list
   snapshots

--- a/src/commands/temporal.ts
+++ b/src/commands/temporal.ts
@@ -134,15 +134,15 @@ function addQueryOptions(cmd: Command): Command {
 export function registerTemporalCommand(program: Command): void {
   const temporal = program
     .command("temporal")
-    .description("Temporal entity operations");
+    .description("Manage temporal entities");
 
   const entities = temporal
     .command("entities")
-    .description("Temporal entity CRUD operations");
+    .description("List, get, create, and delete temporal entities");
 
   const entityOperations = temporal
     .command("entityOperations")
-    .description("Temporal entity batch operations");
+    .description("Perform batch operations on temporal entities");
 
   // temporal entities list
   addTemporalListOptions(


### PR DESCRIPTION
## Summary
- All command/subcommand descriptions now start with an imperative verb, following git-style conventions
- 15 descriptions updated across 12 files (top-level commands, admin subgroups, temporal subgroups)
- No functional changes — description text only

## Before / After

| Command | Before | After |
|---------|--------|-------|
| `admin` | Admin management commands | Manage admin resources |
| `auth` | Authentication commands | Manage authentication |
| `catalog` | DCAT-AP catalog | Browse DCAT-AP catalog |
| `custom-data-models` | Custom data model management | Manage custom data models |
| `entityOperations` | Batch operations on entities | Perform batch operations on entities |
| `rules` | Rule engine management | Manage rule engine |
| `snapshots` | Snapshot operations | Manage snapshots |
| `temporal` | Temporal entity operations | Manage temporal entities |
| `temporal entities` | Temporal entity CRUD operations | List, get, create, and delete temporal entities |
| `temporal entityOperations` | Temporal entity batch operations | Perform batch operations on temporal entities |
| `admin policies` | Admin policy management | Manage policies |
| `admin users` | Admin user management | Manage users |
| `admin tenants` | Admin tenant management | Manage tenants |
| `admin oauth-clients` | Admin OAuth client management | Manage OAuth clients |
| `admin cadde` | Admin CADDE configuration | Manage CADDE configuration |

## Test plan
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes (124 tests)
- [x] `geonic help` output verified — all descriptions start with verbs
- [x] `geonic help admin` / `geonic help temporal` subcommand help verified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * CLIコマンドの説明文を改善しました。複数のコマンド（管理、認証、バッチ処理、カタログ、ルールエンジン、スナップショット、テンポラル機能など）の説明をより明確で分かりやすい表現に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->