### PR TITLE
Use npm Trusted Publisher (OIDC) instead of NPM_TOKEN

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,5 +56,3 @@ jobs:
             exit 1
           fi
       - run: npm publish --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Remove `NODE_AUTH_TOKEN` secret from publish workflow
- npm package is already configured with a Trusted Publisher via OpenID Connect (OIDC)
- Existing workflow settings (`id-token: write`, `registry-url`, `--provenance`) are sufficient for OIDC auth

## After merge
```bash
git tag -d v0.2.0 && git push origin :refs/tags/v0.2.0
git tag v0.2.0 && git push origin v0.2.0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 公開ワークフロー設定の調整を実施しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->