### PR TITLE
feat(cli): add --count-only option for entities list

### DIFF
--- a/src/commands/entities.ts
+++ b/src/commands/entities.ts
@@ -6,7 +6,7 @@ import {
   outputResponse,
 } from "../helpers.js";
 import { parseJsonInput } from "../input.js";
-import { printSuccess } from "../output.js";
+import { printCount, printSuccess } from "../output.js";
 import { registerAttrsSubcommand } from "./attrs.js";
 import { addExamples } from "./help.js";
 
@@ -31,6 +31,7 @@ export function registerEntitiesCommand(program: Command): void {
     .option("--offset <n>", "Skip first N entities", parseInt)
     .option("--order-by <field>", "Order results by field")
     .option("--count", "Include total count in response")
+    .option("--count-only", "Only show the total count without listing entities")
     .option("--key-values", "Request simplified key-value format")
     .action(
       withErrorHandler(async (opts: Record<string, unknown>, cmd: Command) => {
@@ -50,11 +51,16 @@ export function registerEntitiesCommand(program: Command): void {
         if (opts.limit !== undefined) params.limit = String(opts.limit);
         if (opts.offset !== undefined) params.offset = String(opts.offset);
         if (opts.orderBy) params.orderBy = String(opts.orderBy);
-        if (opts.count) params.count = "true";
+        if (opts.count || opts.countOnly) params.count = "true";
+        if (opts.countOnly) params.limit = "0";
         if (opts.keyValues) params.options = "keyValues";
 
         const response = await client.get("/entities", params);
-        outputResponse(response, format, !!opts.count);
+        if (opts.countOnly) {
+          printCount(response.count ?? 0);
+        } else {
+          outputResponse(response, format, !!opts.count);
+        }
       }),
     );
 
@@ -116,6 +122,10 @@ export function registerEntitiesCommand(program: Command): void {
     {
       description: "Get total count with results",
       command: "geonic entities list --type Sensor --count",
+    },
+    {
+      description: "Get only the total count (no entity data)",
+      command: "geonic entities list --type Sensor --count-only",
     },
   ]);
 

--- a/tests/entities.test.ts
+++ b/tests/entities.test.ts
@@ -32,7 +32,7 @@ vi.mock("../src/commands/attrs.js", () => ({
 
 import { createClient, getFormat, outputResponse } from "../src/helpers.js";
 import { parseJsonInput } from "../src/input.js";
-import { printSuccess } from "../src/output.js";
+import { printCount, printSuccess } from "../src/output.js";
 import { registerEntitiesCommand } from "../src/commands/entities.js";
 
 describe("entities command", () => {
@@ -131,6 +131,26 @@ describe("entities command", () => {
 
       expect(mockClient.get).toHaveBeenCalledWith("/entities", expect.objectContaining({ count: "true" }));
       expect(outputResponse).toHaveBeenCalledWith(expect.anything(), "json", true);
+    });
+
+    it("passes count-only option with limit=0 and only shows count", async () => {
+      mockClient.get.mockResolvedValue(mockResponse([], 200, 42));
+      await runCommand(program, ["entities", "list", "--count-only"]);
+
+      expect(mockClient.get).toHaveBeenCalledWith("/entities", expect.objectContaining({
+        count: "true",
+        limit: "0",
+      }));
+      expect(printCount).toHaveBeenCalledWith(42);
+      expect(outputResponse).not.toHaveBeenCalled();
+    });
+
+    it("count-only defaults to 0 when response has no count", async () => {
+      mockClient.get.mockResolvedValue(mockResponse([]));
+      await runCommand(program, ["entities", "list", "--count-only"]);
+
+      expect(printCount).toHaveBeenCalledWith(0);
+      expect(outputResponse).not.toHaveBeenCalled();
     });
 
     it("passes keyValues option as options=keyValues", async () => {


### PR DESCRIPTION
## Summary

Closes geolonia/geonicdb#661 (CLI-side)

- Added `--count-only` option to `geonic entities list`
- When used, sends `count=true&limit=0` and displays only the count
- Example: `geonic entities list --type Earthquake --count-only`
- Requires server-side PR: geolonia/geonicdb (allows `limit=0` with count)

## Test plan

- [x] Unit tests: 540 pass (2 new tests for --count-only)
- [x] Lint and typecheck clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * `entities list` コマンドに `--count-only` オプションを追加。エンティティのリストを表示せず、総数のみを返すように設定できます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->