### PR TITLE
docs: admin users create のヘルプをAPI仕様に合わせて改善

### DIFF
--- a/src/commands/admin/users.ts
+++ b/src/commands/admin/users.ts
@@ -61,8 +61,11 @@ export function registerUsersCommand(parent: Command): void {
         "  {\n" +
         '    "email": "user@example.com",\n' +
         '    "password": "SecurePassword123!",\n' +
-        '    "role": "super_admin"\n' +
-        "  }",
+        '    "role": "tenant_admin",\n' +
+        '    "tenantId": "<tenant-id>"\n' +
+        "  }\n\n" +
+        "Roles: super_admin, tenant_admin, user\n" +
+        "tenantId is required for tenant_admin and user roles.",
     )
     .action(
       withErrorHandler(async (json: unknown, _opts: unknown, cmd: Command) => {
@@ -79,8 +82,12 @@ export function registerUsersCommand(parent: Command): void {
 
   addExamples(create, [
     {
-      description: "Create with inline JSON",
-      command: `geonic admin users create '{"email":"user@example.com","password":"SecurePassword123!","role":"super_admin"}'`,
+      description: "Create a tenant admin",
+      command: `geonic admin users create '{"email":"admin@example.com","password":"SecurePass12345!","role":"tenant_admin","tenantId":"<tenant-id>"}'`,
+    },
+    {
+      description: "Create a user for a tenant",
+      command: `geonic admin users create '{"email":"user@example.com","password":"SecurePass12345!","role":"user","tenantId":"<tenant-id>"}'`,
     },
     {
       description: "Create from a JSON file",


### PR DESCRIPTION
## Summary
- `geonic admin users create` のヘルプ表示をGeonicDBサーバーの実装に合わせて修正
- JSON payload example に `tenantId` フィールドを追加し、有効なロール一覧を記載
- Examples から `super_admin` の例を削除し、`tenant_admin`（テナント管理者）と `user`（一般ユーザー）の例を追加

## Test plan
- [x] `npm run lint` パス
- [x] `npm run typecheck` パス
- [x] `npm test` 全624テストパス
- [x] `geonic admin users create --help` で新しいヘルプ表示を確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## ドキュメント

* ユーザー作成コマンドのドキュメントを更新しました。テナント管理者またはテナントユーザーロールの作成時に、テナントIDの入力が必須となりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->