### PR TITLE
Use backtick syntax for commands in E2E feature files

### DIFF
--- a/tests/e2e/features/api-key.feature
+++ b/tests/e2e/features/api-key.feature
@@ -15,10 +15,10 @@ Feature: API key authentication
 
   Scenario: API key from config fallback
     Given I have a valid API key saved in config as apiKey
-    When I run "geonic entities list"
+    When I run `geonic entities list`
     Then the exit code should be 0
 
   Scenario: Token takes priority over API key
     Given I am logged in with token and invalid apiKey in config
-    When I run "geonic entities list"
+    When I run `geonic entities list`
     Then the exit code should be 0

--- a/tests/e2e/features/attrs.feature
+++ b/tests/e2e/features/attrs.feature
@@ -6,45 +6,45 @@ Feature: Entity attribute management
 
   Scenario: List entity attributes
     Given I am logged in
-    And I run "geonic entities create '{\"id\":\"urn:ngsi-ld:Room:A01\",\"type\":\"Room\"}'"
-    When I run "geonic entities attrs list urn:ngsi-ld:Room:A01"
+    And I run `geonic entities create '{"id":"urn:ngsi-ld:Room:A01","type":"Room"}'`
+    When I run `geonic entities attrs list urn:ngsi-ld:Room:A01`
     Then the exit code should be 0
     And stdout should be valid JSON
 
   Scenario: Add attributes to an entity
     Given I am logged in
-    And I run "geonic entities create '{\"id\":\"urn:ngsi-ld:Room:A02\",\"type\":\"Room\"}'"
-    When I run "geonic entities attrs add urn:ngsi-ld:Room:A02 '{\"humidity\":{\"value\":60,\"type\":\"Property\"}}'"
+    And I run `geonic entities create '{"id":"urn:ngsi-ld:Room:A02","type":"Room"}'`
+    When I run `geonic entities attrs add urn:ngsi-ld:Room:A02 '{"humidity":{"value":60,"type":"Property"}}'`
     Then the exit code should be 0
     And the output should contain "Attributes added."
 
   Scenario: Get a specific attribute
     Given I am logged in
-    And I run "geonic entities create '{\"id\":\"urn:ngsi-ld:Room:A03\",\"type\":\"Room\"}'"
-    And I run "geonic entities attrs add urn:ngsi-ld:Room:A03 '{\"humidity\":{\"value\":60,\"type\":\"Property\"}}'"
-    When I run "geonic entities attrs get urn:ngsi-ld:Room:A03 humidity"
+    And I run `geonic entities create '{"id":"urn:ngsi-ld:Room:A03","type":"Room"}'`
+    And I run `geonic entities attrs add urn:ngsi-ld:Room:A03 '{"humidity":{"value":60,"type":"Property"}}'`
+    When I run `geonic entities attrs get urn:ngsi-ld:Room:A03 humidity`
     Then the exit code should be 0
     And stdout should be valid JSON
 
   Scenario: Update a specific attribute
     Given I am logged in
-    And I run "geonic entities create '{\"id\":\"urn:ngsi-ld:Room:A04\",\"type\":\"Room\"}'"
-    And I run "geonic entities attrs add urn:ngsi-ld:Room:A04 '{\"humidity\":{\"value\":60,\"type\":\"Property\"}}'"
-    When I run "geonic entities attrs update urn:ngsi-ld:Room:A04 humidity '{\"value\":80,\"type\":\"Property\"}'"
+    And I run `geonic entities create '{"id":"urn:ngsi-ld:Room:A04","type":"Room"}'`
+    And I run `geonic entities attrs add urn:ngsi-ld:Room:A04 '{"humidity":{"value":60,"type":"Property"}}'`
+    When I run `geonic entities attrs update urn:ngsi-ld:Room:A04 humidity '{"value":80,"type":"Property"}'`
     Then the exit code should be 0
     And the output should contain "Attribute updated."
-    When I run "geonic entities attrs get urn:ngsi-ld:Room:A04 humidity"
+    When I run `geonic entities attrs get urn:ngsi-ld:Room:A04 humidity`
     Then the exit code should be 0
     And the output should contain "80"
 
   Scenario: Delete a specific attribute
     Given I am logged in
-    And I run "geonic entities create '{\"id\":\"urn:ngsi-ld:Room:A05\",\"type\":\"Room\"}'"
-    And I run "geonic entities attrs add urn:ngsi-ld:Room:A05 '{\"humidity\":{\"value\":60,\"type\":\"Property\"}}'"
-    And I run "geonic entities attrs add urn:ngsi-ld:Room:A05 '{\"pressure\":{\"value\":1013,\"type\":\"Property\"}}'"
-    When I run "geonic entities attrs delete urn:ngsi-ld:Room:A05 humidity"
+    And I run `geonic entities create '{"id":"urn:ngsi-ld:Room:A05","type":"Room"}'`
+    And I run `geonic entities attrs add urn:ngsi-ld:Room:A05 '{"humidity":{"value":60,"type":"Property"}}'`
+    And I run `geonic entities attrs add urn:ngsi-ld:Room:A05 '{"pressure":{"value":1013,"type":"Property"}}'`
+    When I run `geonic entities attrs delete urn:ngsi-ld:Room:A05 humidity`
     Then the exit code should be 0
     And the output should contain "Attribute deleted."
-    When I run "geonic entities attrs list urn:ngsi-ld:Room:A05"
+    When I run `geonic entities attrs list urn:ngsi-ld:Room:A05`
     Then the exit code should be 0
     And the output should not contain "humidity"

--- a/tests/e2e/features/auth.feature
+++ b/tests/e2e/features/auth.feature
@@ -46,20 +46,20 @@ Feature: Authentication
 
   Scenario: Logout clears token from config
     Given I am logged in
-    When I run "geonic logout"
+    When I run `geonic logout`
     Then the exit code should be 0
     And the output should contain "Logged out"
     And no token should be in config
 
   Scenario: Logout clears refresh token from config
     Given I am logged in
-    When I run "geonic logout"
+    When I run `geonic logout`
     Then the exit code should be 0
     And no refresh token should be in config
 
   Scenario: Logout when not logged in still succeeds
     Given I am not logged in
-    When I run "geonic logout"
+    When I run `geonic logout`
     Then the exit code should be 0
     And the output should contain "Logged out"
 
@@ -67,19 +67,19 @@ Feature: Authentication
 
   Scenario: Display user info when logged in
     Given I am logged in
-    When I run "geonic whoami"
+    When I run `geonic whoami`
     Then the exit code should be 0
     And stdout should contain "admin@test.com"
 
   Scenario: Show message when not logged in
     Given I am not logged in
-    When I run "geonic whoami"
+    When I run `geonic whoami`
     Then the exit code should be 0
     And the output should contain "Not logged in"
 
   Scenario: Whoami with JSON format
     Given I am logged in
-    When I run "geonic whoami --format json"
+    When I run `geonic whoami --format json`
     Then the exit code should be 0
     And stdout should be valid JSON
     And the JSON output should have key "email"
@@ -87,7 +87,7 @@ Feature: Authentication
 
   Scenario: Whoami with expired token
     Given I have invalid authentication tokens
-    When I run "geonic whoami"
+    When I run `geonic whoami`
     Then the exit code should be 1
     And the output should contain "Authentication failed"
 
@@ -95,11 +95,11 @@ Feature: Authentication
 
   Scenario: Automatic token refresh on 401
     Given I am logged in with an invalidated token
-    When I run "geonic entities list"
+    When I run `geonic entities list`
     Then the exit code should be 0
 
   Scenario: Failed token refresh propagates error
     Given I have invalid authentication tokens
-    When I run "geonic entities list"
+    When I run `geonic entities list`
     Then the exit code should be 1
     And the output should contain "Authentication failed"

--- a/tests/e2e/features/batch.feature
+++ b/tests/e2e/features/batch.feature
@@ -5,43 +5,43 @@ Feature: Batch entity operations
 
   Scenario: Batch create entities
     Given I am logged in
-    When I run "geonic batch create '[{\"id\":\"urn:ngsi-ld:Room:B01\",\"type\":\"Room\"},{\"id\":\"urn:ngsi-ld:Room:B02\",\"type\":\"Room\"}]'"
+    When I run `geonic batch create '[{"id":"urn:ngsi-ld:Room:B01","type":"Room"},{"id":"urn:ngsi-ld:Room:B02","type":"Room"}]'`
     Then the exit code should be 0
-    When I run "geonic entities list --type Room"
+    When I run `geonic entities list --type Room`
     Then the exit code should be 0
     And the output should contain "urn:ngsi-ld:Room:B01"
     And the output should contain "urn:ngsi-ld:Room:B02"
 
   Scenario: Batch upsert entities
     Given I am logged in
-    When I run "geonic batch upsert '[{\"id\":\"urn:ngsi-ld:Room:B10\",\"type\":\"Room\"},{\"id\":\"urn:ngsi-ld:Room:B11\",\"type\":\"Room\"}]'"
+    When I run `geonic batch upsert '[{"id":"urn:ngsi-ld:Room:B10","type":"Room"},{"id":"urn:ngsi-ld:Room:B11","type":"Room"}]'`
     Then the exit code should be 0
-    When I run "geonic entities list --type Room"
+    When I run `geonic entities list --type Room`
     Then the exit code should be 0
     And the output should contain "urn:ngsi-ld:Room:B10"
     And the output should contain "urn:ngsi-ld:Room:B11"
 
   Scenario: Batch update entities
     Given I am logged in
-    And I run "geonic batch create '[{\"id\":\"urn:ngsi-ld:Room:B20\",\"type\":\"Room\"},{\"id\":\"urn:ngsi-ld:Room:B21\",\"type\":\"Room\"}]'"
-    When I run "geonic batch update '[{\"id\":\"urn:ngsi-ld:Room:B20\",\"type\":\"Room\",\"temperature\":{\"value\":25,\"type\":\"Property\"}},{\"id\":\"urn:ngsi-ld:Room:B21\",\"type\":\"Room\",\"temperature\":{\"value\":30,\"type\":\"Property\"}}]'"
+    And I run `geonic batch create '[{"id":"urn:ngsi-ld:Room:B20","type":"Room"},{"id":"urn:ngsi-ld:Room:B21","type":"Room"}]'`
+    When I run `geonic batch update '[{"id":"urn:ngsi-ld:Room:B20","type":"Room","temperature":{"value":25,"type":"Property"}},{"id":"urn:ngsi-ld:Room:B21","type":"Room","temperature":{"value":30,"type":"Property"}}]'`
     Then the exit code should be 0
-    When I run "geonic entities get urn:ngsi-ld:Room:B20"
+    When I run `geonic entities get urn:ngsi-ld:Room:B20`
     Then the exit code should be 0
     And the output should contain "temperature"
 
   Scenario: Batch delete entities
     Given I am logged in
-    And I run "geonic batch create '[{\"id\":\"urn:ngsi-ld:Room:B30\",\"type\":\"Room\"},{\"id\":\"urn:ngsi-ld:Room:B31\",\"type\":\"Room\"}]'"
-    When I run "geonic batch delete '[\"urn:ngsi-ld:Room:B30\",\"urn:ngsi-ld:Room:B31\"]'"
+    And I run `geonic batch create '[{"id":"urn:ngsi-ld:Room:B30","type":"Room"},{"id":"urn:ngsi-ld:Room:B31","type":"Room"}]'`
+    When I run `geonic batch delete '["urn:ngsi-ld:Room:B30","urn:ngsi-ld:Room:B31"]'`
     Then the exit code should be 0
-    When I run "geonic entities get urn:ngsi-ld:Room:B30"
+    When I run `geonic entities get urn:ngsi-ld:Room:B30`
     Then the exit code should be 1
 
   Scenario: Batch query entities
     Given I am logged in
-    And I run "geonic batch create '[{\"id\":\"urn:ngsi-ld:Room:B40\",\"type\":\"Room\"},{\"id\":\"urn:ngsi-ld:Room:B41\",\"type\":\"Room\"}]'"
-    When I run "geonic batch query '{\"entities\":[{\"type\":\"Room\"}]}'"
+    And I run `geonic batch create '[{"id":"urn:ngsi-ld:Room:B40","type":"Room"},{"id":"urn:ngsi-ld:Room:B41","type":"Room"}]'`
+    When I run `geonic batch query '{"entities":[{"type":"Room"}]}'`
     Then the exit code should be 0
     And stdout should be valid JSON
 
@@ -49,15 +49,15 @@ Feature: Batch entity operations
   Scenario: Batch merge entities
     # Server merge endpoint requires additional fields not yet documented
     Given I am logged in
-    And I run "geonic batch create '[{\"id\":\"urn:ngsi-ld:Room:B50\",\"type\":\"Room\"}]'"
-    When I run "geonic batch merge '[{\"id\":\"urn:ngsi-ld:Room:B50\",\"temperature\":{\"value\":22,\"type\":\"Property\"}}]'"
+    And I run `geonic batch create '[{"id":"urn:ngsi-ld:Room:B50","type":"Room"}]'`
+    When I run `geonic batch merge '[{"id":"urn:ngsi-ld:Room:B50","temperature":{"value":22,"type":"Property"}}]'`
     Then the exit code should be 0
 
   Scenario: entityOperations alias works
     Given I am logged in
-    When I run "geonic entityOperations create '[{\"id\":\"urn:ngsi-ld:Room:B60\",\"type\":\"Room\"}]'"
+    When I run `geonic entityOperations create '[{"id":"urn:ngsi-ld:Room:B60","type":"Room"}]'`
     Then the exit code should be 0
-    When I run "geonic entities get urn:ngsi-ld:Room:B60"
+    When I run `geonic entities get urn:ngsi-ld:Room:B60`
     Then the exit code should be 0
     And stdout should be valid JSON
 

--- a/tests/e2e/features/cadde.feature
+++ b/tests/e2e/features/cadde.feature
@@ -7,17 +7,17 @@ Feature: Admin CADDE configuration
 
   Scenario: Get CADDE configuration
     Given I am logged in
-    When I run "geonic admin cadde get"
+    When I run `geonic admin cadde get`
     Then the exit code should be 0
 
   Scenario: Set CADDE configuration
     Given I am logged in
-    When I run "geonic admin cadde set '{\"provider\":\"test\",\"endpoint\":\"http://localhost:6000\"}'"
+    When I run `geonic admin cadde set '{"provider":"test","endpoint":"http://localhost:6000"}'`
     Then the exit code should be 0
     And the output should contain "CADDE configuration set."
 
   Scenario: Delete CADDE configuration
     Given I am logged in
-    When I run "geonic admin cadde delete"
+    When I run `geonic admin cadde delete`
     Then the exit code should be 0
     And the output should contain "CADDE configuration deleted."

--- a/tests/e2e/features/catalog.feature
+++ b/tests/e2e/features/catalog.feature
@@ -6,12 +6,12 @@ Feature: Catalog management
 
   Scenario: Get the catalog
     Given I am logged in
-    When I run "geonic catalog get"
+    When I run `geonic catalog get`
     Then the exit code should be 0
     And stdout should be valid JSON
 
   Scenario: List datasets
     Given I am logged in
-    When I run "geonic catalog datasets list"
+    When I run `geonic catalog datasets list`
     Then the exit code should be 0
     And stdout should be valid JSON

--- a/tests/e2e/features/config.feature
+++ b/tests/e2e/features/config.feature
@@ -5,10 +5,10 @@ Feature: Config management
 
   Scenario: Set and get a config value
     Given no config file exists
-    When I run "geonic config set url http://localhost:3000"
+    When I run `geonic config set url http://localhost:3000`
     Then the exit code should be 0
     And the output should contain "Set url"
-    When I run "geonic config get url"
+    When I run `geonic config get url`
     Then the exit code should be 0
     And stdout should contain "http://localhost:3000"
 
@@ -17,7 +17,7 @@ Feature: Config management
       """
       { "url": "http://localhost:3000", "service": "myservice" }
       """
-    When I run "geonic config list"
+    When I run `geonic config list`
     Then the exit code should be 0
     And stdout should contain "url"
     And stdout should contain "http://localhost:3000"
@@ -29,7 +29,7 @@ Feature: Config management
       """
       { "url": "http://localhost:3000", "service": "myservice" }
       """
-    When I run "geonic config delete service"
+    When I run `geonic config delete service`
     Then the exit code should be 0
     And the output should contain "Deleted"
     And the config should not have key "service"
@@ -42,6 +42,6 @@ Feature: Config management
       """
       { "url": "http://localhost:3000", "token": "old-token" }
       """
-    When I run "geonic config list"
+    When I run `geonic config list`
     Then the exit code should be 0
     And stdout should contain "url"

--- a/tests/e2e/features/entities.feature
+++ b/tests/e2e/features/entities.feature
@@ -5,100 +5,100 @@ Feature: Entity management
 
   Scenario: List entities when none exist
     Given I am logged in
-    When I run "geonic entities list"
+    When I run `geonic entities list`
     Then the exit code should be 0
     And stdout should be valid JSON
 
   Scenario: Create an entity
     Given I am logged in
-    When I run "geonic entities create '{\"id\":\"urn:ngsi-ld:Room:001\",\"type\":\"Room\"}'"
+    When I run `geonic entities create '{"id":"urn:ngsi-ld:Room:001","type":"Room"}'`
     Then the exit code should be 0
     And the output should contain "Entity created."
 
   Scenario: Get an entity by ID
     Given I am logged in
-    And I run "geonic entities create '{\"id\":\"urn:ngsi-ld:Room:002\",\"type\":\"Room\"}'"
-    When I run "geonic entities get urn:ngsi-ld:Room:002"
+    And I run `geonic entities create '{"id":"urn:ngsi-ld:Room:002","type":"Room"}'`
+    When I run `geonic entities get urn:ngsi-ld:Room:002`
     Then the exit code should be 0
     And stdout should be valid JSON
     And the JSON output should have key "id"
 
   Scenario: List shows created entities
     Given I am logged in
-    And I run "geonic entities create '{\"id\":\"urn:ngsi-ld:Room:003\",\"type\":\"Room\"}'"
-    When I run "geonic entities list"
+    And I run `geonic entities create '{"id":"urn:ngsi-ld:Room:003","type":"Room"}'`
+    When I run `geonic entities list`
     Then the exit code should be 0
     And the output should contain "Room:003"
 
   Scenario: Filter entities by type
     Given I am logged in
-    And I run "geonic entities create '{\"id\":\"urn:ngsi-ld:Room:010\",\"type\":\"Room\"}'"
-    And I run "geonic entities create '{\"id\":\"urn:ngsi-ld:Car:010\",\"type\":\"Car\"}'"
-    When I run "geonic entities list --type Room"
+    And I run `geonic entities create '{"id":"urn:ngsi-ld:Room:010","type":"Room"}'`
+    And I run `geonic entities create '{"id":"urn:ngsi-ld:Car:010","type":"Car"}'`
+    When I run `geonic entities list --type Room`
     Then the exit code should be 0
     And the output should contain "Room:010"
     And the output should not contain "Car:010"
 
   Scenario: List entities with count
     Given I am logged in
-    And I run "geonic entities create '{\"id\":\"urn:ngsi-ld:Room:020\",\"type\":\"Room\"}'"
-    When I run "geonic entities list --count"
+    And I run `geonic entities create '{"id":"urn:ngsi-ld:Room:020","type":"Room"}'`
+    When I run `geonic entities list --count`
     Then the exit code should be 0
 
   Scenario: Update an entity
     Given I am logged in
-    And I run "geonic entities create '{\"id\":\"urn:ngsi-ld:Room:030\",\"type\":\"Room\"}'"
-    When I run "geonic entities update urn:ngsi-ld:Room:030 '{\"temperature\":{\"value\":25,\"type\":\"Property\"}}'"
+    And I run `geonic entities create '{"id":"urn:ngsi-ld:Room:030","type":"Room"}'`
+    When I run `geonic entities update urn:ngsi-ld:Room:030 '{"temperature":{"value":25,"type":"Property"}}'`
     Then the exit code should be 0
     And the output should contain "Entity updated."
 
   Scenario: Delete an entity
     Given I am logged in
-    And I run "geonic entities create '{\"id\":\"urn:ngsi-ld:Room:040\",\"type\":\"Room\"}'"
-    When I run "geonic entities delete urn:ngsi-ld:Room:040"
+    And I run `geonic entities create '{"id":"urn:ngsi-ld:Room:040","type":"Room"}'`
+    When I run `geonic entities delete urn:ngsi-ld:Room:040`
     Then the exit code should be 0
     And the output should contain "Entity deleted."
 
   Scenario: Get non-existent entity returns error
     Given I am logged in
-    When I run "geonic entities get urn:ngsi-ld:NonExistent:999"
+    When I run `geonic entities get urn:ngsi-ld:NonExistent:999`
     Then the exit code should be 1
 
   Scenario: List entities without authentication
     Given I am not logged in
-    When I run "geonic entities list"
+    When I run `geonic entities list`
     Then the exit code should be 1
 
   @wip
   Scenario: Replace entity attributes
     # Server does not support PUT on /entities/{id}/attrs
     Given I am logged in
-    And I run "geonic entities create '{\"id\":\"urn:ngsi-ld:Room:050\",\"type\":\"Room\"}'"
-    When I run "geonic entities replace urn:ngsi-ld:Room:050 '{\"temperature\":{\"value\":30,\"type\":\"Property\"}}'"
+    And I run `geonic entities create '{"id":"urn:ngsi-ld:Room:050","type":"Room"}'`
+    When I run `geonic entities replace urn:ngsi-ld:Room:050 '{"temperature":{"value":30,"type":"Property"}}'`
     Then the exit code should be 0
     And the output should contain "Entity replaced."
 
   Scenario: Upsert entities
     Given I am logged in
-    When I run "geonic entities upsert '[{\"id\":\"urn:ngsi-ld:Room:060\",\"type\":\"Room\"},{\"id\":\"urn:ngsi-ld:Room:061\",\"type\":\"Room\"}]'"
+    When I run `geonic entities upsert '[{"id":"urn:ngsi-ld:Room:060","type":"Room"},{"id":"urn:ngsi-ld:Room:061","type":"Room"}]'`
     Then the exit code should be 0
     And the output should contain "Entity upserted."
 
   Scenario: List entities with limit
     Given I am logged in
-    And I run "geonic entities create '{\"id\":\"urn:ngsi-ld:Room:070\",\"type\":\"Room\"}'"
-    And I run "geonic entities create '{\"id\":\"urn:ngsi-ld:Room:071\",\"type\":\"Room\"}'"
-    And I run "geonic entities create '{\"id\":\"urn:ngsi-ld:Room:072\",\"type\":\"Room\"}'"
-    When I run "geonic entities list --limit 2"
+    And I run `geonic entities create '{"id":"urn:ngsi-ld:Room:070","type":"Room"}'`
+    And I run `geonic entities create '{"id":"urn:ngsi-ld:Room:071","type":"Room"}'`
+    And I run `geonic entities create '{"id":"urn:ngsi-ld:Room:072","type":"Room"}'`
+    When I run `geonic entities list --limit 2`
     Then the exit code should be 0
     And stdout should be valid JSON
 
   Scenario: List entities with id-pattern
     Given I am logged in
-    And I run "geonic entities create '{\"id\":\"urn:ngsi-ld:Sensor:080\",\"type\":\"Sensor\"}'"
-    And I run "geonic entities create '{\"id\":\"urn:ngsi-ld:Sensor:081\",\"type\":\"Sensor\"}'"
-    And I run "geonic entities create '{\"id\":\"urn:ngsi-ld:Room:080\",\"type\":\"Room\"}'"
-    When I run "geonic entities list --id-pattern Sensor"
+    And I run `geonic entities create '{"id":"urn:ngsi-ld:Sensor:080","type":"Sensor"}'`
+    And I run `geonic entities create '{"id":"urn:ngsi-ld:Sensor:081","type":"Sensor"}'`
+    And I run `geonic entities create '{"id":"urn:ngsi-ld:Room:080","type":"Room"}'`
+    When I run `geonic entities list --id-pattern Sensor`
     Then the exit code should be 0
     And the output should contain "Sensor:080"
     And the output should not contain "Room:080"
@@ -107,17 +107,17 @@ Feature: Entity management
   Scenario: List entities with query filter
     # Server query filter (NGSI-LD q parameter) not fully supported
     Given I am logged in
-    And I run "geonic entities create '{\"id\":\"urn:ngsi-ld:Room:090\",\"type\":\"Room\"}'"
-    And I run "geonic entities update urn:ngsi-ld:Room:090 '{\"temperature\":{\"value\":35,\"type\":\"Property\"}}'"
-    And I run "geonic entities list --query temperature>30"
+    And I run `geonic entities create '{"id":"urn:ngsi-ld:Room:090","type":"Room"}'`
+    And I run `geonic entities update urn:ngsi-ld:Room:090 '{"temperature":{"value":35,"type":"Property"}}'`
+    And I run `geonic entities list --query temperature>30`
     Then the exit code should be 0
     And the output should contain "Room:090"
 
   Scenario: List entities with order-by
     Given I am logged in
-    And I run "geonic entities create '{\"id\":\"urn:ngsi-ld:Room:100\",\"type\":\"Room\"}'"
-    And I run "geonic entities create '{\"id\":\"urn:ngsi-ld:Room:101\",\"type\":\"Room\"}'"
-    When I run "geonic entities list --type Room --order-by id"
+    And I run `geonic entities create '{"id":"urn:ngsi-ld:Room:100","type":"Room"}'`
+    And I run `geonic entities create '{"id":"urn:ngsi-ld:Room:101","type":"Room"}'`
+    When I run `geonic entities list --type Room --order-by id`
     Then the exit code should be 0
     And stdout should be valid JSON
 

--- a/tests/e2e/features/health.feature
+++ b/tests/e2e/features/health.feature
@@ -5,18 +5,18 @@ Feature: Health and version
 
   Scenario: Health check returns valid JSON
     Given I am logged in
-    When I run "geonic health"
+    When I run `geonic health`
     Then the exit code should be 0
     And stdout should be valid JSON
 
   Scenario: Health check without URL configured
     Given no config file exists
-    When I run "geonic health"
+    When I run `geonic health`
     Then the exit code should be 1
     And the output should contain "No URL configured"
 
   Scenario: Version displays CLI version
     Given I am logged in
-    When I run "geonic version"
+    When I run `geonic version`
     Then the exit code should be 0
     And the output should contain "CLI version:"

--- a/tests/e2e/features/models.feature
+++ b/tests/e2e/features/models.feature
@@ -7,41 +7,41 @@ Feature: Custom data model management
 
   Scenario: List models when none exist
     Given I am logged in
-    When I run "geonic models list"
+    When I run `geonic models list`
     Then the exit code should be 0
 
   Scenario: Create a model
     Given I am logged in
-    When I run "geonic models create '{\"type\":\"TestModel01\",\"domain\":\"test\",\"description\":\"Model TestModel01\",\"propertyDetails\":{\"temperature\":{\"ngsiType\":\"Property\",\"valueType\":\"Number\",\"example\":25},\"humidity\":{\"ngsiType\":\"Property\",\"valueType\":\"Number\",\"example\":60}}}'"
+    When I run `geonic models create '{"type":"TestModel01","domain":"test","description":"Model TestModel01","propertyDetails":{"temperature":{"ngsiType":"Property","valueType":"Number","example":25},"humidity":{"ngsiType":"Property","valueType":"Number","example":60}}}'`
     Then the exit code should be 0
     And the output should contain "Model created."
 
   Scenario: List models after creation
     Given I am logged in
-    And I run "geonic models create '{\"type\":\"TestModel02\",\"domain\":\"test\",\"description\":\"Model TestModel02\",\"propertyDetails\":{\"temperature\":{\"ngsiType\":\"Property\",\"valueType\":\"Number\",\"example\":25},\"humidity\":{\"ngsiType\":\"Property\",\"valueType\":\"Number\",\"example\":60}}}'"
-    When I run "geonic models list"
+    And I run `geonic models create '{"type":"TestModel02","domain":"test","description":"Model TestModel02","propertyDetails":{"temperature":{"ngsiType":"Property","valueType":"Number","example":25},"humidity":{"ngsiType":"Property","valueType":"Number","example":60}}}'`
+    When I run `geonic models list`
     Then the exit code should be 0
     And the output should contain "TestModel02"
 
   Scenario: Get a model by ID
     Given I am logged in
-    And I run "geonic models create '{\"type\":\"TestModel03\",\"domain\":\"test\",\"description\":\"Model TestModel03\",\"propertyDetails\":{\"temperature\":{\"ngsiType\":\"Property\",\"valueType\":\"Number\",\"example\":25},\"humidity\":{\"ngsiType\":\"Property\",\"valueType\":\"Number\",\"example\":60}}}'"
-    And I run "geonic models list --format json"
+    And I run `geonic models create '{"type":"TestModel03","domain":"test","description":"Model TestModel03","propertyDetails":{"temperature":{"ngsiType":"Property","valueType":"Number","example":25},"humidity":{"ngsiType":"Property","valueType":"Number","example":60}}}'`
+    And I run `geonic models list --format json`
     And I save the ID from the JSON output
-    When I run "geonic models get $ID" replacing ID
+    When I run `geonic models get $ID` replacing ID
     Then the exit code should be 0
     And stdout should be valid JSON
 
   Scenario: Delete a model
     Given I am logged in
-    And I run "geonic models create '{\"type\":\"TestModel04\",\"domain\":\"test\",\"description\":\"Model TestModel04\",\"propertyDetails\":{\"temperature\":{\"ngsiType\":\"Property\",\"valueType\":\"Number\",\"example\":25},\"humidity\":{\"ngsiType\":\"Property\",\"valueType\":\"Number\",\"example\":60}}}'"
-    And I run "geonic models list --format json"
+    And I run `geonic models create '{"type":"TestModel04","domain":"test","description":"Model TestModel04","propertyDetails":{"temperature":{"ngsiType":"Property","valueType":"Number","example":25},"humidity":{"ngsiType":"Property","valueType":"Number","example":60}}}'`
+    And I run `geonic models list --format json`
     And I save the ID from the JSON output
-    When I run "geonic models delete $ID" replacing ID
+    When I run `geonic models delete $ID` replacing ID
     Then the exit code should be 0
     And the output should contain "Model deleted."
 
   Scenario: custom-data-models alias works
     Given I am logged in
-    When I run "geonic custom-data-models list"
+    When I run `geonic custom-data-models list`
     Then the exit code should be 0

--- a/tests/e2e/features/oauth-clients.feature
+++ b/tests/e2e/features/oauth-clients.feature
@@ -6,41 +6,41 @@ Feature: Admin OAuth client management
 
   Scenario: List OAuth clients
     Given I am logged in
-    When I run "geonic admin oauth-clients list"
+    When I run `geonic admin oauth-clients list`
     Then the exit code should be 0
     And stdout should be valid JSON
 
   Scenario: Create an OAuth client
     Given I am logged in
-    When I run "geonic admin oauth-clients create '{\"clientName\":\"test-client-01\",\"allowedScopes\":[]}'"
+    When I run `geonic admin oauth-clients create '{"clientName":"test-client-01","allowedScopes":[]}'`
     Then the exit code should be 0
     And the output should contain "OAuth client created."
 
   Scenario: Get an OAuth client by ID
     Given I am logged in
-    And I run "geonic admin oauth-clients create '{\"clientName\":\"test-client-02\",\"allowedScopes\":[]}'"
-    And I run "geonic admin oauth-clients list --format json"
+    And I run `geonic admin oauth-clients create '{"clientName":"test-client-02","allowedScopes":[]}'`
+    And I run `geonic admin oauth-clients list --format json`
     And I save the ID from the JSON output
-    When I run "geonic admin oauth-clients get $ID" replacing ID
+    When I run `geonic admin oauth-clients get $ID` replacing ID
     Then the exit code should be 0
     And stdout should be valid JSON
 
   Scenario: Update an OAuth client
     Given I am logged in
-    And I run "geonic admin oauth-clients create '{\"clientName\":\"test-client-04\",\"allowedScopes\":[]}'"
-    And I run "geonic admin oauth-clients list --format json"
+    And I run `geonic admin oauth-clients create '{"clientName":"test-client-04","allowedScopes":[]}'`
+    And I run `geonic admin oauth-clients list --format json`
     And I save the ID from the JSON output
-    When I run "geonic admin oauth-clients update $ID '{\"description\":\"Updated client\"}'" replacing ID
+    When I run `geonic admin oauth-clients update $ID '{"description":"Updated client"}'` replacing ID
     Then the exit code should be 0
-    When I run "geonic admin oauth-clients get $ID" replacing ID
+    When I run `geonic admin oauth-clients get $ID` replacing ID
     Then the exit code should be 0
     And the output should contain "Updated client"
 
   Scenario: Delete an OAuth client
     Given I am logged in
-    And I run "geonic admin oauth-clients create '{\"clientName\":\"test-client-03\",\"allowedScopes\":[]}'"
-    And I run "geonic admin oauth-clients list --format json"
+    And I run `geonic admin oauth-clients create '{"clientName":"test-client-03","allowedScopes":[]}'`
+    And I run `geonic admin oauth-clients list --format json`
     And I save the ID from the JSON output
-    When I run "geonic admin oauth-clients delete $ID" replacing ID
+    When I run `geonic admin oauth-clients delete $ID` replacing ID
     Then the exit code should be 0
     And the output should contain "OAuth client deleted."

--- a/tests/e2e/features/policies.feature
+++ b/tests/e2e/features/policies.feature
@@ -6,53 +6,53 @@ Feature: Admin policy management
 
   Scenario: List policies
     Given I am logged in
-    When I run "geonic admin policies list"
+    When I run `geonic admin policies list`
     Then the exit code should be 0
     And stdout should be valid JSON
 
   Scenario: Create a policy
     Given I am logged in
-    When I run "geonic admin policies create '{\"description\":\"Policy test-policy-01\",\"rules\":[{\"ruleId\":\"test-policy-01\",\"effect\":\"Permit\"}]}'"
+    When I run `geonic admin policies create '{"description":"Policy test-policy-01","rules":[{"ruleId":"test-policy-01","effect":"Permit"}]}'`
     Then the exit code should be 0
     And the output should contain "Policy created."
 
   Scenario: Get a policy by ID
     Given I am logged in
-    And I run "geonic admin policies create '{\"description\":\"Policy test-policy-02\",\"rules\":[{\"ruleId\":\"test-policy-02\",\"effect\":\"Permit\"}]}'"
-    And I run "geonic admin policies list --format json"
+    And I run `geonic admin policies create '{"description":"Policy test-policy-02","rules":[{"ruleId":"test-policy-02","effect":"Permit"}]}'`
+    And I run `geonic admin policies list --format json`
     And I save the ID from the JSON output
-    When I run "geonic admin policies get $ID" replacing ID
+    When I run `geonic admin policies get $ID` replacing ID
     Then the exit code should be 0
     And stdout should be valid JSON
 
   Scenario: Update a policy
     Given I am logged in
-    And I run "geonic admin policies create '{\"description\":\"Policy test-policy-05\",\"rules\":[{\"ruleId\":\"test-policy-05\",\"effect\":\"Permit\"}]}'"
-    And I run "geonic admin policies list --format json"
+    And I run `geonic admin policies create '{"description":"Policy test-policy-05","rules":[{"ruleId":"test-policy-05","effect":"Permit"}]}'`
+    And I run `geonic admin policies list --format json`
     And I save the ID from the JSON output
-    When I run "geonic admin policies update $ID '{\"description\":\"Updated policy\"}'" replacing ID
+    When I run `geonic admin policies update $ID '{"description":"Updated policy"}'` replacing ID
     Then the exit code should be 0
-    When I run "geonic admin policies get $ID" replacing ID
+    When I run `geonic admin policies get $ID` replacing ID
     Then the exit code should be 0
     And the output should contain "Updated policy"
 
   Scenario: Delete a policy
     Given I am logged in
-    And I run "geonic admin policies create '{\"description\":\"Policy test-policy-03\",\"rules\":[{\"ruleId\":\"test-policy-03\",\"effect\":\"Permit\"}]}'"
-    And I run "geonic admin policies list --format json"
+    And I run `geonic admin policies create '{"description":"Policy test-policy-03","rules":[{"ruleId":"test-policy-03","effect":"Permit"}]}'`
+    And I run `geonic admin policies list --format json`
     And I save the ID from the JSON output
-    When I run "geonic admin policies delete $ID" replacing ID
+    When I run `geonic admin policies delete $ID` replacing ID
     Then the exit code should be 0
     And the output should contain "Policy deleted."
 
   Scenario: Activate and deactivate a policy
     Given I am logged in
-    And I run "geonic admin policies create '{\"description\":\"Policy test-policy-04\",\"rules\":[{\"ruleId\":\"test-policy-04\",\"effect\":\"Permit\"}]}'"
-    And I run "geonic admin policies list --format json"
+    And I run `geonic admin policies create '{"description":"Policy test-policy-04","rules":[{"ruleId":"test-policy-04","effect":"Permit"}]}'`
+    And I run `geonic admin policies list --format json`
     And I save the ID from the JSON output
-    When I run "geonic admin policies deactivate $ID" replacing ID
+    When I run `geonic admin policies deactivate $ID` replacing ID
     Then the exit code should be 0
     And the output should contain "Policy deactivated."
-    When I run "geonic admin policies activate $ID" replacing ID
+    When I run `geonic admin policies activate $ID` replacing ID
     Then the exit code should be 0
     And the output should contain "Policy activated."

--- a/tests/e2e/features/profile.feature
+++ b/tests/e2e/features/profile.feature
@@ -5,13 +5,13 @@ Feature: Profile management
 
   Scenario: List profiles when none exist
     Given no config file exists
-    When I run "geonic profile list"
+    When I run `geonic profile list`
     Then the exit code should be 0
     And the output should contain "default"
 
   Scenario: Create a new profile
     Given no config file exists
-    When I run "geonic profile create staging"
+    When I run `geonic profile create staging`
     Then the exit code should be 0
     And the output should contain "staging"
 
@@ -27,7 +27,7 @@ Feature: Profile management
         }
       }
       """
-    When I run "geonic profile use staging"
+    When I run `geonic profile use staging`
     Then the exit code should be 0
     And the active profile should be "staging"
 
@@ -42,7 +42,7 @@ Feature: Profile management
         }
       }
       """
-    When I run "geonic profile show default"
+    When I run `geonic profile show default`
     Then the exit code should be 0
     And the output should contain "http://localhost:3000"
 
@@ -58,7 +58,7 @@ Feature: Profile management
         }
       }
       """
-    When I run "geonic profile delete staging"
+    When I run `geonic profile delete staging`
     Then the exit code should be 0
     And the config should not have profile "staging"
 
@@ -73,7 +73,7 @@ Feature: Profile management
         }
       }
       """
-    When I run "geonic profile delete default"
+    When I run `geonic profile delete default`
     Then the exit code should be 1
 
   Scenario: Cannot create duplicate profile
@@ -88,7 +88,7 @@ Feature: Profile management
         }
       }
       """
-    When I run "geonic profile create staging"
+    When I run `geonic profile create staging`
     Then the exit code should be 1
 
   Scenario: Cannot switch to non-existent profile
@@ -102,7 +102,7 @@ Feature: Profile management
         }
       }
       """
-    When I run "geonic profile use nonexistent"
+    When I run `geonic profile use nonexistent`
     Then the exit code should be 1
 
   Scenario: Delete active profile switches to default
@@ -117,7 +117,7 @@ Feature: Profile management
         }
       }
       """
-    When I run "geonic profile delete staging"
+    When I run `geonic profile delete staging`
     Then the exit code should be 0
     And the config should not have profile "staging"
     And the active profile should be "default"
@@ -133,6 +133,6 @@ Feature: Profile management
         }
       }
       """
-    When I run "geonic profile show nonexistent"
+    When I run `geonic profile show nonexistent`
     Then the exit code should be 0
     And the output should contain "has no settings"

--- a/tests/e2e/features/registrations.feature
+++ b/tests/e2e/features/registrations.feature
@@ -7,44 +7,44 @@ Feature: Registration management
 
   Scenario: List registrations when none exist
     Given I am logged in
-    When I run "geonic registrations list"
+    When I run `geonic registrations list`
     Then the exit code should be 0
     And stdout should contain "[]"
 
   Scenario: Create a registration
     Given I am logged in
-    When I run "geonic registrations create '{\"type\":\"ContextSourceRegistration\",\"information\":[{\"entities\":[{\"type\":\"Room\"}]}],\"endpoint\":\"http://localhost:4000/source\"}'"
+    When I run `geonic registrations create '{"type":"ContextSourceRegistration","information":[{"entities":[{"type":"Room"}]}],"endpoint":"http://localhost:4000/source"}'`
     Then the exit code should be 0
     And the output should contain "Registration created."
 
   Scenario: List registrations after creation
     Given I am logged in
-    And I run "geonic registrations create '{\"type\":\"ContextSourceRegistration\",\"information\":[{\"entities\":[{\"type\":\"Room\"}]}],\"endpoint\":\"http://localhost:4000/source\"}'"
-    When I run "geonic registrations list"
+    And I run `geonic registrations create '{"type":"ContextSourceRegistration","information":[{"entities":[{"type":"Room"}]}],"endpoint":"http://localhost:4000/source"}'`
+    When I run `geonic registrations list`
     Then the exit code should be 0
     And the output should contain "Room"
 
   Scenario: Get registration by ID
     Given I am logged in
-    And I run "geonic registrations create '{\"type\":\"ContextSourceRegistration\",\"information\":[{\"entities\":[{\"type\":\"Room\"}]}],\"endpoint\":\"http://localhost:4000/source\"}'"
-    And I run "geonic registrations list --format json"
+    And I run `geonic registrations create '{"type":"ContextSourceRegistration","information":[{"entities":[{"type":"Room"}]}],"endpoint":"http://localhost:4000/source"}'`
+    And I run `geonic registrations list --format json`
     And I save the ID from the JSON output
-    When I run "geonic registrations get $ID" replacing ID
+    When I run `geonic registrations get $ID` replacing ID
     Then the exit code should be 0
     And stdout should be valid JSON
 
   Scenario: Delete a registration
     Given I am logged in
-    And I run "geonic registrations create '{\"type\":\"ContextSourceRegistration\",\"information\":[{\"entities\":[{\"type\":\"Room\"}]}],\"endpoint\":\"http://localhost:4000/source\"}'"
-    And I run "geonic registrations list --format json"
+    And I run `geonic registrations create '{"type":"ContextSourceRegistration","information":[{"entities":[{"type":"Room"}]}],"endpoint":"http://localhost:4000/source"}'`
+    And I run `geonic registrations list --format json`
     And I save the ID from the JSON output
-    When I run "geonic registrations delete $ID" replacing ID
+    When I run `geonic registrations delete $ID` replacing ID
     Then the exit code should be 0
     And the output should contain "Registration deleted."
 
   Scenario: List registrations with count
     Given I am logged in
-    And I run "geonic registrations create '{\"type\":\"ContextSourceRegistration\",\"information\":[{\"entities\":[{\"type\":\"Room\"}]}],\"endpoint\":\"http://localhost:4000/source\"}'"
-    When I run "geonic registrations list --count"
+    And I run `geonic registrations create '{"type":"ContextSourceRegistration","information":[{"entities":[{"type":"Room"}]}],"endpoint":"http://localhost:4000/source"}'`
+    When I run `geonic registrations list --count`
     Then the exit code should be 0
     And the output should contain "Count:"

--- a/tests/e2e/features/rules.feature
+++ b/tests/e2e/features/rules.feature
@@ -6,48 +6,48 @@ Feature: Rule management
 
   Scenario: List rules when none exist
     Given I am logged in
-    When I run "geonic rules list"
+    When I run `geonic rules list`
     Then the exit code should be 0
 
   Scenario: Create a rule
     Given I am logged in
-    When I run "geonic rules create '{\"name\":\"test-rule-01\",\"description\":\"Rule test-rule-01\",\"conditions\":[{\"type\":\"celExpression\",\"expression\":\"entity.temperature > 30\"}],\"actions\":[{\"type\":\"webhook\",\"url\":\"http://localhost:5000/rules\",\"method\":\"POST\"}]}'"
+    When I run `geonic rules create '{"name":"test-rule-01","description":"Rule test-rule-01","conditions":[{"type":"celExpression","expression":"entity.temperature > 30"}],"actions":[{"type":"webhook","url":"http://localhost:5000/rules","method":"POST"}]}'`
     Then the exit code should be 0
     And the output should contain "Rule created."
 
   Scenario: List rules after creation
     Given I am logged in
-    And I run "geonic rules create '{\"name\":\"test-rule-02\",\"description\":\"Rule test-rule-02\",\"conditions\":[{\"type\":\"celExpression\",\"expression\":\"entity.temperature > 30\"}],\"actions\":[{\"type\":\"webhook\",\"url\":\"http://localhost:5000/rules\",\"method\":\"POST\"}]}'"
-    When I run "geonic rules list"
+    And I run `geonic rules create '{"name":"test-rule-02","description":"Rule test-rule-02","conditions":[{"type":"celExpression","expression":"entity.temperature > 30"}],"actions":[{"type":"webhook","url":"http://localhost:5000/rules","method":"POST"}]}'`
+    When I run `geonic rules list`
     Then the exit code should be 0
     And the output should contain "test-rule-02"
 
   Scenario: Get a rule by ID
     Given I am logged in
-    And I run "geonic rules create '{\"name\":\"test-rule-03\",\"description\":\"Rule test-rule-03\",\"conditions\":[{\"type\":\"celExpression\",\"expression\":\"entity.temperature > 30\"}],\"actions\":[{\"type\":\"webhook\",\"url\":\"http://localhost:5000/rules\",\"method\":\"POST\"}]}'"
-    And I run "geonic rules list --format json"
+    And I run `geonic rules create '{"name":"test-rule-03","description":"Rule test-rule-03","conditions":[{"type":"celExpression","expression":"entity.temperature > 30"}],"actions":[{"type":"webhook","url":"http://localhost:5000/rules","method":"POST"}]}'`
+    And I run `geonic rules list --format json`
     And I save the ID from the JSON output
-    When I run "geonic rules get $ID" replacing ID
+    When I run `geonic rules get $ID` replacing ID
     Then the exit code should be 0
     And stdout should be valid JSON
 
   Scenario: Delete a rule
     Given I am logged in
-    And I run "geonic rules create '{\"name\":\"test-rule-04\",\"description\":\"Rule test-rule-04\",\"conditions\":[{\"type\":\"celExpression\",\"expression\":\"entity.temperature > 30\"}],\"actions\":[{\"type\":\"webhook\",\"url\":\"http://localhost:5000/rules\",\"method\":\"POST\"}]}'"
-    And I run "geonic rules list --format json"
+    And I run `geonic rules create '{"name":"test-rule-04","description":"Rule test-rule-04","conditions":[{"type":"celExpression","expression":"entity.temperature > 30"}],"actions":[{"type":"webhook","url":"http://localhost:5000/rules","method":"POST"}]}'`
+    And I run `geonic rules list --format json`
     And I save the ID from the JSON output
-    When I run "geonic rules delete $ID" replacing ID
+    When I run `geonic rules delete $ID` replacing ID
     Then the exit code should be 0
     And the output should contain "Rule deleted."
 
   Scenario: Activate and deactivate a rule
     Given I am logged in
-    And I run "geonic rules create '{\"name\":\"test-rule-05\",\"description\":\"Rule test-rule-05\",\"conditions\":[{\"type\":\"celExpression\",\"expression\":\"entity.temperature > 30\"}],\"actions\":[{\"type\":\"webhook\",\"url\":\"http://localhost:5000/rules\",\"method\":\"POST\"}]}'"
-    And I run "geonic rules list --format json"
+    And I run `geonic rules create '{"name":"test-rule-05","description":"Rule test-rule-05","conditions":[{"type":"celExpression","expression":"entity.temperature > 30"}],"actions":[{"type":"webhook","url":"http://localhost:5000/rules","method":"POST"}]}'`
+    And I run `geonic rules list --format json`
     And I save the ID from the JSON output
-    When I run "geonic rules deactivate $ID" replacing ID
+    When I run `geonic rules deactivate $ID` replacing ID
     Then the exit code should be 0
     And the output should contain "Rule deactivated."
-    When I run "geonic rules activate $ID" replacing ID
+    When I run `geonic rules activate $ID` replacing ID
     Then the exit code should be 0
     And the output should contain "Rule activated."

--- a/tests/e2e/features/snapshots.feature
+++ b/tests/e2e/features/snapshots.feature
@@ -6,47 +6,47 @@ Feature: Snapshot management
 
   Scenario: List snapshots when none exist
     Given I am logged in
-    When I run "geonic snapshots list"
+    When I run `geonic snapshots list`
     Then the exit code should be 0
 
   Scenario: Create a snapshot
     Given I am logged in
-    When I run "geonic snapshots create"
+    When I run `geonic snapshots create`
     Then the exit code should be 0
     And the output should contain "Snapshot created."
 
   Scenario: List snapshots after creation
     Given I am logged in
-    And I run "geonic snapshots create"
-    And I run "geonic snapshots list --format json"
+    And I run `geonic snapshots create`
+    And I run `geonic snapshots list --format json`
     And I save the ID from the JSON output
     Then the exit code should be 0
 
   Scenario: Get a snapshot by ID
     Given I am logged in
-    And I run "geonic snapshots create"
-    And I run "geonic snapshots list --format json"
+    And I run `geonic snapshots create`
+    And I run `geonic snapshots list --format json`
     And I save the ID from the JSON output
-    When I run "geonic snapshots get $ID" replacing ID
+    When I run `geonic snapshots get $ID` replacing ID
     Then the exit code should be 0
     And stdout should be valid JSON
 
   Scenario: Delete a snapshot
     Given I am logged in
-    And I run "geonic snapshots create"
-    And I run "geonic snapshots list --format json"
+    And I run `geonic snapshots create`
+    And I run `geonic snapshots list --format json`
     And I save the ID from the JSON output
-    When I run "geonic snapshots delete $ID" replacing ID
+    When I run `geonic snapshots delete $ID` replacing ID
     Then the exit code should be 0
     And the output should contain "Snapshot deleted."
 
   Scenario: Clone a snapshot
     Given I am logged in
-    And I run "geonic snapshots create"
-    And I run "geonic snapshots list --format json"
+    And I run `geonic snapshots create`
+    And I run `geonic snapshots list --format json`
     And I save the ID from the JSON output
-    When I run "geonic snapshots clone $ID" replacing ID
+    When I run `geonic snapshots clone $ID` replacing ID
     Then the exit code should be 0
-    When I run "geonic snapshots list --format json"
+    When I run `geonic snapshots list --format json`
     Then the exit code should be 0
     And the snapshot count should be at least 2

--- a/tests/e2e/features/subscriptions.feature
+++ b/tests/e2e/features/subscriptions.feature
@@ -5,61 +5,61 @@ Feature: Subscription management
 
   Scenario: Create a subscription
     Given I am logged in
-    When I run "geonic subscriptions create '{\"type\":\"Subscription\",\"description\":\"Notify on Room changes\",\"entities\":[{\"type\":\"Room\"}],\"watchedAttributes\":[\"temperature\"],\"notification\":{\"endpoint\":{\"uri\":\"http://localhost:3000/notify\"},\"attributes\":[\"temperature\"]}}'"
+    When I run `geonic subscriptions create '{"type":"Subscription","description":"Notify on Room changes","entities":[{"type":"Room"}],"watchedAttributes":["temperature"],"notification":{"endpoint":{"uri":"http://localhost:3000/notify"},"attributes":["temperature"]}}'`
     Then the exit code should be 0
     And the output should contain "Subscription created."
 
   Scenario: List subscriptions
     Given I am logged in
-    And I run "geonic subscriptions create '{\"type\":\"Subscription\",\"description\":\"Notify on Room changes\",\"entities\":[{\"type\":\"Room\"}],\"watchedAttributes\":[\"temperature\"],\"notification\":{\"endpoint\":{\"uri\":\"http://localhost:3000/notify\"},\"attributes\":[\"temperature\"]}}'"
-    When I run "geonic subscriptions list"
+    And I run `geonic subscriptions create '{"type":"Subscription","description":"Notify on Room changes","entities":[{"type":"Room"}],"watchedAttributes":["temperature"],"notification":{"endpoint":{"uri":"http://localhost:3000/notify"},"attributes":["temperature"]}}'`
+    When I run `geonic subscriptions list`
     Then the exit code should be 0
     And the output should contain "Room"
 
   Scenario: Delete a subscription
     Given I am logged in
-    And I run "geonic subscriptions create '{\"type\":\"Subscription\",\"description\":\"Notify on Room changes\",\"entities\":[{\"type\":\"Room\"}],\"watchedAttributes\":[\"temperature\"],\"notification\":{\"endpoint\":{\"uri\":\"http://localhost:3000/notify\"},\"attributes\":[\"temperature\"]}}'"
-    And I run "geonic subscriptions list --format json"
+    And I run `geonic subscriptions create '{"type":"Subscription","description":"Notify on Room changes","entities":[{"type":"Room"}],"watchedAttributes":["temperature"],"notification":{"endpoint":{"uri":"http://localhost:3000/notify"},"attributes":["temperature"]}}'`
+    And I run `geonic subscriptions list --format json`
     And I save the ID from the JSON output
-    When I run "geonic subscriptions delete $ID" replacing ID
+    When I run `geonic subscriptions delete $ID` replacing ID
     Then the exit code should be 0
     And the output should contain "Subscription deleted."
 
   Scenario: Get subscription by ID
     Given I am logged in
-    And I run "geonic subscriptions create '{\"type\":\"Subscription\",\"description\":\"Notify on Room changes\",\"entities\":[{\"type\":\"Room\"}],\"watchedAttributes\":[\"temperature\"],\"notification\":{\"endpoint\":{\"uri\":\"http://localhost:3000/notify\"},\"attributes\":[\"temperature\"]}}'"
-    And I run "geonic subscriptions list --format json"
+    And I run `geonic subscriptions create '{"type":"Subscription","description":"Notify on Room changes","entities":[{"type":"Room"}],"watchedAttributes":["temperature"],"notification":{"endpoint":{"uri":"http://localhost:3000/notify"},"attributes":["temperature"]}}'`
+    And I run `geonic subscriptions list --format json`
     And I save the ID from the JSON output
-    When I run "geonic subscriptions get $ID" replacing ID
+    When I run `geonic subscriptions get $ID` replacing ID
     Then the exit code should be 0
     And stdout should be valid JSON
     And the JSON output should have key "id"
 
   Scenario: Update a subscription
     Given I am logged in
-    And I run "geonic subscriptions create '{\"type\":\"Subscription\",\"description\":\"Notify on Room changes\",\"entities\":[{\"type\":\"Room\"}],\"watchedAttributes\":[\"temperature\"],\"notification\":{\"endpoint\":{\"uri\":\"http://localhost:3000/notify\"},\"attributes\":[\"temperature\"]}}'"
-    And I run "geonic subscriptions list --format json"
+    And I run `geonic subscriptions create '{"type":"Subscription","description":"Notify on Room changes","entities":[{"type":"Room"}],"watchedAttributes":["temperature"],"notification":{"endpoint":{"uri":"http://localhost:3000/notify"},"attributes":["temperature"]}}'`
+    And I run `geonic subscriptions list --format json`
     And I save the ID from the JSON output
-    When I run "geonic subscriptions update $ID '{\"description\":\"Updated subscription\"}'" replacing ID
+    When I run `geonic subscriptions update $ID '{"description":"Updated subscription"}'` replacing ID
     Then the exit code should be 0
     And the output should contain "Subscription updated."
-    When I run "geonic subscriptions get $ID" replacing ID
+    When I run `geonic subscriptions get $ID` replacing ID
     Then the exit code should be 0
     And stdout should be valid JSON
     And the output should contain "Updated subscription"
 
   Scenario: List subscriptions with count
     Given I am logged in
-    And I run "geonic subscriptions create '{\"type\":\"Subscription\",\"description\":\"Notify on Room changes\",\"entities\":[{\"type\":\"Room\"}],\"watchedAttributes\":[\"temperature\"],\"notification\":{\"endpoint\":{\"uri\":\"http://localhost:3000/notify\"},\"attributes\":[\"temperature\"]}}'"
-    When I run "geonic subscriptions list --count"
+    And I run `geonic subscriptions create '{"type":"Subscription","description":"Notify on Room changes","entities":[{"type":"Room"}],"watchedAttributes":["temperature"],"notification":{"endpoint":{"uri":"http://localhost:3000/notify"},"attributes":["temperature"]}}'`
+    When I run `geonic subscriptions list --count`
     Then the exit code should be 0
     And stdout should be valid JSON
 
   Scenario: List subscriptions with limit
     Given I am logged in
-    And I run "geonic subscriptions create '{\"type\":\"Subscription\",\"description\":\"Notify on Room changes\",\"entities\":[{\"type\":\"Room\"}],\"watchedAttributes\":[\"temperature\"],\"notification\":{\"endpoint\":{\"uri\":\"http://localhost:3000/notify\"},\"attributes\":[\"temperature\"]}}'"
-    And I run "geonic subscriptions create '{\"type\":\"Subscription\",\"description\":\"Notify on Car changes\",\"entities\":[{\"type\":\"Car\"}],\"watchedAttributes\":[\"temperature\"],\"notification\":{\"endpoint\":{\"uri\":\"http://localhost:3000/notify\"},\"attributes\":[\"temperature\"]}}'"
-    When I run "geonic subscriptions list --limit 1 --format json"
+    And I run `geonic subscriptions create '{"type":"Subscription","description":"Notify on Room changes","entities":[{"type":"Room"}],"watchedAttributes":["temperature"],"notification":{"endpoint":{"uri":"http://localhost:3000/notify"},"attributes":["temperature"]}}'`
+    And I run `geonic subscriptions create '{"type":"Subscription","description":"Notify on Car changes","entities":[{"type":"Car"}],"watchedAttributes":["temperature"],"notification":{"endpoint":{"uri":"http://localhost:3000/notify"},"attributes":["temperature"]}}'`
+    When I run `geonic subscriptions list --limit 1 --format json`
     Then the exit code should be 0
     And stdout should be valid JSON
     And the JSON array length should be 1

--- a/tests/e2e/features/temporal.feature
+++ b/tests/e2e/features/temporal.feature
@@ -6,48 +6,48 @@ Feature: Temporal entity management
 
   Scenario: List temporal entities when none exist
     Given I am logged in
-    When I run "geonic temporal entities list"
+    When I run `geonic temporal entities list`
     Then the exit code should be 0
     And stdout should contain "[]"
 
   Scenario: Create a temporal entity
     Given I am logged in
-    When I run "geonic temporal entities create '{\"id\":\"urn:ngsi-ld:Room:T01\",\"type\":\"Room\",\"temperature\":[{\"type\":\"Property\",\"value\":25,\"observedAt\":\"2025-01-01T00:00:00Z\"}]}'"
+    When I run `geonic temporal entities create '{"id":"urn:ngsi-ld:Room:T01","type":"Room","temperature":[{"type":"Property","value":25,"observedAt":"2025-01-01T00:00:00Z"}]}'`
     Then the exit code should be 0
     And the output should contain "Temporal entity created."
 
   Scenario: List temporal entities after creation
     Given I am logged in
-    And I run "geonic temporal entities create '{\"id\":\"urn:ngsi-ld:Room:T02\",\"type\":\"Room\",\"temperature\":[{\"type\":\"Property\",\"value\":25,\"observedAt\":\"2025-01-01T00:00:00Z\"}]}'"
-    When I run "geonic temporal entities list"
+    And I run `geonic temporal entities create '{"id":"urn:ngsi-ld:Room:T02","type":"Room","temperature":[{"type":"Property","value":25,"observedAt":"2025-01-01T00:00:00Z"}]}'`
+    When I run `geonic temporal entities list`
     Then the exit code should be 0
     And the output should contain "urn:ngsi-ld:Room:T02"
 
   Scenario: Get a temporal entity by ID
     Given I am logged in
-    And I run "geonic temporal entities create '{\"id\":\"urn:ngsi-ld:Room:T03\",\"type\":\"Room\",\"temperature\":[{\"type\":\"Property\",\"value\":25,\"observedAt\":\"2025-01-01T00:00:00Z\"}]}'"
-    When I run "geonic temporal entities get urn:ngsi-ld:Room:T03"
+    And I run `geonic temporal entities create '{"id":"urn:ngsi-ld:Room:T03","type":"Room","temperature":[{"type":"Property","value":25,"observedAt":"2025-01-01T00:00:00Z"}]}'`
+    When I run `geonic temporal entities get urn:ngsi-ld:Room:T03`
     Then the exit code should be 0
     And stdout should be valid JSON
     And the JSON output should have key "id"
 
   Scenario: Delete a temporal entity
     Given I am logged in
-    And I run "geonic temporal entities create '{\"id\":\"urn:ngsi-ld:Room:T04\",\"type\":\"Room\",\"temperature\":[{\"type\":\"Property\",\"value\":25,\"observedAt\":\"2025-01-01T00:00:00Z\"}]}'"
-    When I run "geonic temporal entities delete urn:ngsi-ld:Room:T04"
+    And I run `geonic temporal entities create '{"id":"urn:ngsi-ld:Room:T04","type":"Room","temperature":[{"type":"Property","value":25,"observedAt":"2025-01-01T00:00:00Z"}]}'`
+    When I run `geonic temporal entities delete urn:ngsi-ld:Room:T04`
     Then the exit code should be 0
     And the output should contain "Temporal entity deleted."
 
   Scenario: List temporal entities with type filter
     Given I am logged in
-    And I run "geonic temporal entities create '{\"id\":\"urn:ngsi-ld:Room:T05\",\"type\":\"Room\",\"temperature\":[{\"type\":\"Property\",\"value\":25,\"observedAt\":\"2025-01-01T00:00:00Z\"}]}'"
-    When I run "geonic temporal entities list --type Room"
+    And I run `geonic temporal entities create '{"id":"urn:ngsi-ld:Room:T05","type":"Room","temperature":[{"type":"Property","value":25,"observedAt":"2025-01-01T00:00:00Z"}]}'`
+    When I run `geonic temporal entities list --type Room`
     Then the exit code should be 0
     And the output should contain "urn:ngsi-ld:Room:T05"
 
   Scenario: Temporal entityOperations query
     Given I am logged in
-    And I run "geonic temporal entities create '{\"id\":\"urn:ngsi-ld:Room:T06\",\"type\":\"Room\",\"temperature\":[{\"type\":\"Property\",\"value\":25,\"observedAt\":\"2025-01-01T00:00:00Z\"}]}'"
-    When I run "geonic temporal entityOperations query '{\"entities\":[{\"type\":\"Room\"}]}'"
+    And I run `geonic temporal entities create '{"id":"urn:ngsi-ld:Room:T06","type":"Room","temperature":[{"type":"Property","value":25,"observedAt":"2025-01-01T00:00:00Z"}]}'`
+    When I run `geonic temporal entityOperations query '{"entities":[{"type":"Room"}]}'`
     Then the exit code should be 0
     And stdout should be valid JSON

--- a/tests/e2e/features/tenants.feature
+++ b/tests/e2e/features/tenants.feature
@@ -6,51 +6,51 @@ Feature: Admin tenant management
 
   Scenario: List tenants
     Given I am logged in
-    When I run "geonic admin tenants list"
+    When I run `geonic admin tenants list`
     Then the exit code should be 0
     And stdout should be valid JSON
 
   Scenario: Create a tenant
     Given I am logged in
-    When I run "geonic admin tenants create '{\"name\":\"test-tenant-01\",\"description\":\"Tenant test-tenant-01\"}'"
+    When I run `geonic admin tenants create '{"name":"test-tenant-01","description":"Tenant test-tenant-01"}'`
     Then the exit code should be 0
     And the output should contain "Tenant created."
 
   Scenario: Get a tenant by ID
     Given I am logged in
-    And I run "geonic admin tenants create '{\"name\":\"test-tenant-02\",\"description\":\"Tenant test-tenant-02\"}'"
-    And I run "geonic admin tenants list --format json"
+    And I run `geonic admin tenants create '{"name":"test-tenant-02","description":"Tenant test-tenant-02"}'`
+    And I run `geonic admin tenants list --format json`
     And I save the ID from the JSON output
-    When I run "geonic admin tenants get $ID" replacing ID
+    When I run `geonic admin tenants get $ID` replacing ID
     Then the exit code should be 0
     And stdout should be valid JSON
 
   Scenario: Update a tenant
     Given I am logged in
-    And I run "geonic admin tenants create '{\"name\":\"test-tenant-03\",\"description\":\"Tenant test-tenant-03\"}'"
-    And I run "geonic admin tenants list --format json"
+    And I run `geonic admin tenants create '{"name":"test-tenant-03","description":"Tenant test-tenant-03"}'`
+    And I run `geonic admin tenants list --format json`
     And I save the ID from the JSON output
-    When I run "geonic admin tenants update $ID '{\"description\":\"Updated tenant\"}'" replacing ID
+    When I run `geonic admin tenants update $ID '{"description":"Updated tenant"}'` replacing ID
     Then the exit code should be 0
     And the output should contain "Tenant updated."
 
   Scenario: Delete a tenant
     Given I am logged in
-    And I run "geonic admin tenants create '{\"name\":\"test-tenant-04\",\"description\":\"Tenant test-tenant-04\"}'"
-    And I run "geonic admin tenants list --format json"
+    And I run `geonic admin tenants create '{"name":"test-tenant-04","description":"Tenant test-tenant-04"}'`
+    And I run `geonic admin tenants list --format json`
     And I save the ID from the JSON output
-    When I run "geonic admin tenants delete $ID" replacing ID
+    When I run `geonic admin tenants delete $ID` replacing ID
     Then the exit code should be 0
     And the output should contain "Tenant deleted."
 
   Scenario: Activate and deactivate a tenant
     Given I am logged in
-    And I run "geonic admin tenants create '{\"name\":\"test-tenant-05\",\"description\":\"Tenant test-tenant-05\"}'"
-    And I run "geonic admin tenants list --format json"
+    And I run `geonic admin tenants create '{"name":"test-tenant-05","description":"Tenant test-tenant-05"}'`
+    And I run `geonic admin tenants list --format json`
     And I save the ID from the JSON output
-    When I run "geonic admin tenants deactivate $ID" replacing ID
+    When I run `geonic admin tenants deactivate $ID` replacing ID
     Then the exit code should be 0
     And the output should contain "Tenant deactivated."
-    When I run "geonic admin tenants activate $ID" replacing ID
+    When I run `geonic admin tenants activate $ID` replacing ID
     Then the exit code should be 0
     And the output should contain "Tenant activated."

--- a/tests/e2e/features/types.feature
+++ b/tests/e2e/features/types.feature
@@ -5,14 +5,14 @@ Feature: Entity types
 
   Scenario: List entity types
     Given I am logged in
-    And I run "geonic entities create '{\"id\":\"urn:ngsi-ld:Room:100\",\"type\":\"Room\"}'"
-    When I run "geonic types list"
+    And I run `geonic entities create '{"id":"urn:ngsi-ld:Room:100","type":"Room"}'`
+    When I run `geonic types list`
     Then the exit code should be 0
     And the output should contain "Room"
 
   Scenario: Get entity type details
     Given I am logged in
-    And I run "geonic entities create '{\"id\":\"urn:ngsi-ld:Room:101\",\"type\":\"Room\"}'"
-    When I run "geonic types get Room"
+    And I run `geonic entities create '{"id":"urn:ngsi-ld:Room:101","type":"Room"}'`
+    When I run `geonic types get Room`
     Then the exit code should be 0
     And stdout should be valid JSON

--- a/tests/e2e/features/users.feature
+++ b/tests/e2e/features/users.feature
@@ -6,52 +6,52 @@ Feature: Admin user management
 
   Scenario: List users
     Given I am logged in
-    When I run "geonic admin users list"
+    When I run `geonic admin users list`
     Then the exit code should be 0
     And stdout should be valid JSON
 
   Scenario: Create a user
     Given I am logged in
-    When I run "geonic admin users create '{\"email\":\"testuser01@example.com\",\"password\":\"TestPassword123!\",\"role\":\"super_admin\"}'"
+    When I run `geonic admin users create '{"email":"testuser01@example.com","password":"TestPassword123!","role":"super_admin"}'`
     Then the exit code should be 0
     And the output should contain "User created."
 
   Scenario: Get a user by ID
     Given I am logged in
-    And I run "geonic admin users create '{\"email\":\"testuser02@example.com\",\"password\":\"TestPassword123!\",\"role\":\"super_admin\"}'"
-    And I run "geonic admin users list --format json"
+    And I run `geonic admin users create '{"email":"testuser02@example.com","password":"TestPassword123!","role":"super_admin"}'`
+    And I run `geonic admin users list --format json`
     And I save the ID from the JSON output
-    When I run "geonic admin users get $ID" replacing ID
+    When I run `geonic admin users get $ID` replacing ID
     Then the exit code should be 0
     And stdout should be valid JSON
     And the output should contain "testuser02@example.com"
 
   Scenario: Delete a user
     Given I am logged in
-    And I run "geonic admin users create '{\"email\":\"testuser03@example.com\",\"password\":\"TestPassword123!\",\"role\":\"super_admin\"}'"
-    And I run "geonic admin users list --format json"
+    And I run `geonic admin users create '{"email":"testuser03@example.com","password":"TestPassword123!","role":"super_admin"}'`
+    And I run `geonic admin users list --format json`
     And I save the ID from the JSON output
-    When I run "geonic admin users delete $ID" replacing ID
+    When I run `geonic admin users delete $ID` replacing ID
     Then the exit code should be 0
     And the output should contain "User deleted."
 
   Scenario: Activate and deactivate a user
     Given I am logged in
-    And I run "geonic admin users create '{\"email\":\"testuser04@example.com\",\"password\":\"TestPassword123!\",\"role\":\"super_admin\"}'"
-    And I run "geonic admin users list --format json"
+    And I run `geonic admin users create '{"email":"testuser04@example.com","password":"TestPassword123!","role":"super_admin"}'`
+    And I run `geonic admin users list --format json`
     And I save the ID from the JSON output
-    When I run "geonic admin users deactivate $ID" replacing ID
+    When I run `geonic admin users deactivate $ID` replacing ID
     Then the exit code should be 0
     And the output should contain "User deactivated."
-    When I run "geonic admin users activate $ID" replacing ID
+    When I run `geonic admin users activate $ID` replacing ID
     Then the exit code should be 0
     And the output should contain "User activated."
 
   Scenario: Unlock a user
     Given I am logged in
-    And I run "geonic admin users create '{\"email\":\"testuser05@example.com\",\"password\":\"TestPassword123!\",\"role\":\"super_admin\"}'"
-    And I run "geonic admin users list --format json"
+    And I run `geonic admin users create '{"email":"testuser05@example.com","password":"TestPassword123!","role":"super_admin"}'`
+    And I run `geonic admin users list --format json`
     And I save the ID from the JSON output
-    When I run "geonic admin users unlock $ID" replacing ID
+    When I run `geonic admin users unlock $ID` replacing ID
     Then the exit code should be 0
     And the output should contain "User unlocked."

--- a/tests/e2e/step_definitions/common.steps.ts
+++ b/tests/e2e/step_definitions/common.steps.ts
@@ -20,12 +20,12 @@ Given("no config file exists", function (this: GdbWorld) {
   // configDir is already empty from Before hook
 });
 
-When("I run {string}", async function (this: GdbWorld, command: string) {
+When(/^I run `([^`]+)`$/, async function (this: GdbWorld, command: string) {
   const args = stripCommandPrefix(parseArgs(command));
   await this.run(args);
 });
 
-When("I run {string} with URL", async function (this: GdbWorld, command: string) {
+When(/^I run `([^`]+)` with URL$/, async function (this: GdbWorld, command: string) {
   const args = stripCommandPrefix(parseArgs(command));
   args.push("--url", this.serverUrl);
   await this.run(args);
@@ -36,7 +36,7 @@ When(/^I run `([^`]+)` with stdin:$/, async function (this: GdbWorld, command: s
   await this.run(args, undefined, docString);
 });
 
-When("I run {string} with env {string}", async function (this: GdbWorld, command: string, envPair: string) {
+When(/^I run `([^`]+)` with env "([^"]+)"$/, async function (this: GdbWorld, command: string, envPair: string) {
   const args = stripCommandPrefix(parseArgs(command));
   const eqIdx = envPair.indexOf("=");
   const key = envPair.substring(0, eqIdx);
@@ -44,7 +44,7 @@ When("I run {string} with env {string}", async function (this: GdbWorld, command
   await this.run(args, { [key]: value });
 });
 
-When("I run {string} replacing ID", async function (this: GdbWorld, command: string) {
+When(/^I run `([^`]+)` replacing ID$/, async function (this: GdbWorld, command: string) {
   const savedId = (this as Record<string, unknown>).savedId as string;
   assert.ok(savedId, "No saved ID available. Run 'I save the ID from the JSON output' first.");
   const resolved = command.replace(/\$ID/g, savedId);


### PR DESCRIPTION
## Summary

- Replace `I run "..."` with `` I run `...` `` across all 21 feature files
- Update step definitions in `common.steps.ts` to use regex matching for backtick-delimited commands
- Eliminates all `\"` JSON escape sequences, making feature files readable as CLI usage references

**Before:**
```gherkin
When I run "geonic entities create '{\"id\":\"urn:ngsi-ld:Room:001\",\"type\":\"Room\"}'"
```

**After:**
```gherkin
When I run `geonic entities create '{"id":"urn:ngsi-ld:Room:001","type":"Room"}'`
```

22 files changed, 247 lines replaced (1:1 substitution, no logic changes).

## Test plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes (184 tests)
- [ ] E2E tests pass against running GeonicDB server

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリース ノート

* **Tests**
  * エンドツーエンドテストのコマンド呼び出し表記を統一しました。テスト手順全体で、クォート形式をバックティック構文に変更し、JSON ペイロードの形式を標準化しました。テストの実行動作に変更はなく、テスト定義の読みやすさが向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->