### PR TITLE
Use Node 22 for npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,9 +41,8 @@ jobs:
           fi
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
-          registry-url: "https://registry.npmjs.org"
       - name: Remove local-only dependencies
         run: node -e "const p=require('./package.json'); delete p.devDependencies.geonicdb; delete p.devDependencies.mongodb; require('fs').writeFileSync('package.json', JSON.stringify(p, null, 2)+'\n')"
       - run: npm install


### PR DESCRIPTION
## Summary
- Update publish job to Node 22 (npm CLI >= 11.5.1 required for OIDC trusted publishing)
- Remove registry-url from actions/setup-node to prevent .npmrc token reference interfering with OIDC auth
- Remove NODE_AUTH_TOKEN secret (already merged in #39)

## Context
npm Trusted Publishing via OIDC requires npm CLI v11.5.1+, which is bundled with Node 22. The previous Node 20 setup (npm 10.8.2) did not support OIDC authentication.

## After merge
git tag -d v0.2.0 && git push origin :refs/tags/v0.2.0
git tag v0.2.0 && git push origin v0.2.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * ビルドおよび公開ワークフローを更新しました。Node.js バージョンを新しいバージョンにアップグレードし、認証設定を簡素化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->