### PR TITLE
feat: add --sys-attrs flag to entities list/get commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## [Unreleased]
 
+### 2026-04-06
+- **Feat**: エンティティ取得コマンド (`entities list`, `entities get`) に `--sys-attrs` フラグを追加 — `options=sysAttrs` を付与し `createdAt` / `modifiedAt` を取得可能に (#104)
+
 ## [0.10.1] - 2026-04-06
 
 ### 2026-04-06

--- a/src/commands/entities.ts
+++ b/src/commands/entities.ts
@@ -33,6 +33,7 @@ export function registerEntitiesCommand(program: Command): void {
     .option("--count", "Include total count in response")
     .option("--count-only", "Only show the total count without listing entities")
     .option("--key-values", "Request simplified key-value format")
+    .option("--sys-attrs", "Include system attributes (createdAt, modifiedAt)")
     .action(
       withErrorHandler(async (opts: Record<string, unknown>, cmd: Command) => {
         const client = createClient(cmd);
@@ -53,7 +54,11 @@ export function registerEntitiesCommand(program: Command): void {
         if (opts.orderBy) params.orderBy = String(opts.orderBy);
         if (opts.count || opts.countOnly) params.count = "true";
         if (opts.countOnly) params.limit = "0";
-        if (opts.keyValues) params.options = "keyValues";
+
+        const optionsList: string[] = [];
+        if (opts.keyValues) optionsList.push("keyValues");
+        if (opts.sysAttrs) optionsList.push("sysAttrs");
+        if (optionsList.length > 0) params.options = optionsList.join(",");
 
         const response = await client.get("/entities", params);
         if (opts.countOnly) {
@@ -127,6 +132,10 @@ export function registerEntitiesCommand(program: Command): void {
       description: "Get only the total count (no entity data)",
       command: "geonic entities list --type Sensor --count-only",
     },
+    {
+      description: "Include system attributes (createdAt, modifiedAt)",
+      command: "geonic entities list --type Sensor --sys-attrs",
+    },
   ]);
 
   // entities get
@@ -135,15 +144,17 @@ export function registerEntitiesCommand(program: Command): void {
     .description("Get a single entity by ID")
     .argument("<id>", "Entity ID")
     .option("--key-values", "Request simplified key-value format")
+    .option("--sys-attrs", "Include system attributes (createdAt, modifiedAt)")
     .action(
       withErrorHandler(async (id: string, opts: Record<string, unknown>, cmd: Command) => {
         const client = createClient(cmd);
         const format = getFormat(cmd);
 
         const params: Record<string, string> = {};
-        if (opts.keyValues) {
-          params.options = "keyValues";
-        }
+        const optionsList: string[] = [];
+        if (opts.keyValues) optionsList.push("keyValues");
+        if (opts.sysAttrs) optionsList.push("sysAttrs");
+        if (optionsList.length > 0) params.options = optionsList.join(",");
 
         const response = await client.get(
           `/entities/${encodeURIComponent(id)}`,
@@ -161,6 +172,10 @@ export function registerEntitiesCommand(program: Command): void {
     {
       description: "Get entity in keyValues format",
       command: "geonic entities get urn:ngsi-ld:Sensor:001 --key-values",
+    },
+    {
+      description: "Get entity with system attributes",
+      command: "geonic entities get urn:ngsi-ld:Sensor:001 --sys-attrs",
     },
   ]);
 

--- a/tests/entities.test.ts
+++ b/tests/entities.test.ts
@@ -160,6 +160,20 @@ describe("entities command", () => {
 
       expect(mockClient.get).toHaveBeenCalledWith("/entities", expect.objectContaining({ options: "keyValues" }));
     });
+
+    it("passes sysAttrs option as options=sysAttrs", async () => {
+      mockClient.get.mockResolvedValue(mockResponse([]));
+      await runCommand(program, ["entities", "list", "--sys-attrs"]);
+
+      expect(mockClient.get).toHaveBeenCalledWith("/entities", expect.objectContaining({ options: "sysAttrs" }));
+    });
+
+    it("combines keyValues and sysAttrs options", async () => {
+      mockClient.get.mockResolvedValue(mockResponse([]));
+      await runCommand(program, ["entities", "list", "--key-values", "--sys-attrs"]);
+
+      expect(mockClient.get).toHaveBeenCalledWith("/entities", expect.objectContaining({ options: "keyValues,sysAttrs" }));
+    });
   });
 
   describe("get", () => {
@@ -181,6 +195,26 @@ describe("entities command", () => {
       expect(mockClient.get).toHaveBeenCalledWith(
         `/entities/${encodeURIComponent("e1")}`,
         { options: "keyValues" },
+      );
+    });
+
+    it("passes sysAttrs option", async () => {
+      mockClient.get.mockResolvedValue(mockResponse({ id: "e1" }));
+      await runCommand(program, ["entities", "get", "e1", "--sys-attrs"]);
+
+      expect(mockClient.get).toHaveBeenCalledWith(
+        `/entities/${encodeURIComponent("e1")}`,
+        { options: "sysAttrs" },
+      );
+    });
+
+    it("combines keyValues and sysAttrs options", async () => {
+      mockClient.get.mockResolvedValue(mockResponse({ id: "e1" }));
+      await runCommand(program, ["entities", "get", "e1", "--key-values", "--sys-attrs"]);
+
+      expect(mockClient.get).toHaveBeenCalledWith(
+        `/entities/${encodeURIComponent("e1")}`,
+        { options: "keyValues,sysAttrs" },
       );
     });
   });


### PR DESCRIPTION
## Summary
- エンティティ取得コマンド (`entities list`, `entities get`) に `--sys-attrs` フラグを追加
- API リクエストの `options` パラメータに `sysAttrs` を付与し、`createdAt` / `modifiedAt` を取得可能に
- `--key-values` との併用時は `options=keyValues,sysAttrs` とカンマ結合

Closes #104

## Test plan
- [x] `entities list --sys-attrs` で `options=sysAttrs` が送信される
- [x] `entities get --sys-attrs` で `options=sysAttrs` が送信される
- [x] `--key-values --sys-attrs` 併用時に `options=keyValues,sysAttrs` が送信される
- [x] 既存テスト全件通過（699 tests passed）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * `entities list` および `entities get` コマンドに `--sys-attrs` フラグを追加しました。このフラグを使用することで、`createdAt` および `modifiedAt` の取得が可能になります。`--key-values` と組み合わせて使用することもできます。

* **Documentation**
  * 新しい `--sys-attrs` フラグの使用方法をドキュメントに追加しました。

* **Tests**
  * `--sys-attrs` フラグの動作を検証するテストケースを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->