### PR TITLE
Install npm@latest for OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,8 @@ jobs:
         with:
           node-version: 22
           cache: npm
+          registry-url: "https://registry.npmjs.org"
+      - run: npm install -g npm@latest
       - name: Remove local-only dependencies
         run: node -e "const p=require('./package.json'); delete p.devDependencies.geonicdb; delete p.devDependencies.mongodb; require('fs').writeFileSync('package.json', JSON.stringify(p, null, 2)+'\n')"
       - run: npm install


### PR DESCRIPTION
## Summary
- Add npm install -g npm@latest step (npm 11.5.1+ required for OIDC)
- Restore registry-url for npm registry target configuration

## Context
Node 22 bundles npm 10.x which does not support OIDC trusted publishing. npm 11.5.1+ is required. The registry-url is also needed for npm to target the correct registry.

ref: https://github.com/npm/cli/issues/8730

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * npm パッケージの発行ワークフローを更新し、NPM レジストリ設定を明示的に指定し、発行プロセス中に最新の npm バージョンを使用するようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->