### PR TITLE
Add help examples and improve descriptions for all commands

### DIFF
--- a/src/commands/admin/oauth-clients.ts
+++ b/src/commands/admin/oauth-clients.ts
@@ -2,6 +2,7 @@ import type { Command } from "commander";
 import { withErrorHandler, createClient, getFormat, outputResponse } from "../../helpers.js";
 import { parseJsonInput } from "../../input.js";
 import { printSuccess } from "../../output.js";
+import { addExamples } from "../help.js";
 
 export function registerOAuthClientsCommand(parent: Command): void {
   const oauthClients = parent
@@ -9,7 +10,7 @@ export function registerOAuthClientsCommand(parent: Command): void {
     .description("Manage OAuth clients");
 
   // oauth-clients list
-  oauthClients
+  const list = oauthClients
     .command("list")
     .description("List all OAuth clients")
     .action(
@@ -21,8 +22,15 @@ export function registerOAuthClientsCommand(parent: Command): void {
       }),
     );
 
+  addExamples(list, [
+    {
+      description: "List all OAuth clients",
+      command: "geonic admin oauth-clients list",
+    },
+  ]);
+
   // oauth-clients get
-  oauthClients
+  const get = oauthClients
     .command("get <id>")
     .description("Get an OAuth client by ID")
     .action(
@@ -37,8 +45,15 @@ export function registerOAuthClientsCommand(parent: Command): void {
       }),
     );
 
+  addExamples(get, [
+    {
+      description: "Get an OAuth client by ID",
+      command: "geonic admin oauth-clients get <client-id>",
+    },
+  ]);
+
   // oauth-clients create
-  oauthClients
+  const create = oauthClients
     .command("create <json>")
     .description("Create a new OAuth client")
     .action(
@@ -54,8 +69,15 @@ export function registerOAuthClientsCommand(parent: Command): void {
       }),
     );
 
+  addExamples(create, [
+    {
+      description: "Create an OAuth client from a JSON file",
+      command: "geonic admin oauth-clients create @client.json",
+    },
+  ]);
+
   // oauth-clients update
-  oauthClients
+  const update = oauthClients
     .command("update <id> <json>")
     .description("Update an OAuth client")
     .action(
@@ -75,8 +97,15 @@ export function registerOAuthClientsCommand(parent: Command): void {
       ),
     );
 
+  addExamples(update, [
+    {
+      description: "Update an OAuth client from a JSON file",
+      command: "geonic admin oauth-clients update <client-id> @client.json",
+    },
+  ]);
+
   // oauth-clients delete
-  oauthClients
+  const del = oauthClients
     .command("delete <id>")
     .description("Delete an OAuth client")
     .action(
@@ -89,6 +118,13 @@ export function registerOAuthClientsCommand(parent: Command): void {
         printSuccess("OAuth client deleted.");
       }),
     );
+
+  addExamples(del, [
+    {
+      description: "Delete an OAuth client",
+      command: "geonic admin oauth-clients delete <client-id>",
+    },
+  ]);
 }
 
 export function registerCaddeCommand(parent: Command): void {
@@ -97,7 +133,7 @@ export function registerCaddeCommand(parent: Command): void {
     .description("Manage CADDE configuration");
 
   // cadde get
-  cadde
+  const caddeGet = cadde
     .command("get")
     .description("Get CADDE configuration")
     .action(
@@ -109,8 +145,15 @@ export function registerCaddeCommand(parent: Command): void {
       }),
     );
 
+  addExamples(caddeGet, [
+    {
+      description: "Get CADDE configuration",
+      command: "geonic admin cadde get",
+    },
+  ]);
+
   // cadde set
-  cadde
+  const caddeSet = cadde
     .command("set <json>")
     .description("Set CADDE configuration")
     .action(
@@ -126,8 +169,15 @@ export function registerCaddeCommand(parent: Command): void {
       }),
     );
 
+  addExamples(caddeSet, [
+    {
+      description: "Set CADDE configuration from a JSON file",
+      command: "geonic admin cadde set @cadde-config.json",
+    },
+  ]);
+
   // cadde delete
-  cadde
+  const caddeDelete = cadde
     .command("delete")
     .description("Delete CADDE configuration")
     .action(
@@ -137,4 +187,11 @@ export function registerCaddeCommand(parent: Command): void {
         printSuccess("CADDE configuration deleted.");
       }),
     );
+
+  addExamples(caddeDelete, [
+    {
+      description: "Delete CADDE configuration",
+      command: "geonic admin cadde delete",
+    },
+  ]);
 }

--- a/src/commands/admin/policies.ts
+++ b/src/commands/admin/policies.ts
@@ -2,6 +2,7 @@ import type { Command } from "commander";
 import { withErrorHandler, createClient, getFormat, outputResponse } from "../../helpers.js";
 import { parseJsonInput } from "../../input.js";
 import { printSuccess } from "../../output.js";
+import { addExamples } from "../help.js";
 
 export function registerPoliciesCommand(parent: Command): void {
   const policies = parent
@@ -9,7 +10,7 @@ export function registerPoliciesCommand(parent: Command): void {
     .description("Manage policies");
 
   // policies list
-  policies
+  const list = policies
     .command("list")
     .description("List all policies")
     .action(
@@ -21,8 +22,15 @@ export function registerPoliciesCommand(parent: Command): void {
       }),
     );
 
+  addExamples(list, [
+    {
+      description: "List all policies",
+      command: "geonic admin policies list",
+    },
+  ]);
+
   // policies get
-  policies
+  const get = policies
     .command("get <id>")
     .description("Get a policy by ID")
     .action(
@@ -37,8 +45,15 @@ export function registerPoliciesCommand(parent: Command): void {
       }),
     );
 
+  addExamples(get, [
+    {
+      description: "Get a policy by ID",
+      command: "geonic admin policies get <policy-id>",
+    },
+  ]);
+
   // policies create
-  policies
+  const create = policies
     .command("create <json>")
     .description("Create a new policy")
     .action(
@@ -54,8 +69,15 @@ export function registerPoliciesCommand(parent: Command): void {
       }),
     );
 
+  addExamples(create, [
+    {
+      description: "Create a policy from a JSON file",
+      command: "geonic admin policies create @policy.json",
+    },
+  ]);
+
   // policies update
-  policies
+  const update = policies
     .command("update <id> <json>")
     .description("Update a policy")
     .action(
@@ -75,8 +97,15 @@ export function registerPoliciesCommand(parent: Command): void {
       ),
     );
 
+  addExamples(update, [
+    {
+      description: "Update a policy from a JSON file",
+      command: "geonic admin policies update <policy-id> @policy.json",
+    },
+  ]);
+
   // policies delete
-  policies
+  const del = policies
     .command("delete <id>")
     .description("Delete a policy")
     .action(
@@ -90,8 +119,15 @@ export function registerPoliciesCommand(parent: Command): void {
       }),
     );
 
+  addExamples(del, [
+    {
+      description: "Delete a policy",
+      command: "geonic admin policies delete <policy-id>",
+    },
+  ]);
+
   // policies activate
-  policies
+  const activate = policies
     .command("activate <id>")
     .description("Activate a policy")
     .action(
@@ -105,8 +141,15 @@ export function registerPoliciesCommand(parent: Command): void {
       }),
     );
 
+  addExamples(activate, [
+    {
+      description: "Activate a policy",
+      command: "geonic admin policies activate <policy-id>",
+    },
+  ]);
+
   // policies deactivate
-  policies
+  const deactivate = policies
     .command("deactivate <id>")
     .description("Deactivate a policy")
     .action(
@@ -119,4 +162,11 @@ export function registerPoliciesCommand(parent: Command): void {
         printSuccess("Policy deactivated.");
       }),
     );
+
+  addExamples(deactivate, [
+    {
+      description: "Deactivate a policy",
+      command: "geonic admin policies deactivate <policy-id>",
+    },
+  ]);
 }

--- a/src/commands/admin/tenants.ts
+++ b/src/commands/admin/tenants.ts
@@ -2,6 +2,7 @@ import type { Command } from "commander";
 import { withErrorHandler, createClient, getFormat, outputResponse } from "../../helpers.js";
 import { parseJsonInput } from "../../input.js";
 import { printSuccess } from "../../output.js";
+import { addExamples } from "../help.js";
 
 export function registerTenantsCommand(parent: Command): void {
   const tenants = parent
@@ -9,7 +10,7 @@ export function registerTenantsCommand(parent: Command): void {
     .description("Manage tenants");
 
   // tenants list
-  tenants
+  const list = tenants
     .command("list")
     .description("List all tenants")
     .action(
@@ -21,8 +22,15 @@ export function registerTenantsCommand(parent: Command): void {
       }),
     );
 
+  addExamples(list, [
+    {
+      description: "List all tenants",
+      command: "geonic admin tenants list",
+    },
+  ]);
+
   // tenants get
-  tenants
+  const get = tenants
     .command("get <id>")
     .description("Get a tenant by ID")
     .action(
@@ -37,8 +45,15 @@ export function registerTenantsCommand(parent: Command): void {
       }),
     );
 
+  addExamples(get, [
+    {
+      description: "Get a tenant by ID",
+      command: "geonic admin tenants get <tenant-id>",
+    },
+  ]);
+
   // tenants create
-  tenants
+  const create = tenants
     .command("create <json>")
     .description("Create a new tenant")
     .action(
@@ -54,8 +69,15 @@ export function registerTenantsCommand(parent: Command): void {
       }),
     );
 
+  addExamples(create, [
+    {
+      description: "Create a tenant from a JSON file",
+      command: "geonic admin tenants create @tenant.json",
+    },
+  ]);
+
   // tenants update
-  tenants
+  const update = tenants
     .command("update <id> <json>")
     .description("Update a tenant")
     .action(
@@ -75,8 +97,15 @@ export function registerTenantsCommand(parent: Command): void {
       ),
     );
 
+  addExamples(update, [
+    {
+      description: "Update a tenant from a JSON file",
+      command: "geonic admin tenants update <tenant-id> @tenant.json",
+    },
+  ]);
+
   // tenants delete
-  tenants
+  const del = tenants
     .command("delete <id>")
     .description("Delete a tenant")
     .action(
@@ -90,8 +119,15 @@ export function registerTenantsCommand(parent: Command): void {
       }),
     );
 
+  addExamples(del, [
+    {
+      description: "Delete a tenant",
+      command: "geonic admin tenants delete <tenant-id>",
+    },
+  ]);
+
   // tenants activate
-  tenants
+  const activate = tenants
     .command("activate <id>")
     .description("Activate a tenant")
     .action(
@@ -105,8 +141,15 @@ export function registerTenantsCommand(parent: Command): void {
       }),
     );
 
+  addExamples(activate, [
+    {
+      description: "Activate a tenant",
+      command: "geonic admin tenants activate <tenant-id>",
+    },
+  ]);
+
   // tenants deactivate
-  tenants
+  const deactivate = tenants
     .command("deactivate <id>")
     .description("Deactivate a tenant")
     .action(
@@ -119,4 +162,11 @@ export function registerTenantsCommand(parent: Command): void {
         printSuccess("Tenant deactivated.");
       }),
     );
+
+  addExamples(deactivate, [
+    {
+      description: "Deactivate a tenant",
+      command: "geonic admin tenants deactivate <tenant-id>",
+    },
+  ]);
 }

--- a/src/commands/admin/users.ts
+++ b/src/commands/admin/users.ts
@@ -2,6 +2,7 @@ import type { Command } from "commander";
 import { withErrorHandler, createClient, getFormat, outputResponse } from "../../helpers.js";
 import { parseJsonInput } from "../../input.js";
 import { printSuccess } from "../../output.js";
+import { addExamples } from "../help.js";
 
 export function registerUsersCommand(parent: Command): void {
   const users = parent
@@ -9,7 +10,7 @@ export function registerUsersCommand(parent: Command): void {
     .description("Manage users");
 
   // users list
-  users
+  const list = users
     .command("list")
     .description("List all users")
     .action(
@@ -21,8 +22,15 @@ export function registerUsersCommand(parent: Command): void {
       }),
     );
 
+  addExamples(list, [
+    {
+      description: "List all users",
+      command: "geonic admin users list",
+    },
+  ]);
+
   // users get
-  users
+  const get = users
     .command("get <id>")
     .description("Get a user by ID")
     .action(
@@ -37,8 +45,15 @@ export function registerUsersCommand(parent: Command): void {
       }),
     );
 
+  addExamples(get, [
+    {
+      description: "Get a user by ID",
+      command: "geonic admin users get <user-id>",
+    },
+  ]);
+
   // users create
-  users
+  const create = users
     .command("create <json>")
     .description("Create a new user")
     .action(
@@ -54,8 +69,15 @@ export function registerUsersCommand(parent: Command): void {
       }),
     );
 
+  addExamples(create, [
+    {
+      description: "Create a user from a JSON file",
+      command: "geonic admin users create @user.json",
+    },
+  ]);
+
   // users update
-  users
+  const update = users
     .command("update <id> <json>")
     .description("Update a user")
     .action(
@@ -75,8 +97,15 @@ export function registerUsersCommand(parent: Command): void {
       ),
     );
 
+  addExamples(update, [
+    {
+      description: "Update a user from a JSON file",
+      command: "geonic admin users update <user-id> @user.json",
+    },
+  ]);
+
   // users delete
-  users
+  const del = users
     .command("delete <id>")
     .description("Delete a user")
     .action(
@@ -90,8 +119,15 @@ export function registerUsersCommand(parent: Command): void {
       }),
     );
 
+  addExamples(del, [
+    {
+      description: "Delete a user",
+      command: "geonic admin users delete <user-id>",
+    },
+  ]);
+
   // users activate
-  users
+  const activate = users
     .command("activate <id>")
     .description("Activate a user")
     .action(
@@ -105,8 +141,15 @@ export function registerUsersCommand(parent: Command): void {
       }),
     );
 
+  addExamples(activate, [
+    {
+      description: "Activate a user",
+      command: "geonic admin users activate <user-id>",
+    },
+  ]);
+
   // users deactivate
-  users
+  const deactivate = users
     .command("deactivate <id>")
     .description("Deactivate a user")
     .action(
@@ -120,8 +163,15 @@ export function registerUsersCommand(parent: Command): void {
       }),
     );
 
+  addExamples(deactivate, [
+    {
+      description: "Deactivate a user",
+      command: "geonic admin users deactivate <user-id>",
+    },
+  ]);
+
   // users unlock
-  users
+  const unlock = users
     .command("unlock <id>")
     .description("Unlock a user")
     .action(
@@ -134,4 +184,11 @@ export function registerUsersCommand(parent: Command): void {
         printSuccess("User unlocked.");
       }),
     );
+
+  addExamples(unlock, [
+    {
+      description: "Unlock a locked user account",
+      command: "geonic admin users unlock <user-id>",
+    },
+  ]);
 }

--- a/src/commands/attrs.ts
+++ b/src/commands/attrs.ts
@@ -7,10 +7,11 @@ import {
 } from "../helpers.js";
 import { parseJsonInput } from "../input.js";
 import { printSuccess } from "../output.js";
+import { addExamples } from "./help.js";
 
 export function addAttrsSubcommands(attrs: Command): void {
   // attrs list
-  attrs
+  const list = attrs
     .command("list")
     .description("List all attributes of an entity")
     .argument("<entityId>", "Entity ID")
@@ -28,8 +29,15 @@ export function addAttrsSubcommands(attrs: Command): void {
       ),
     );
 
+  addExamples(list, [
+    {
+      description: "List all attributes of an entity",
+      command: "geonic entities attrs list urn:ngsi-ld:Sensor:001",
+    },
+  ]);
+
   // attrs get
-  attrs
+  const get = attrs
     .command("get")
     .description("Get a specific attribute of an entity")
     .argument("<entityId>", "Entity ID")
@@ -53,8 +61,15 @@ export function addAttrsSubcommands(attrs: Command): void {
       ),
     );
 
+  addExamples(get, [
+    {
+      description: "Get a specific attribute",
+      command: "geonic entities attrs get urn:ngsi-ld:Sensor:001 temperature",
+    },
+  ]);
+
   // attrs add
-  attrs
+  const add = attrs
     .command("add")
     .description("Add attributes to an entity")
     .argument("<entityId>", "Entity ID")
@@ -79,8 +94,15 @@ export function addAttrsSubcommands(attrs: Command): void {
       ),
     );
 
+  addExamples(add, [
+    {
+      description: "Add attributes from a file",
+      command: "geonic entities attrs add urn:ngsi-ld:Sensor:001 @attrs.json",
+    },
+  ]);
+
   // attrs update
-  attrs
+  const attrUpdate = attrs
     .command("update")
     .description("Update a specific attribute of an entity")
     .argument("<entityId>", "Entity ID")
@@ -107,8 +129,16 @@ export function addAttrsSubcommands(attrs: Command): void {
       ),
     );
 
+  addExamples(attrUpdate, [
+    {
+      description: "Update a specific attribute",
+      command:
+        "geonic entities attrs update urn:ngsi-ld:Sensor:001 temperature '{\"value\":25}'",
+    },
+  ]);
+
   // attrs delete
-  attrs
+  const del = attrs
     .command("delete")
     .description("Delete a specific attribute from an entity")
     .argument("<entityId>", "Entity ID")
@@ -130,6 +160,14 @@ export function addAttrsSubcommands(attrs: Command): void {
         },
       ),
     );
+
+  addExamples(del, [
+    {
+      description: "Delete a specific attribute",
+      command:
+        "geonic entities attrs delete urn:ngsi-ld:Sensor:001 temperature",
+    },
+  ]);
 }
 
 export function registerAttrsSubcommand(entitiesCmd: Command): void {

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -212,13 +212,28 @@ export function registerAuthCommands(program: Command): void {
     },
   ]);
   auth.addCommand(login);
-  auth.addCommand(createLogoutCommand());
+
+  const logout = createLogoutCommand();
+  addExamples(logout, [
+    {
+      description: "Clear saved authentication token",
+      command: "geonic auth logout",
+    },
+  ]);
+  auth.addCommand(logout);
 
   // me command (top-level, maps to /me API endpoint)
-  program
+  const me = program
     .command("me")
     .description("Display current authenticated user")
     .action(createMeAction());
+
+  addExamples(me, [
+    {
+      description: "Show current user info",
+      command: "geonic me",
+    },
+  ]);
 
   // Backward-compatible hidden aliases
   program.addCommand(createLoginCommand(), { hidden: true });

--- a/src/commands/batch.ts
+++ b/src/commands/batch.ts
@@ -67,9 +67,9 @@ export function registerBatchCommand(program: Command): void {
   ]);
 
   // batch update
-  batch
+  const update = batch
     .command("update <json>")
-    .description("Batch update entities")
+    .description("Batch update entity attributes")
     .action(
       withErrorHandler(async (json: unknown, _opts: unknown, cmd: Command) => {
         const client = createClient(cmd);
@@ -81,10 +81,21 @@ export function registerBatchCommand(program: Command): void {
       }),
     );
 
+  addExamples(update, [
+    {
+      description: "Batch update from a file",
+      command: "geonic batch update @updates.json",
+    },
+    {
+      description: "Batch update from stdin",
+      command: "cat updates.json | geonic batch update -",
+    },
+  ]);
+
   // batch delete
-  batch
+  const del = batch
     .command("delete <json>")
-    .description("Batch delete entities")
+    .description("Batch delete entities by ID")
     .action(
       withErrorHandler(async (json: unknown, _opts: unknown, cmd: Command) => {
         const client = createClient(cmd);
@@ -96,10 +107,21 @@ export function registerBatchCommand(program: Command): void {
       }),
     );
 
+  addExamples(del, [
+    {
+      description: "Batch delete from a file",
+      command: "geonic batch delete @entity-ids.json",
+    },
+    {
+      description: "Batch delete from stdin",
+      command: "cat entity-ids.json | geonic batch delete -",
+    },
+  ]);
+
   // batch query
-  batch
+  const query = batch
     .command("query <json>")
-    .description("Batch query entities")
+    .description("Query entities by posting a query payload")
     .action(
       withErrorHandler(async (json: unknown, _opts: unknown, cmd: Command) => {
         const client = createClient(cmd);
@@ -111,10 +133,21 @@ export function registerBatchCommand(program: Command): void {
       }),
     );
 
+  addExamples(query, [
+    {
+      description: "Query entities from a file",
+      command: "geonic batch query @query.json",
+    },
+    {
+      description: "Query entities from stdin",
+      command: "cat query.json | geonic batch query -",
+    },
+  ]);
+
   // batch merge
-  batch
+  const merge = batch
     .command("merge <json>")
-    .description("Batch merge entities")
+    .description("Batch merge-patch entities")
     .action(
       withErrorHandler(async (json: unknown, _opts: unknown, cmd: Command) => {
         const client = createClient(cmd);
@@ -125,4 +158,15 @@ export function registerBatchCommand(program: Command): void {
         outputResponse(response, format);
       }),
     );
+
+  addExamples(merge, [
+    {
+      description: "Batch merge-patch from a file",
+      command: "geonic batch merge @patches.json",
+    },
+    {
+      description: "Batch merge-patch from stdin",
+      command: "cat patches.json | geonic batch merge -",
+    },
+  ]);
 }

--- a/src/commands/catalog.ts
+++ b/src/commands/catalog.ts
@@ -1,5 +1,6 @@
 import type { Command } from "commander";
 import { withErrorHandler, createClient, getFormat, outputResponse } from "../helpers.js";
+import { addExamples } from "./help.js";
 
 export function registerCatalogCommand(program: Command): void {
   const catalog = program
@@ -7,7 +8,7 @@ export function registerCatalogCommand(program: Command): void {
     .description("Browse DCAT-AP catalog");
 
   // catalog get
-  catalog
+  const get = catalog
     .command("get")
     .description("Get the catalog")
     .action(
@@ -19,13 +20,20 @@ export function registerCatalogCommand(program: Command): void {
       }),
     );
 
+  addExamples(get, [
+    {
+      description: "Get the DCAT-AP catalog",
+      command: "geonic catalog get",
+    },
+  ]);
+
   // catalog datasets
   const datasets = catalog
     .command("datasets")
     .description("Manage catalog datasets");
 
   // catalog datasets list
-  datasets
+  const datasetsList = datasets
     .command("list")
     .description("List all datasets")
     .action(
@@ -37,8 +45,15 @@ export function registerCatalogCommand(program: Command): void {
       }),
     );
 
+  addExamples(datasetsList, [
+    {
+      description: "List all catalog datasets",
+      command: "geonic catalog datasets list",
+    },
+  ]);
+
   // catalog datasets get
-  datasets
+  const datasetsGet = datasets
     .command("get <id>")
     .description("Get a dataset by ID")
     .action(
@@ -53,8 +68,15 @@ export function registerCatalogCommand(program: Command): void {
       }),
     );
 
+  addExamples(datasetsGet, [
+    {
+      description: "Get a specific dataset",
+      command: "geonic catalog datasets get <dataset-id>",
+    },
+  ]);
+
   // catalog datasets sample
-  datasets
+  const datasetsSample = datasets
     .command("sample <id>")
     .description("Get sample data for a dataset")
     .action(
@@ -68,4 +90,11 @@ export function registerCatalogCommand(program: Command): void {
         outputResponse(response, format);
       }),
     );
+
+  addExamples(datasetsSample, [
+    {
+      description: "Get sample data for a dataset",
+      command: "geonic catalog datasets sample <dataset-id>",
+    },
+  ]);
 }

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -62,7 +62,7 @@ export function registerConfigCommand(program: Command): void {
     },
   ]);
 
-  config
+  const get = config
     .command("get")
     .description("Get a config value")
     .argument("<key>", "Configuration key")
@@ -78,7 +78,18 @@ export function registerConfigCommand(program: Command): void {
       }
     });
 
-  config
+  addExamples(get, [
+    {
+      description: "Get server URL",
+      command: "geonic config get url",
+    },
+    {
+      description: "Get config value for a specific profile",
+      command: "geonic config get url --profile staging",
+    },
+  ]);
+
+  const list = config
     .command("list")
     .description("List all config values")
     .action((...args: unknown[]) => {
@@ -92,7 +103,14 @@ export function registerConfigCommand(program: Command): void {
       }
     });
 
-  config
+  addExamples(list, [
+    {
+      description: "List all configuration values",
+      command: "geonic config list",
+    },
+  ]);
+
+  const del = config
     .command("delete")
     .description("Delete a config value")
     .argument("<key>", "Configuration key")
@@ -103,4 +121,11 @@ export function registerConfigCommand(program: Command): void {
       deleteConfigValue(key, profile);
       printSuccess(`Deleted key "${key}".`);
     });
+
+  addExamples(del, [
+    {
+      description: "Delete a config value",
+      command: "geonic config delete url",
+    },
+  ]);
 }

--- a/src/commands/entities.ts
+++ b/src/commands/entities.ts
@@ -188,7 +188,7 @@ export function registerEntitiesCommand(program: Command): void {
   ]);
 
   // entities update
-  entities
+  const update = entities
     .command("update")
     .description("Update attributes of an entity (PATCH)")
     .argument("<id>", "Entity ID")
@@ -208,8 +208,20 @@ export function registerEntitiesCommand(program: Command): void {
       ),
     );
 
+  addExamples(update, [
+    {
+      description: "Update entity attributes from inline JSON",
+      command:
+        "geonic entities update urn:ngsi-ld:Sensor:001 '{\"temperature\":{\"value\":25}}'",
+    },
+    {
+      description: "Update entity attributes from a file",
+      command: "geonic entities update urn:ngsi-ld:Sensor:001 @attrs.json",
+    },
+  ]);
+
   // entities replace
-  entities
+  const replace = entities
     .command("replace")
     .description("Replace all attributes of an entity (PUT)")
     .argument("<id>", "Entity ID")
@@ -229,8 +241,15 @@ export function registerEntitiesCommand(program: Command): void {
       ),
     );
 
+  addExamples(replace, [
+    {
+      description: "Replace all attributes from a file",
+      command: "geonic entities replace urn:ngsi-ld:Sensor:001 @attrs.json",
+    },
+  ]);
+
   // entities upsert
-  entities
+  const upsert = entities
     .command("upsert")
     .description("Create or update entities")
     .argument("<json>", "JSON payload (inline, @file, or - for stdin)")
@@ -244,8 +263,19 @@ export function registerEntitiesCommand(program: Command): void {
       }),
     );
 
+  addExamples(upsert, [
+    {
+      description: "Upsert entities from a file",
+      command: "geonic entities upsert @entities.json",
+    },
+    {
+      description: "Upsert from stdin",
+      command: "cat entities.json | geonic entities upsert -",
+    },
+  ]);
+
   // entities delete
-  entities
+  const del = entities
     .command("delete")
     .description("Delete an entity by ID")
     .argument("<id>", "Entity ID")
@@ -257,6 +287,13 @@ export function registerEntitiesCommand(program: Command): void {
         printSuccess("Entity deleted.");
       }),
     );
+
+  addExamples(del, [
+    {
+      description: "Delete an entity by ID",
+      command: "geonic entities delete urn:ngsi-ld:Sensor:001",
+    },
+  ]);
 
   // Register attrs as a subcommand of entities
   registerAttrsSubcommand(entities);

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -7,9 +7,10 @@ import {
   outputResponse,
 } from "../helpers.js";
 import { printInfo } from "../output.js";
+import { addExamples } from "./help.js";
 
 export function registerHealthCommand(program: Command): void {
-  program
+  const health = program
     .command("health")
     .description("Check the health status of the server")
     .action(
@@ -21,10 +22,17 @@ export function registerHealthCommand(program: Command): void {
         outputResponse(response, format);
       }),
     );
+
+  addExamples(health, [
+    {
+      description: "Check server health",
+      command: "geonic health",
+    },
+  ]);
 }
 
 export function registerVersionCommand(program: Command): void {
-  program
+  const version = program
     .command("version")
     .description("Display CLI and server version information")
     .action(
@@ -43,4 +51,11 @@ export function registerVersionCommand(program: Command): void {
         outputResponse(response, format);
       }),
     );
+
+  addExamples(version, [
+    {
+      description: "Show CLI and server version",
+      command: "geonic version",
+    },
+  ]);
 }

--- a/src/commands/models.ts
+++ b/src/commands/models.ts
@@ -2,6 +2,7 @@ import type { Command } from "commander";
 import { withErrorHandler, createClient, getFormat, outputResponse } from "../helpers.js";
 import { parseJsonInput } from "../input.js";
 import { printSuccess } from "../output.js";
+import { addExamples } from "./help.js";
 
 export function registerModelsCommand(program: Command): void {
   const models = program
@@ -10,7 +11,7 @@ export function registerModelsCommand(program: Command): void {
     .description("Manage custom data models");
 
   // models list
-  models
+  const list = models
     .command("list")
     .description("List all models")
     .action(
@@ -22,8 +23,15 @@ export function registerModelsCommand(program: Command): void {
       }),
     );
 
+  addExamples(list, [
+    {
+      description: "List all models",
+      command: "geonic models list",
+    },
+  ]);
+
   // models get
-  models
+  const get = models
     .command("get <id>")
     .description("Get a model by ID")
     .action(
@@ -38,8 +46,15 @@ export function registerModelsCommand(program: Command): void {
       }),
     );
 
+  addExamples(get, [
+    {
+      description: "Get a specific model",
+      command: "geonic models get <model-id>",
+    },
+  ]);
+
   // models create
-  models
+  const create = models
     .command("create <json>")
     .description("Create a new model")
     .action(
@@ -53,8 +68,15 @@ export function registerModelsCommand(program: Command): void {
       }),
     );
 
+  addExamples(create, [
+    {
+      description: "Create a model from a file",
+      command: "geonic models create @model.json",
+    },
+  ]);
+
   // models update
-  models
+  const update = models
     .command("update <id> <json>")
     .description("Update a model")
     .action(
@@ -74,8 +96,15 @@ export function registerModelsCommand(program: Command): void {
       ),
     );
 
+  addExamples(update, [
+    {
+      description: "Update a model from a file",
+      command: "geonic models update <model-id> @model.json",
+    },
+  ]);
+
   // models delete
-  models
+  const del = models
     .command("delete <id>")
     .description("Delete a model")
     .action(
@@ -88,4 +117,11 @@ export function registerModelsCommand(program: Command): void {
         printSuccess("Model deleted.");
       }),
     );
+
+  addExamples(del, [
+    {
+      description: "Delete a model",
+      command: "geonic models delete <model-id>",
+    },
+  ]);
 }

--- a/src/commands/profile.ts
+++ b/src/commands/profile.ts
@@ -13,7 +13,7 @@ import { addExamples } from "./help.js";
 export function registerProfileCommands(program: Command): void {
   const profile = program.command("profile").description("Manage connection profiles");
 
-  profile
+  const list = profile
     .command("list")
     .description("List all profiles")
     .action(() => {
@@ -23,6 +23,13 @@ export function registerProfileCommands(program: Command): void {
         console.log(`${p.name}${marker}`);
       }
     });
+
+  addExamples(list, [
+    {
+      description: "List all profiles (active profile marked with *)",
+      command: "geonic profile list",
+    },
+  ]);
 
   const use = profile
     .command("use <name>")
@@ -64,7 +71,7 @@ export function registerProfileCommands(program: Command): void {
     },
   ]);
 
-  profile
+  const del = profile
     .command("delete <name>")
     .description("Delete a profile")
     .action((name: string) => {
@@ -77,7 +84,14 @@ export function registerProfileCommands(program: Command): void {
       }
     });
 
-  profile
+  addExamples(del, [
+    {
+      description: "Delete a profile",
+      command: "geonic profile delete staging",
+    },
+  ]);
+
+  const show = profile
     .command("show [name]")
     .description("Show profile settings")
     .action((name?: string) => {
@@ -99,4 +113,15 @@ export function registerProfileCommands(program: Command): void {
         }
       }
     });
+
+  addExamples(show, [
+    {
+      description: "Show current profile settings",
+      command: "geonic profile show",
+    },
+    {
+      description: "Show settings for a specific profile",
+      command: "geonic profile show production",
+    },
+  ]);
 }

--- a/src/commands/registrations.ts
+++ b/src/commands/registrations.ts
@@ -7,6 +7,7 @@ import {
 } from "../helpers.js";
 import { parseJsonInput } from "../input.js";
 import { printSuccess } from "../output.js";
+import { addExamples } from "./help.js";
 
 export function registerRegistrationsCommand(program: Command): void {
   const registrations = program
@@ -15,7 +16,7 @@ export function registerRegistrationsCommand(program: Command): void {
     .description("Manage context registrations");
 
   // registrations list
-  registrations
+  const list = registrations
     .command("list")
     .description("List registrations")
     .option("--limit <n>", "Maximum number of results", parseInt)
@@ -37,8 +38,19 @@ export function registerRegistrationsCommand(program: Command): void {
       }),
     );
 
+  addExamples(list, [
+    {
+      description: "List all registrations",
+      command: "geonic registrations list",
+    },
+    {
+      description: "List with pagination",
+      command: "geonic registrations list --limit 10",
+    },
+  ]);
+
   // registrations get
-  registrations
+  const get = registrations
     .command("get <id>")
     .description("Get a registration by ID")
     .action(
@@ -53,8 +65,16 @@ export function registerRegistrationsCommand(program: Command): void {
       }),
     );
 
+  addExamples(get, [
+    {
+      description: "Get registration by ID",
+      command:
+        "geonic registrations get urn:ngsi-ld:ContextSourceRegistration:001",
+    },
+  ]);
+
   // registrations create
-  registrations
+  const create = registrations
     .command("create <json>")
     .description("Create a registration")
     .action(
@@ -69,8 +89,15 @@ export function registerRegistrationsCommand(program: Command): void {
       }),
     );
 
+  addExamples(create, [
+    {
+      description: "Create a registration from a file",
+      command: "geonic registrations create @registration.json",
+    },
+  ]);
+
   // registrations update
-  registrations
+  const regUpdate = registrations
     .command("update <id> <json>")
     .description("Update a registration")
     .action(
@@ -90,8 +117,16 @@ export function registerRegistrationsCommand(program: Command): void {
       ),
     );
 
+  addExamples(regUpdate, [
+    {
+      description: "Update a registration from a file",
+      command:
+        "geonic registrations update urn:ngsi-ld:ContextSourceRegistration:001 @registration.json",
+    },
+  ]);
+
   // registrations delete
-  registrations
+  const del = registrations
     .command("delete <id>")
     .description("Delete a registration")
     .action(
@@ -104,4 +139,12 @@ export function registerRegistrationsCommand(program: Command): void {
         printSuccess("Registration deleted.");
       }),
     );
+
+  addExamples(del, [
+    {
+      description: "Delete a registration",
+      command:
+        "geonic registrations delete urn:ngsi-ld:ContextSourceRegistration:001",
+    },
+  ]);
 }

--- a/src/commands/rules.ts
+++ b/src/commands/rules.ts
@@ -2,6 +2,7 @@ import type { Command } from "commander";
 import { withErrorHandler, createClient, getFormat, outputResponse } from "../helpers.js";
 import { parseJsonInput } from "../input.js";
 import { printSuccess } from "../output.js";
+import { addExamples } from "./help.js";
 
 export function registerRulesCommand(program: Command): void {
   const rules = program
@@ -9,7 +10,7 @@ export function registerRulesCommand(program: Command): void {
     .description("Manage rule engine");
 
   // rules list
-  rules
+  const list = rules
     .command("list")
     .description("List all rules")
     .action(
@@ -21,8 +22,15 @@ export function registerRulesCommand(program: Command): void {
       }),
     );
 
+  addExamples(list, [
+    {
+      description: "List all rules",
+      command: "geonic rules list",
+    },
+  ]);
+
   // rules get
-  rules
+  const get = rules
     .command("get <id>")
     .description("Get a rule by ID")
     .action(
@@ -37,8 +45,15 @@ export function registerRulesCommand(program: Command): void {
       }),
     );
 
+  addExamples(get, [
+    {
+      description: "Get a specific rule",
+      command: "geonic rules get <rule-id>",
+    },
+  ]);
+
   // rules create
-  rules
+  const create = rules
     .command("create <json>")
     .description("Create a new rule")
     .action(
@@ -52,8 +67,15 @@ export function registerRulesCommand(program: Command): void {
       }),
     );
 
+  addExamples(create, [
+    {
+      description: "Create a rule from a file",
+      command: "geonic rules create @rule.json",
+    },
+  ]);
+
   // rules update
-  rules
+  const update = rules
     .command("update <id> <json>")
     .description("Update a rule")
     .action(
@@ -73,8 +95,15 @@ export function registerRulesCommand(program: Command): void {
       ),
     );
 
+  addExamples(update, [
+    {
+      description: "Update a rule from a file",
+      command: "geonic rules update <rule-id> @rule.json",
+    },
+  ]);
+
   // rules delete
-  rules
+  const del = rules
     .command("delete <id>")
     .description("Delete a rule")
     .action(
@@ -88,8 +117,15 @@ export function registerRulesCommand(program: Command): void {
       }),
     );
 
+  addExamples(del, [
+    {
+      description: "Delete a rule",
+      command: "geonic rules delete <rule-id>",
+    },
+  ]);
+
   // rules activate
-  rules
+  const activate = rules
     .command("activate <id>")
     .description("Activate a rule")
     .action(
@@ -103,8 +139,15 @@ export function registerRulesCommand(program: Command): void {
       }),
     );
 
+  addExamples(activate, [
+    {
+      description: "Activate a rule",
+      command: "geonic rules activate <rule-id>",
+    },
+  ]);
+
   // rules deactivate
-  rules
+  const deactivate = rules
     .command("deactivate <id>")
     .description("Deactivate a rule")
     .action(
@@ -117,4 +160,11 @@ export function registerRulesCommand(program: Command): void {
         printSuccess("Rule deactivated.");
       }),
     );
+
+  addExamples(deactivate, [
+    {
+      description: "Deactivate a rule",
+      command: "geonic rules deactivate <rule-id>",
+    },
+  ]);
 }

--- a/src/commands/snapshots.ts
+++ b/src/commands/snapshots.ts
@@ -6,6 +6,7 @@ import {
   outputResponse,
 } from "../helpers.js";
 import { printSuccess } from "../output.js";
+import { addExamples } from "./help.js";
 
 export function registerSnapshotsCommand(program: Command): void {
   const snapshots = program
@@ -13,7 +14,7 @@ export function registerSnapshotsCommand(program: Command): void {
     .description("Manage snapshots");
 
   // snapshots list
-  snapshots
+  const list = snapshots
     .command("list")
     .description("List snapshots")
     .option("--limit <n>", "Maximum number of snapshots to return", parseInt)
@@ -34,8 +35,19 @@ export function registerSnapshotsCommand(program: Command): void {
       }),
     );
 
+  addExamples(list, [
+    {
+      description: "List all snapshots",
+      command: "geonic snapshots list",
+    },
+    {
+      description: "List with a limit",
+      command: "geonic snapshots list --limit 10",
+    },
+  ]);
+
   // snapshots get
-  snapshots
+  const get = snapshots
     .command("get <id>")
     .description("Get a snapshot by ID")
     .action(
@@ -50,8 +62,15 @@ export function registerSnapshotsCommand(program: Command): void {
       }),
     );
 
+  addExamples(get, [
+    {
+      description: "Get a specific snapshot",
+      command: "geonic snapshots get <snapshot-id>",
+    },
+  ]);
+
   // snapshots create
-  snapshots
+  const create = snapshots
     .command("create")
     .description("Create a new snapshot")
     .action(
@@ -63,8 +82,15 @@ export function registerSnapshotsCommand(program: Command): void {
       }),
     );
 
+  addExamples(create, [
+    {
+      description: "Create a new snapshot",
+      command: "geonic snapshots create",
+    },
+  ]);
+
   // snapshots delete
-  snapshots
+  const del = snapshots
     .command("delete <id>")
     .description("Delete a snapshot by ID")
     .action(
@@ -78,8 +104,15 @@ export function registerSnapshotsCommand(program: Command): void {
       }),
     );
 
+  addExamples(del, [
+    {
+      description: "Delete a snapshot",
+      command: "geonic snapshots delete <snapshot-id>",
+    },
+  ]);
+
   // snapshots clone
-  snapshots
+  const clone = snapshots
     .command("clone <id>")
     .description("Clone a snapshot by ID")
     .action(
@@ -97,4 +130,11 @@ export function registerSnapshotsCommand(program: Command): void {
         }
       }),
     );
+
+  addExamples(clone, [
+    {
+      description: "Clone a snapshot",
+      command: "geonic snapshots clone <snapshot-id>",
+    },
+  ]);
 }

--- a/src/commands/subscriptions.ts
+++ b/src/commands/subscriptions.ts
@@ -54,7 +54,7 @@ export function registerSubscriptionsCommand(program: Command): void {
   ]);
 
   // subscriptions get
-  subscriptions
+  const get = subscriptions
     .command("get <id>")
     .description("Get a subscription by ID")
     .action(
@@ -68,6 +68,13 @@ export function registerSubscriptionsCommand(program: Command): void {
         outputResponse(response, format);
       }),
     );
+
+  addExamples(get, [
+    {
+      description: "Get subscription by ID",
+      command: "geonic subscriptions get urn:ngsi-ld:Subscription:001",
+    },
+  ]);
 
   // subscriptions create
   const create = subscriptions
@@ -97,7 +104,7 @@ export function registerSubscriptionsCommand(program: Command): void {
   ]);
 
   // subscriptions update
-  subscriptions
+  const update = subscriptions
     .command("update <id> <json>")
     .description("Update a subscription")
     .action(
@@ -117,8 +124,16 @@ export function registerSubscriptionsCommand(program: Command): void {
       ),
     );
 
+  addExamples(update, [
+    {
+      description: "Update a subscription from a file",
+      command:
+        "geonic subscriptions update urn:ngsi-ld:Subscription:001 @sub.json",
+    },
+  ]);
+
   // subscriptions delete
-  subscriptions
+  const del = subscriptions
     .command("delete <id>")
     .description("Delete a subscription")
     .action(
@@ -131,4 +146,11 @@ export function registerSubscriptionsCommand(program: Command): void {
         printSuccess("Subscription deleted.");
       }),
     );
+
+  addExamples(del, [
+    {
+      description: "Delete a subscription",
+      command: "geonic subscriptions delete urn:ngsi-ld:Subscription:001",
+    },
+  ]);
 }

--- a/src/commands/temporal.ts
+++ b/src/commands/temporal.ts
@@ -187,16 +187,30 @@ export function registerTemporalCommand(program: Command): void {
   ]);
 
   // temporal entities create
-  entities
+  const create = entities
     .command("create <json>")
     .description("Create a temporal entity")
     .action(createCreateAction());
 
+  addExamples(create, [
+    {
+      description: "Create temporal entity from a file",
+      command: "geonic temporal entities create @temporal-entity.json",
+    },
+  ]);
+
   // temporal entities delete
-  entities
+  const del = entities
     .command("delete <id>")
     .description("Delete a temporal entity by ID")
     .action(createDeleteAction());
+
+  addExamples(del, [
+    {
+      description: "Delete temporal data for an entity",
+      command: "geonic temporal entities delete urn:ngsi-ld:Sensor:001",
+    },
+  ]);
 
   // temporal entityOperations query
   const opsQuery = addQueryOptions(

--- a/src/commands/types.ts
+++ b/src/commands/types.ts
@@ -5,6 +5,7 @@ import {
   getFormat,
   outputResponse,
 } from "../helpers.js";
+import { addExamples } from "./help.js";
 
 export function registerTypesCommand(program: Command): void {
   const types = program
@@ -12,7 +13,7 @@ export function registerTypesCommand(program: Command): void {
     .description("Browse entity types");
 
   // types list
-  types
+  const list = types
     .command("list")
     .description("List available entity types")
     .action(
@@ -25,8 +26,15 @@ export function registerTypesCommand(program: Command): void {
       }),
     );
 
+  addExamples(list, [
+    {
+      description: "List all entity types",
+      command: "geonic types list",
+    },
+  ]);
+
   // types get
-  types
+  const get = types
     .command("get <typeName>")
     .description("Get details for an entity type")
     .action(
@@ -42,4 +50,11 @@ export function registerTypesCommand(program: Command): void {
         },
       ),
     );
+
+  addExamples(get, [
+    {
+      description: "Get details for a specific type",
+      command: "geonic types get Sensor",
+    },
+  ]);
 }

--- a/tests/help.test.ts
+++ b/tests/help.test.ts
@@ -205,13 +205,75 @@ describe("help", () => {
   });
 
   describe("formatCommandDetails — no EXAMPLES when none registered", () => {
-    const health = findCommand(program, "health");
+    const admin = findCommand(program, "admin");
     const output = stripAnsi(
-      formatCommandDetails(program, health as never, "geonic health"),
+      formatCommandDetails(program, admin as never, "geonic admin"),
     );
 
     it("does not include EXAMPLES section", () => {
       expect(output).not.toContain("EXAMPLES");
+    });
+  });
+
+  describe("formatCommandDetails — new EXAMPLES coverage", () => {
+    it("health command has examples", () => {
+      const health = findCommand(program, "health");
+      const output = stripAnsi(
+        formatCommandDetails(program, health as never, "geonic health"),
+      );
+      expect(output).toContain("EXAMPLES");
+      expect(output).toContain("$ geonic health");
+    });
+
+    it("batch update command has examples", () => {
+      const batchUpdate = findCommand(program, "batch", "update");
+      const output = stripAnsi(
+        formatCommandDetails(
+          program,
+          batchUpdate as never,
+          "geonic batch update",
+        ),
+      );
+      expect(output).toContain("EXAMPLES");
+      expect(output).toContain("$ geonic batch update");
+    });
+
+    it("admin tenants list command has examples", () => {
+      const tenantsList = findCommand(program, "admin", "tenants", "list");
+      const output = stripAnsi(
+        formatCommandDetails(
+          program,
+          tenantsList as never,
+          "geonic admin tenants list",
+        ),
+      );
+      expect(output).toContain("EXAMPLES");
+      expect(output).toContain("$ geonic admin tenants list");
+    });
+
+    it("entities attrs list command has examples", () => {
+      const attrsList = findCommand(program, "entities", "attrs", "list");
+      const output = stripAnsi(
+        formatCommandDetails(
+          program,
+          attrsList as never,
+          "geonic entities attrs list",
+        ),
+      );
+      expect(output).toContain("EXAMPLES");
+    });
+
+    it("rules activate command has examples", () => {
+      const rulesActivate = findCommand(program, "rules", "activate");
+      const output = stripAnsi(
+        formatCommandDetails(
+          program,
+          rulesActivate as never,
+          "geonic rules activate",
+        ),
+      );
+      expect(output).toContain("EXAMPLES");
+      expect(output).toContain("$ geonic rules activate");
     });
   });
 


### PR DESCRIPTION
## Summary

- Add `addExamples()` calls with practical usage examples to all ~95 commands/subcommands across 19 source files
- Improve terse descriptions (e.g. "Batch update entities" → "Batch update entity attributes")
- Update help tests: change "no EXAMPLES" test target from `health` → `admin` group, add 5 spot-check tests for newly added examples

## Files changed (20)

**Tier 1-2 — Core & Batch**
- `src/commands/entities.ts` — examples for `update`, `replace`, `upsert`, `delete`
- `src/commands/attrs.ts` — examples for all 5 subcommands
- `src/commands/batch.ts` — examples for `update`, `delete`, `query`, `merge`
- `src/commands/subscriptions.ts` — examples for `get`, `update`, `delete`
- `src/commands/registrations.ts` — examples for all 5 subcommands

**Tier 3 — Types, Temporal, Snapshots, Rules, Models**
- `src/commands/types.ts` — examples for `list`, `get`
- `src/commands/temporal.ts` — examples for temporal entities & entityOperations
- `src/commands/snapshots.ts` — examples for all 5 subcommands
- `src/commands/rules.ts` — examples for all 7 subcommands
- `src/commands/models.ts` — examples for all 5 subcommands

**Tier 4-5 — Config, Auth, Admin**
- `src/commands/catalog.ts`, `health.ts`, `auth.ts`, `config.ts`, `profile.ts`
- `src/commands/admin/tenants.ts`, `users.ts`, `policies.ts`, `oauth-clients.ts`

**Tests**
- `tests/help.test.ts` — 5 new spot-check tests (51 total, 171 overall)

## Test plan

- [x] `npm run lint` — pass
- [x] `npm run typecheck` — pass
- [x] `npm test` — 171 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * CLIコマンドの全サブコマンドに使用例を追加しました
  * コマンドヘルプにサンプルコマンド実行方法が表示されるようになり、操作がより容易になりました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->