### PR TITLE
Remove pinned commit hash from geonicdb dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@eslint/js": "^9.19.0",
         "@types/node": "^22.13.0",
         "eslint": "^9.19.0",
-        "geonicdb": "github:geolonia/geonicdb#e3daecb61666c8b25d198d4c4eb9c34a23132c48",
+        "geonicdb": "github:geolonia/geonicdb",
         "mongodb": "^7.1.0",
         "mongodb-memory-server": "^11.0.1",
         "prettier": "^3.4.2",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@eslint/js": "^9.19.0",
     "@types/node": "^22.13.0",
     "eslint": "^9.19.0",
-    "geonicdb": "github:geolonia/geonicdb#e3daecb61666c8b25d198d4c4eb9c34a23132c48",
+    "geonicdb": "github:geolonia/geonicdb",
     "mongodb": "^7.1.0",
     "mongodb-memory-server": "^11.0.1",
     "prettier": "^3.4.2",


### PR DESCRIPTION
## Summary
- `geonicdb` devDependency を `github:geolonia/geonicdb#e3daecb...`（コミット固定）から `github:geolonia/geonicdb`（デフォルトブランチ）に変更
- `package-lock.json` が実質的にバージョンを固定するため、再現性は維持される
- 更新が必要な場合は `npm update geonicdb` で明示的に行う

## Test plan
- [x] `npm run lint` パス
- [x] `npm run typecheck` パス
- [x] `npm test` 全166件パス

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 開発用依存関係を更新し、より柔軟な依存関係管理体制に移行しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->