### PR TITLE
fix(cli): format GeoProperty as readable coordinates in table display

### DIFF
--- a/src/output.ts
+++ b/src/output.ts
@@ -105,7 +105,9 @@ function formatGeoJSON(geo: Record<string, unknown>): string {
     return `Point(${Number(coords[0]).toFixed(2)}, ${Number(coords[1]).toFixed(2)})`;
   }
   if (Array.isArray(coords)) {
-    const count = geoType === "Polygon" ? (coords[0] as unknown[]).length : coords.length;
+    const count = geoType === "Polygon"
+      ? (Array.isArray(coords[0]) ? (coords[0] as unknown[]).length : 0)
+      : coords.length;
     return `${geoType}(${count} coords)`;
   }
   return `${geoType}(...)`;

--- a/tests/output.test.ts
+++ b/tests/output.test.ts
@@ -185,6 +185,41 @@ describe("output", () => {
       expect(result).toContain("Polygon(4 coords)");
     });
 
+    it("formats MultiPoint with coordinate count", () => {
+      const data = [
+        {
+          id: "e1",
+          stops: {
+            type: "GeoProperty",
+            value: {
+              type: "MultiPoint",
+              coordinates: [
+                [139.7, 35.6],
+                [139.8, 35.7],
+                [139.9, 35.8],
+              ],
+            },
+          },
+        },
+      ];
+      const result = stripAnsi(formatOutput(data, "table"));
+      expect(result).toContain("MultiPoint(3 coords)");
+    });
+
+    it("handles Polygon with empty coordinates", () => {
+      const data = [
+        {
+          id: "e1",
+          area: {
+            type: "GeoProperty",
+            value: { type: "Polygon", coordinates: [] },
+          },
+        },
+      ];
+      const result = stripAnsi(formatOutput(data, "table"));
+      expect(result).toContain("Polygon(0 coords)");
+    });
+
     it("returns empty string for null/undefined values", () => {
       const data = [{ id: "e1", n: null, u: undefined }];
       const result = stripAnsi(formatOutput(data, "table"));


### PR DESCRIPTION
## Summary

Closes #657

- `cellValue` in table formatter now detects GeoJSON geometry objects and formats them as human-readable strings
- Point: `Point(139.70, 35.60)`
- LineString/MultiPoint: `LineString(N coords)`
- Polygon: `Polygon(N coords)`
- Handles NGSIv2, NGSI-LD normalized, and keyValues formats

## Test plan

- [x] Unit tests: 5 new tests covering all GeoJSON patterns
- [x] All 543 tests pass
- [x] Lint and typecheck clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * テーブル表示でGeoJSONやNGSI形式の地理情報を簡潔で読みやすい表記（例: Point(139.70, 35.60)、LineString(3点)など）に整形して表示するよう改善しました。

* **テスト**
  * Point/LineString/Polygon/MultiPointや空の座標を含むケースを含む、地理情報の表示フォーマットに関する包括的なテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->