### PR TITLE
Add cli version command and show cli in help

### DIFF
--- a/src/commands/cli.ts
+++ b/src/commands/cli.ts
@@ -1,3 +1,4 @@
+import { createRequire } from "node:module";
 import type { Command, Option } from "commander";
 import { addExamples } from "./help.js";
 
@@ -193,8 +194,9 @@ complete -o default -F _geonic_completions geonic`;
 
 export function registerCliCommand(program: Command): void {
   const cli = program
-    .command("cli", { hidden: true })
-    .description("Manage CLI internals");
+    .command("cli")
+    .summary("Manage CLI internals")
+    .description("Manage CLI internals such as shell completions.");
 
   const completions = cli
     .command("completions")
@@ -255,6 +257,22 @@ export function registerCliCommand(program: Command): void {
       description: "Persist in ~/.zshrc",
       command:
         'echo \'eval "$(geonic cli completions zsh)"\' >> ~/.zshrc',
+    },
+  ]);
+
+  const version = cli
+    .command("version")
+    .description("Display the CLI version")
+    .action(() => {
+      const require = createRequire(import.meta.url);
+      const pkg = require("../package.json") as { version: string };
+      console.log(pkg.version);
+    });
+
+  addExamples(version, [
+    {
+      description: "Show CLI version",
+      command: "geonic cli version",
     },
   ]);
 }

--- a/tests/completions.test.ts
+++ b/tests/completions.test.ts
@@ -26,7 +26,6 @@ describe("completions", () => {
       expect(result).not.toContain("login");
       expect(result).not.toContain("logout");
       expect(result).not.toContain("whoami");
-      expect(result).not.toContain("cli");
     });
 
     it("filters by partial input", () => {
@@ -213,7 +212,6 @@ describe("completions", () => {
 
     it("excludes hidden commands after help", () => {
       const result = complete("geonic help ");
-      expect(result).not.toContain("cli");
       expect(result).not.toContain("attrs");
     });
 

--- a/tests/help.test.ts
+++ b/tests/help.test.ts
@@ -38,6 +38,7 @@ describe("help", () => {
     it("lists all command groups", () => {
       const commands = [
         "auth",
+        "cli",
         "entities",
         "entityOperations",
         "custom-data-models",


### PR DESCRIPTION
## Summary
- `cli` コマンドの `hidden` フラグを削除し、`geonic help` の AVAILABLE COMMANDS に表示されるようにした
- `geonic cli version` サブコマンドを追加。`package.json` からバージョン番号を動的に取得して出力する
- ヘルプおよび補完テストを更新

## Test plan
- [x] `npm run lint` パス
- [x] `npm run typecheck` パス
- [x] `npm test` 全171テストパス
- [x] `npm run build && node dist/index.js cli version` で `0.1.0` が出力されることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 新しい "version" サブコマンドを追加しました。CLI のバージョンを確認できるようになります。

* **ドキュメント**
  * CLI コマンドの説明とサンプルを充実させました。
  * CLI コマンドが最上位レベルで表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->