### PR TITLE
Add EXAMPLES section to help system

### DIFF
--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -12,6 +12,7 @@ import { isInteractive, promptEmail, promptPassword } from "../prompt.js";
 import { getTokenStatus, formatDuration } from "../token.js";
 import { clientCredentialsGrant } from "../oauth.js";
 import chalk from "chalk";
+import { addExamples } from "./help.js";
 
 function createLoginCommand(): Command {
   return new Command("login")
@@ -190,7 +191,27 @@ export function registerAuthCommands(program: Command): void {
     .command("auth")
     .description("Manage authentication");
 
-  auth.addCommand(createLoginCommand());
+  const login = createLoginCommand();
+  addExamples(login, [
+    {
+      description: "Interactive login (email/password prompt)",
+      command: "geonic auth login",
+    },
+    {
+      description: "Login with OAuth client credentials",
+      command:
+        "geonic auth login --client-credentials --client-id MY_ID --client-secret MY_SECRET",
+    },
+    {
+      description: "Login with environment variables",
+      command: "GDB_EMAIL=user@example.com GDB_PASSWORD=pass geonic auth login",
+    },
+    {
+      description: "Login to a specific tenant",
+      command: "geonic auth login --tenant-id my-tenant",
+    },
+  ]);
+  auth.addCommand(login);
   auth.addCommand(createLogoutCommand());
 
   // me command (top-level, maps to /me API endpoint)

--- a/src/commands/batch.ts
+++ b/src/commands/batch.ts
@@ -6,6 +6,7 @@ import {
   outputResponse,
 } from "../helpers.js";
 import { parseJsonInput } from "../input.js";
+import { addExamples } from "./help.js";
 
 export function registerBatchCommand(program: Command): void {
   const batch = program
@@ -14,7 +15,7 @@ export function registerBatchCommand(program: Command): void {
     .description("Perform batch operations on entities");
 
   // batch create
-  batch
+  const create = batch
     .command("create <json>")
     .description("Batch create entities")
     .action(
@@ -28,8 +29,19 @@ export function registerBatchCommand(program: Command): void {
       }),
     );
 
+  addExamples(create, [
+    {
+      description: "Batch create from a file",
+      command: "geonic batch create @entities.json",
+    },
+    {
+      description: "Batch create from stdin",
+      command: "cat entities.json | geonic batch create -",
+    },
+  ]);
+
   // batch upsert
-  batch
+  const upsert = batch
     .command("upsert <json>")
     .description("Batch upsert entities")
     .action(
@@ -42,6 +54,17 @@ export function registerBatchCommand(program: Command): void {
         outputResponse(response, format);
       }),
     );
+
+  addExamples(upsert, [
+    {
+      description: "Batch upsert from a file",
+      command: "geonic batch upsert @entities.json",
+    },
+    {
+      description: "Batch upsert from stdin",
+      command: "cat entities.json | geonic batch upsert -",
+    },
+  ]);
 
   // batch update
   batch

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -7,6 +7,7 @@ import {
   getConfigPath,
 } from "../config.js";
 import { printOutput, printSuccess, printInfo } from "../output.js";
+import { addExamples } from "./help.js";
 
 const SENSITIVE_CONFIG_KEYS = new Set(["token", "refreshToken", "apiKey"]);
 
@@ -15,7 +16,7 @@ export function registerConfigCommand(program: Command): void {
     .command("config")
     .description("Manage CLI configuration");
 
-  config
+  const set = config
     .command("set")
     .description("Save a config value")
     .argument("<key>", "Configuration key")
@@ -29,6 +30,21 @@ export function registerConfigCommand(program: Command): void {
       const display = SENSITIVE_CONFIG_KEYS.has(key) ? "***" : value;
       printSuccess(`Set ${key} = ${display}`);
     });
+
+  addExamples(set, [
+    {
+      description: "Set server URL",
+      command: "geonic config set url https://api.example.com",
+    },
+    {
+      description: "Set tenant (NGSILD-Tenant header)",
+      command: "geonic config set service my-tenant",
+    },
+    {
+      description: "Set config for a specific profile",
+      command: "geonic config set url https://staging.example.com --profile staging",
+    },
+  ]);
 
   config
     .command("get")

--- a/src/commands/entities.ts
+++ b/src/commands/entities.ts
@@ -8,6 +8,7 @@ import {
 import { parseJsonInput } from "../input.js";
 import { printSuccess } from "../output.js";
 import { registerAttrsSubcommand } from "./attrs.js";
+import { addExamples } from "./help.js";
 
 export function registerEntitiesCommand(program: Command): void {
   const entities = program
@@ -15,7 +16,7 @@ export function registerEntitiesCommand(program: Command): void {
     .description("Manage context entities");
 
   // entities list
-  entities
+  const list = entities
     .command("list")
     .description("List entities with optional filters")
     .option("--type <type>", "Filter by entity type")
@@ -61,8 +62,35 @@ export function registerEntitiesCommand(program: Command): void {
       }),
     );
 
+  addExamples(list, [
+    {
+      description: "Filter by entity type",
+      command: "geonic entities list --type Sensor",
+    },
+    {
+      description: "Filter by attribute value",
+      command: "geonic entities list --query 'temperature>30'",
+    },
+    {
+      description: "AND conditions (semicolon)",
+      command: "geonic entities list --query 'temperature>30;humidity<50'",
+    },
+    {
+      description: "String match",
+      command: "geonic entities list --query 'name==\"Tokyo\"'",
+    },
+    {
+      description: "Pattern match",
+      command: "geonic entities list --query 'name~=\"Tok.*\"'",
+    },
+    {
+      description: "Check attribute existence",
+      command: "geonic entities list --query 'temperature'",
+    },
+  ]);
+
   // entities get
-  entities
+  const get = entities
     .command("get")
     .description("Get a single entity by ID")
     .argument("<id>", "Entity ID")
@@ -84,8 +112,19 @@ export function registerEntitiesCommand(program: Command): void {
       }),
     );
 
+  addExamples(get, [
+    {
+      description: "Get entity by ID",
+      command: "geonic entities get urn:ngsi-ld:Sensor:001",
+    },
+    {
+      description: "Get entity in keyValues format",
+      command: "geonic entities get urn:ngsi-ld:Sensor:001 --format keyValues",
+    },
+  ]);
+
   // entities create
-  entities
+  const create = entities
     .command("create")
     .description("Create a new entity")
     .argument("<json>", "JSON payload (inline, @file, or - for stdin)")
@@ -98,6 +137,21 @@ export function registerEntitiesCommand(program: Command): void {
         printSuccess("Entity created.");
       }),
     );
+
+  addExamples(create, [
+    {
+      description: "Create from inline JSON",
+      command: `geonic entities create '{"id":"urn:ngsi-ld:Sensor:001","type":"Sensor"}'`,
+    },
+    {
+      description: "Create from a file",
+      command: "geonic entities create @entity.json",
+    },
+    {
+      description: "Create from stdin",
+      command: "cat entity.json | geonic entities create -",
+    },
+  ]);
 
   // entities update
   entities

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -1,6 +1,17 @@
 import chalk from "chalk";
 import type { Command, Help, Option } from "commander";
 
+interface Example {
+  description: string;
+  command: string;
+}
+
+const examplesMap = new WeakMap<Command, Example[]>();
+
+export function addExamples(cmd: Command, examples: Example[]): void {
+  examplesMap.set(cmd, examples);
+}
+
 function header(title: string): string {
   return chalk.yellow.bold(title);
 }
@@ -167,6 +178,19 @@ export function formatCommandDetails(
       lines.push(header("OPTIONS"));
       lines.push("");
       lines.push(...formatOptionList(options));
+    }
+  }
+
+  // EXAMPLES
+  const examples = examplesMap.get(cmd);
+  if (examples && examples.length > 0) {
+    lines.push("");
+    lines.push(header("EXAMPLES"));
+    lines.push("");
+    for (const ex of examples) {
+      lines.push(`  ${ex.description}:`);
+      lines.push(`    $ ${ex.command}`);
+      lines.push("");
     }
   }
 

--- a/src/commands/profile.ts
+++ b/src/commands/profile.ts
@@ -8,6 +8,7 @@ import {
   loadConfig,
 } from "../config.js";
 import { printSuccess, printInfo, printError } from "../output.js";
+import { addExamples } from "./help.js";
 
 export function registerProfileCommands(program: Command): void {
   const profile = program.command("profile").description("Manage connection profiles");
@@ -23,7 +24,7 @@ export function registerProfileCommands(program: Command): void {
       }
     });
 
-  profile
+  const use = profile
     .command("use <name>")
     .description("Switch active profile")
     .action((name: string) => {
@@ -36,7 +37,14 @@ export function registerProfileCommands(program: Command): void {
       }
     });
 
-  profile
+  addExamples(use, [
+    {
+      description: "Switch to staging profile",
+      command: "geonic profile use staging",
+    },
+  ]);
+
+  const profileCreate = profile
     .command("create <name>")
     .description("Create a new profile")
     .action((name: string) => {
@@ -48,6 +56,13 @@ export function registerProfileCommands(program: Command): void {
         process.exit(1);
       }
     });
+
+  addExamples(profileCreate, [
+    {
+      description: "Create a new profile for staging",
+      command: "geonic profile create staging",
+    },
+  ]);
 
   profile
     .command("delete <name>")

--- a/src/commands/subscriptions.ts
+++ b/src/commands/subscriptions.ts
@@ -7,6 +7,7 @@ import {
 } from "../helpers.js";
 import { parseJsonInput } from "../input.js";
 import { printSuccess } from "../output.js";
+import { addExamples } from "./help.js";
 
 export function registerSubscriptionsCommand(program: Command): void {
   const subscriptions = program
@@ -15,7 +16,7 @@ export function registerSubscriptionsCommand(program: Command): void {
     .description("Manage context subscriptions");
 
   // subscriptions list
-  subscriptions
+  const list = subscriptions
     .command("list")
     .description("List subscriptions")
     .option("--limit <n>", "Maximum number of results", parseInt)
@@ -37,6 +38,21 @@ export function registerSubscriptionsCommand(program: Command): void {
       }),
     );
 
+  addExamples(list, [
+    {
+      description: "List all subscriptions",
+      command: "geonic subscriptions list",
+    },
+    {
+      description: "List with pagination",
+      command: "geonic subscriptions list --limit 10 --offset 20",
+    },
+    {
+      description: "List with total count",
+      command: "geonic subscriptions list --count",
+    },
+  ]);
+
   // subscriptions get
   subscriptions
     .command("get <id>")
@@ -54,7 +70,7 @@ export function registerSubscriptionsCommand(program: Command): void {
     );
 
   // subscriptions create
-  subscriptions
+  const create = subscriptions
     .command("create <json>")
     .description("Create a subscription")
     .action(
@@ -68,6 +84,17 @@ export function registerSubscriptionsCommand(program: Command): void {
         printSuccess("Subscription created.");
       }),
     );
+
+  addExamples(create, [
+    {
+      description: "Create from a JSON file",
+      command: "geonic subscriptions create @subscription.json",
+    },
+    {
+      description: "Create from stdin",
+      command: "cat subscription.json | geonic subscriptions create -",
+    },
+  ]);
 
   // subscriptions update
   subscriptions

--- a/src/commands/temporal.ts
+++ b/src/commands/temporal.ts
@@ -7,6 +7,7 @@ import {
 } from "../helpers.js";
 import { parseJsonInput } from "../input.js";
 import { printSuccess } from "../output.js";
+import { addExamples } from "./help.js";
 
 function addTemporalListOptions(cmd: Command): Command {
   return cmd
@@ -145,14 +146,45 @@ export function registerTemporalCommand(program: Command): void {
     .description("Perform batch operations on temporal entities");
 
   // temporal entities list
-  addTemporalListOptions(
+  const entitiesList = addTemporalListOptions(
     entities.command("list").description("List temporal entities with optional filters"),
-  ).action(createListAction());
+  );
+  entitiesList.action(createListAction());
+
+  addExamples(entitiesList, [
+    {
+      description: "List by type with time range",
+      command:
+        "geonic temporal entities list --type Sensor --time-rel between --time-at 2025-01-01T00:00:00Z --end-time-at 2025-01-31T23:59:59Z",
+    },
+    {
+      description: "Get last 5 temporal values",
+      command: "geonic temporal entities list --type Sensor --last-n 5",
+    },
+    {
+      description: "Filter by time (after a point)",
+      command:
+        "geonic temporal entities list --time-rel after --time-at 2025-06-01T00:00:00Z",
+    },
+  ]);
 
   // temporal entities get
-  addTemporalGetOptions(
+  const entitiesGet = addTemporalGetOptions(
     entities.command("get <id>").description("Get a temporal entity by ID"),
-  ).action(createGetAction());
+  );
+  entitiesGet.action(createGetAction());
+
+  addExamples(entitiesGet, [
+    {
+      description: "Get temporal entity with specific attributes",
+      command:
+        "geonic temporal entities get urn:ngsi-ld:Sensor:001 --attrs temperature,humidity",
+    },
+    {
+      description: "Get last 10 values for an entity",
+      command: "geonic temporal entities get urn:ngsi-ld:Sensor:001 --last-n 10",
+    },
+  ]);
 
   // temporal entities create
   entities
@@ -167,9 +199,22 @@ export function registerTemporalCommand(program: Command): void {
     .action(createDeleteAction());
 
   // temporal entityOperations query
-  addQueryOptions(
+  const opsQuery = addQueryOptions(
     entityOperations.command("query <json>").description("Query temporal entities (POST)"),
-  ).action(createQueryAction());
+  );
+  opsQuery.action(createQueryAction());
+
+  addExamples(opsQuery, [
+    {
+      description: "Query with aggregation (hourly count)",
+      command:
+        "geonic temporal entityOperations query @query.json --aggr-methods totalCount --aggr-period PT1H",
+    },
+    {
+      description: "Query from a file",
+      command: "geonic temporal entityOperations query @query.json",
+    },
+  ]);
 
   // Backward-compatible hidden aliases at the temporal level
   addTemporalListOptions(

--- a/tests/help.test.ts
+++ b/tests/help.test.ts
@@ -171,6 +171,50 @@ describe("help", () => {
     });
   });
 
+  describe("formatCommandDetails — EXAMPLES section", () => {
+    const entitiesList = findCommand(program, "entities", "list");
+    const output = stripAnsi(
+      formatCommandDetails(
+        program,
+        entitiesList as never,
+        "geonic entities list",
+      ),
+    );
+
+    it("includes EXAMPLES section for commands with examples", () => {
+      expect(output).toContain("EXAMPLES");
+    });
+
+    it("includes example commands", () => {
+      expect(output).toContain("$ geonic entities list --type Sensor");
+      expect(output).toContain("$ geonic entities list --query 'temperature>30'");
+    });
+
+    it("includes example descriptions", () => {
+      expect(output).toContain("Filter by entity type:");
+      expect(output).toContain("Pattern match:");
+    });
+
+    it("places EXAMPLES between OPTIONS and GLOBAL PARAMETERS", () => {
+      const optionsIdx = output.indexOf("OPTIONS");
+      const examplesIdx = output.indexOf("EXAMPLES");
+      const globalIdx = output.indexOf("GLOBAL PARAMETERS");
+      expect(optionsIdx).toBeLessThan(examplesIdx);
+      expect(examplesIdx).toBeLessThan(globalIdx);
+    });
+  });
+
+  describe("formatCommandDetails — no EXAMPLES when none registered", () => {
+    const health = findCommand(program, "health");
+    const output = stripAnsi(
+      formatCommandDetails(program, health as never, "geonic health"),
+    );
+
+    it("does not include EXAMPLES section", () => {
+      expect(output).not.toContain("EXAMPLES");
+    });
+  });
+
   describe("formatCommandDetails — alias display", () => {
     const subscriptions = findCommand(program, "subscriptions");
     const output = stripAnsi(


### PR DESCRIPTION
## Summary

- Add a generic `addExamples(cmd, examples)` mechanism using `WeakMap<Command, Example[]>` to attach usage examples to any command
- Render EXAMPLES section in `formatCommandDetails` between OPTIONS and GLOBAL PARAMETERS
- Add examples to 12 leaf commands across 8 command groups:
  - **entities**: `list` (NGSI-LD query syntax), `get` (format flag), `create` (JSON input patterns)
  - **subscriptions**: `list` (pagination/count), `create` (file/stdin input)
  - **batch**: `create`, `upsert` (file/stdin input)
  - **temporal**: `entities list` (time range queries), `entities get` (attrs/lastN), `entityOperations query` (aggregation)
  - **config**: `set` (common keys, profile-scoped config)
  - **profile**: `use`, `create`
  - **auth**: `login` (email/password, OAuth client credentials, env vars, tenant)
- Add tests verifying EXAMPLES rendering, section ordering, and absence for commands without examples

## Test plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` — all 166 tests pass
- [x] `npm run build && node dist/index.js help entities list` — EXAMPLES section renders correctly
- [x] `node dist/index.js help auth login` — auth examples render correctly
- [x] `node dist/index.js help temporal entities list` — temporal examples render correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * CLIコマンドのヘルプテキストに使用例セクションを追加し、各コマンドの具体的な実行方法を表示できるようになりました。

* **ドキュメント**
  * ログイン、バッチ操作、設定、エンティティ、プロファイル、サブスクリプション、テンポラルコマンドなど複数のコマンドに実用的な使用例を追加しました。ユーザーはヘルプから直接コマンドの使用方法を学べます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->