### PR TITLE
Add zsh completion support

### DIFF
--- a/src/commands/cli.ts
+++ b/src/commands/cli.ts
@@ -168,6 +168,17 @@ function getOptionValueCompletions(
   return [];
 }
 
+const ZSH_SCRIPT = `_geonic_completions() {
+  local completions
+  completions=(\${(f)"$(geonic cli completions --line="$BUFFER" --point="$CURSOR" 2>/dev/null)"})
+  if [[ "\${completions[1]}" == "<file>" ]]; then
+    _files
+    return
+  fi
+  compadd -a completions
+}
+compdef _geonic_completions geonic`;
+
 const BASH_SCRIPT = `_geonic_completions() {
   local cur="\${COMP_WORDS[COMP_CWORD]}"
   local completions
@@ -221,6 +232,29 @@ export function registerCliCommand(program: Command): void {
       description: "Persist in ~/.bashrc",
       command:
         'echo \'eval "$(geonic cli completions bash)"\' >> ~/.bashrc',
+    },
+  ]);
+
+  const zsh = completions
+    .command("zsh")
+    .description("Output zsh completion script")
+    .action(() => {
+      console.log(ZSH_SCRIPT);
+    });
+
+  addExamples(zsh, [
+    {
+      description: "Print the zsh completion script",
+      command: "geonic cli completions zsh",
+    },
+    {
+      description: "Enable in current shell session",
+      command: 'eval "$(geonic cli completions zsh)"',
+    },
+    {
+      description: "Persist in ~/.zshrc",
+      command:
+        'echo \'eval "$(geonic cli completions zsh)"\' >> ~/.zshrc',
     },
   ]);
 }


### PR DESCRIPTION
## Summary
- `geonic cli completions zsh` サブコマンドを追加
- zsh の `compdef`/`compadd` APIを使用した補完スクリプトを出力
- 既存の `generateCompletions()` エンジン（`--line`/`--point`）をそのまま利用
- EXAMPLES セクションにセットアップ手順を記載

## Test plan
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes (166 tests)
- [x] `geonic cli completions zsh` outputs valid zsh script
- [x] `geonic help cli completions zsh` shows EXAMPLES

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ZSHシェル向けのCLI補完サポートを追加しました。補完スクリプトをセットアップして、現在のセッションで有効化するか、設定ファイル（~/.zshrc）に登録して永続的に使用できます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->