### PR TITLE
fix: display correct number of asterisks for password input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 
 ## [Unreleased]
 
+## [0.12.1] - 2026-04-14
+
+### 2026-04-14
+- **Fix**: パスワード入力時、ペーストなどで複数文字が一度に入力された場合に `*` が1個しか表示されない問題を修正 (#108)
+
 ## [0.12.0] - 2026-04-14
 
 ### 2026-04-14
@@ -196,7 +201,8 @@
 ### 2026-02-26
 - **Docs**: README にインストール手順・使い方・コマンドリファレンスを追加 (#1)
 
-[Unreleased]: https://github.com/geolonia/geonicdb-cli/compare/v0.12.0...HEAD
+[Unreleased]: https://github.com/geolonia/geonicdb-cli/compare/v0.12.1...HEAD
+[0.12.1]: https://github.com/geolonia/geonicdb-cli/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/geolonia/geonicdb-cli/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/geolonia/geonicdb-cli/compare/v0.10.1...v0.11.0
 [0.10.1]: https://github.com/geolonia/geonicdb-cli/compare/v0.10.0...v0.10.1

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -72,18 +72,15 @@ export async function promptPassword(label = "Password"): Promise<string> {
     terminal: true,
   });
 
-  let len = 0;
-  const onKeypress = (str: string | undefined, key: { name?: string; ctrl?: boolean }) => {
-    if (key?.name === "return" || key?.name === "enter") return;
-    if (key?.name === "backspace") {
-      if (len > 0) {
-        len--;
-        stdout.write("\b \b");
-      }
-    } else if (str && str.codePointAt(0)! >= 32 && !key?.ctrl) {
-      len += [...str].length;
-      stdout.write("*".repeat([...str].length));
+  let maskedLen = 0;
+  const onKeypress = () => {
+    const nextLen = [...rl.line].length;
+    if (nextLen > maskedLen) {
+      stdout.write("*".repeat(nextLen - maskedLen));
+    } else if (nextLen < maskedLen) {
+      stdout.write("\b \b".repeat(maskedLen - nextLen));
     }
+    maskedLen = nextLen;
   };
   stdin.on("keypress", onKeypress);
 

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -70,6 +70,7 @@ export async function promptPassword(label = "Password"): Promise<string> {
     input: stdin,
     output: muted,
     terminal: true,
+    historySize: 0,
   });
 
   let maskedLen = 0;

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -1,4 +1,5 @@
 import { createInterface } from "node:readline/promises";
+import { Writable } from "node:stream";
 
 export function isInteractive(): boolean {
   return process.stdin.isTTY === true && process.stdout.isTTY === true;
@@ -15,13 +16,13 @@ export async function promptEmail(): Promise<string> {
 }
 
 export async function promptPassword(label = "Password"): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const stdin = process.stdin;
-    const stdout = process.stdout;
+  const stdin = process.stdin;
+  const stdout = process.stdout;
 
-    stdout.write(`${label}: `);
+  stdout.write(`${label}: `);
 
-    if (!stdin.isTTY) {
+  if (!stdin.isTTY) {
+    return new Promise((resolve, reject) => {
       let data = "";
       stdin.setEncoding("utf-8");
       stdin.resume();
@@ -54,58 +55,46 @@ export async function promptPassword(label = "Password"): Promise<string> {
       stdin.on("data", onData);
       stdin.on("end", onEnd);
       stdin.on("error", onError);
-      return;
-    }
+    });
+  }
 
-    const wasRaw = stdin.isRaw;
-    stdin.setRawMode(true);
-    stdin.resume();
-    stdin.setEncoding("utf-8");
-
-    let password = "";
-
-    const restoreTerminal = () => {
-      stdin.removeListener("data", onData);
-      stdin.removeListener("error", onError);
-      stdin.setRawMode(wasRaw ?? false);
-      stdin.pause();
-    };
-
-    const onError = (err: Error) => {
-      restoreTerminal();
-      stdout.write("\n");
-      reject(err);
-    };
-
-    const onData = (data: string) => {
-      for (const char of data) {
-        const code = char.codePointAt(0)!;
-
-        if (char === "\r" || char === "\n") {
-          restoreTerminal();
-          stdout.write("\n");
-          resolve(password);
-          return;
-        } else if (code === 3) {
-          restoreTerminal();
-          stdout.write("\n");
-          reject(new Error("User cancelled"));
-          return;
-        } else if (code === 127 || code === 8) {
-          if (password.length > 0) {
-            password = password.slice(0, -1);
-            stdout.write("\b \b");
-          }
-        } else if (code >= 32) {
-          password += char;
-          stdout.write("*");
-        }
-      }
-    };
-
-    stdin.on("data", onData);
-    stdin.on("error", onError);
+  // Use readline with muted output to avoid conflicts with emitKeypressEvents
+  // that prior createInterface calls install on stdin.
+  const muted = new Writable({
+    write(_chunk: Buffer, _encoding: string, callback: () => void) {
+      callback();
+    },
   });
+
+  const rl = createInterface({
+    input: stdin,
+    output: muted,
+    terminal: true,
+  });
+
+  let len = 0;
+  const onKeypress = (str: string | undefined, key: { name?: string; ctrl?: boolean }) => {
+    if (key?.name === "return" || key?.name === "enter") return;
+    if (key?.name === "backspace") {
+      if (len > 0) {
+        len--;
+        stdout.write("\b \b");
+      }
+    } else if (str && str.codePointAt(0)! >= 32 && !key?.ctrl) {
+      len += [...str].length;
+      stdout.write("*".repeat([...str].length));
+    }
+  };
+  stdin.on("keypress", onKeypress);
+
+  try {
+    const answer = await rl.question("");
+    stdout.write("\n");
+    return answer;
+  } finally {
+    stdin.removeListener("keypress", onKeypress);
+    rl.close();
+  }
 }
 
 export interface TenantChoice {

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -77,25 +77,29 @@ export async function promptPassword(label = "Password"): Promise<string> {
       reject(err);
     };
 
-    const onData = (char: string) => {
-      const code = char.charCodeAt(0);
+    const onData = (data: string) => {
+      for (const char of data) {
+        const code = char.codePointAt(0)!;
 
-      if (char === "\r" || char === "\n") {
-        restoreTerminal();
-        stdout.write("\n");
-        resolve(password);
-      } else if (code === 3) {
-        restoreTerminal();
-        stdout.write("\n");
-        reject(new Error("User cancelled"));
-      } else if (code === 127 || code === 8) {
-        if (password.length > 0) {
-          password = password.slice(0, -1);
-          stdout.write("\b \b");
+        if (char === "\r" || char === "\n") {
+          restoreTerminal();
+          stdout.write("\n");
+          resolve(password);
+          return;
+        } else if (code === 3) {
+          restoreTerminal();
+          stdout.write("\n");
+          reject(new Error("User cancelled"));
+          return;
+        } else if (code === 127 || code === 8) {
+          if (password.length > 0) {
+            password = password.slice(0, -1);
+            stdout.write("\b \b");
+          }
+        } else if (code >= 32) {
+          password += char;
+          stdout.write("*");
         }
-      } else if (code >= 32) {
-        password += char;
-        stdout.write("*");
       }
     };
 

--- a/tests/prompt.test.ts
+++ b/tests/prompt.test.ts
@@ -83,12 +83,6 @@ describe("prompt", () => {
     describe("TTY mode", () => {
       beforeEach(() => {
         Object.defineProperty(process.stdin, "isTTY", { value: true, writable: true });
-        // Mock setRawMode, resume, pause, setEncoding, on, removeListener
-        (process.stdin as never as Record<string, unknown>).setRawMode = vi.fn();
-        (process.stdin as never as Record<string, unknown>).isRaw = false;
-        vi.spyOn(process.stdin, "resume").mockImplementation(() => process.stdin);
-        vi.spyOn(process.stdin, "pause").mockImplementation(() => process.stdin);
-        vi.spyOn(process.stdin, "setEncoding").mockImplementation(() => process.stdin);
         vi.spyOn(process.stdin, "on").mockImplementation((event: string, cb: (...args: unknown[]) => void) => {
           (stdinListeners[event] ??= []).push(cb);
           return process.stdin;
@@ -103,91 +97,98 @@ describe("prompt", () => {
         });
       });
 
-      it("collects password chars and resolves on Enter", async () => {
-        const promise = promptPassword();
+      it("resolves with answer from readline and displays prompt", async () => {
+        mockQuestion.mockResolvedValue("abc");
+        const result = await promptPassword();
+        expect(result).toBe("abc");
+        expect(stdoutWriteSpy).toHaveBeenCalledWith("Password: ");
+        expect(stdoutWriteSpy).toHaveBeenCalledWith("\n");
+        expect(mockClose).toHaveBeenCalled();
+      });
 
-        // Type "abc" then Enter
+      it("displays * for each keypress character", async () => {
+        let resolveQ!: (v: string) => void;
+        mockQuestion.mockReturnValue(new Promise<string>((r) => { resolveQ = r; }));
+
+        const promise = promptPassword();
         for (const ch of ["a", "b", "c"]) {
-          stdinListeners["data"]?.forEach((cb) => cb(ch));
+          stdinListeners["keypress"]?.forEach((cb) => cb(ch, { name: ch }));
         }
-        stdinListeners["data"]?.forEach((cb) => cb("\r"));
+        resolveQ("abc");
 
         const result = await promise;
         expect(result).toBe("abc");
-        // Should have written Password: prompt and 3 * chars
-        expect(stdoutWriteSpy).toHaveBeenCalledWith("Password: ");
-        expect(stdoutWriteSpy).toHaveBeenCalledWith("*");
+        const starCalls = stdoutWriteSpy.mock.calls.filter(([arg]) => arg === "*");
+        expect(starCalls).toHaveLength(3);
       });
 
-      it("handles newline (\\n) as Enter", async () => {
-        const promise = promptPassword();
-        stdinListeners["data"]?.forEach((cb) => cb("x"));
-        stdinListeners["data"]?.forEach((cb) => cb("\n"));
-        const result = await promise;
-        expect(result).toBe("x");
-      });
+      it("handles backspace keypress by erasing a *", async () => {
+        let resolveQ!: (v: string) => void;
+        mockQuestion.mockReturnValue(new Promise<string>((r) => { resolveQ = r; }));
 
-      it("handles Ctrl+C (code 3) by rejecting", async () => {
         const promise = promptPassword();
-        stdinListeners["data"]?.forEach((cb) => cb(String.fromCharCode(3)));
-        await expect(promise).rejects.toThrow("User cancelled");
-      });
+        stdinListeners["keypress"]?.forEach((cb) => cb("a", { name: "a" }));
+        stdinListeners["keypress"]?.forEach((cb) => cb("b", { name: "b" }));
+        stdinListeners["keypress"]?.forEach((cb) => cb(undefined, { name: "backspace" }));
+        resolveQ("a");
 
-      it("handles backspace (code 127)", async () => {
-        const promise = promptPassword();
-        stdinListeners["data"]?.forEach((cb) => cb("a"));
-        stdinListeners["data"]?.forEach((cb) => cb("b"));
-        // Backspace
-        stdinListeners["data"]?.forEach((cb) => cb(String.fromCharCode(127)));
-        stdinListeners["data"]?.forEach((cb) => cb("\r"));
         const result = await promise;
         expect(result).toBe("a");
         expect(stdoutWriteSpy).toHaveBeenCalledWith("\b \b");
       });
 
-      it("handles backspace (code 8)", async () => {
-        const promise = promptPassword();
-        stdinListeners["data"]?.forEach((cb) => cb("x"));
-        stdinListeners["data"]?.forEach((cb) => cb(String.fromCharCode(8)));
-        stdinListeners["data"]?.forEach((cb) => cb("\r"));
-        const result = await promise;
-        expect(result).toBe("");
-      });
-
       it("ignores backspace on empty password", async () => {
+        let resolveQ!: (v: string) => void;
+        mockQuestion.mockReturnValue(new Promise<string>((r) => { resolveQ = r; }));
+
         const promise = promptPassword();
-        stdinListeners["data"]?.forEach((cb) => cb(String.fromCharCode(127)));
-        stdinListeners["data"]?.forEach((cb) => cb("\r"));
+        stdinListeners["keypress"]?.forEach((cb) => cb(undefined, { name: "backspace" }));
+        resolveQ("");
+
         const result = await promise;
         expect(result).toBe("");
+        expect(stdoutWriteSpy).not.toHaveBeenCalledWith("\b \b");
       });
 
-      it("ignores control chars below code 32", async () => {
+      it("ignores Enter keypress for display", async () => {
+        let resolveQ!: (v: string) => void;
+        mockQuestion.mockReturnValue(new Promise<string>((r) => { resolveQ = r; }));
+
         const promise = promptPassword();
-        // Send a control char that isn't enter, ctrl+c, or backspace
-        stdinListeners["data"]?.forEach((cb) => cb(String.fromCharCode(1))); // Ctrl+A
-        stdinListeners["data"]?.forEach((cb) => cb("z"));
-        stdinListeners["data"]?.forEach((cb) => cb("\r"));
+        stdinListeners["keypress"]?.forEach((cb) => cb("x", { name: "x" }));
+        stdinListeners["keypress"]?.forEach((cb) => cb(undefined, { name: "return" }));
+        resolveQ("x");
+
+        await promise;
+        const starCalls = stdoutWriteSpy.mock.calls.filter(([arg]) => arg === "*");
+        expect(starCalls).toHaveLength(1);
+      });
+
+      it("ignores ctrl key combos for display", async () => {
+        let resolveQ!: (v: string) => void;
+        mockQuestion.mockReturnValue(new Promise<string>((r) => { resolveQ = r; }));
+
+        const promise = promptPassword();
+        stdinListeners["keypress"]?.forEach((cb) => cb("\x01", { name: "a", ctrl: true }));
+        stdinListeners["keypress"]?.forEach((cb) => cb("z", { name: "z" }));
+        resolveQ("z");
+
         const result = await promise;
         expect(result).toBe("z");
+        const starCalls = stdoutWriteSpy.mock.calls.filter(([arg]) => arg === "*");
+        expect(starCalls).toHaveLength(1);
       });
 
-      it("handles error event", async () => {
-        const promise = promptPassword();
-        const error = new Error("stdin error");
-        stdinListeners["error"]?.forEach((cb) => cb(error));
-        await expect(promise).rejects.toThrow("stdin error");
+      it("uses custom label", async () => {
+        mockQuestion.mockResolvedValue("secret");
+        await promptPassword("New password");
+        expect(stdoutWriteSpy).toHaveBeenCalledWith("New password: ");
       });
 
-      it("handles isRaw being undefined (wasRaw ?? false branch)", async () => {
-        (process.stdin as never as Record<string, unknown>).isRaw = undefined;
-        const promise = promptPassword();
-        stdinListeners["data"]?.forEach((cb) => cb("p"));
-        stdinListeners["data"]?.forEach((cb) => cb("\r"));
-        const result = await promise;
-        expect(result).toBe("p");
-        // setRawMode should be called with false (from ?? false)
-        expect((process.stdin as never as Record<string, unknown>).setRawMode).toHaveBeenCalledWith(false);
+      it("cleans up keypress listener after resolve", async () => {
+        mockQuestion.mockResolvedValue("test");
+        await promptPassword();
+        expect(stdinListeners["keypress"]?.length ?? 0).toBe(0);
       });
     });
 

--- a/tests/prompt.test.ts
+++ b/tests/prompt.test.ts
@@ -2,10 +2,12 @@ import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 
 const mockQuestion = vi.fn();
 const mockClose = vi.fn();
+let mockLine = "";
 vi.mock("node:readline/promises", () => ({
   createInterface: vi.fn(() => ({
     question: mockQuestion,
     close: mockClose,
+    get line() { return mockLine; },
   })),
 }));
 
@@ -21,6 +23,7 @@ describe("prompt", () => {
     vi.restoreAllMocks();
     mockQuestion.mockReset();
     mockClose.mockReset();
+    mockLine = "";
   });
 
   describe("isInteractive", () => {
@@ -97,6 +100,10 @@ describe("prompt", () => {
         });
       });
 
+      const fireKeypress = () => {
+        stdinListeners["keypress"]?.forEach((cb) => cb());
+      };
+
       it("resolves with answer from readline and displays prompt", async () => {
         mockQuestion.mockResolvedValue("abc");
         const result = await promptPassword();
@@ -111,25 +118,39 @@ describe("prompt", () => {
         mockQuestion.mockReturnValue(new Promise<string>((r) => { resolveQ = r; }));
 
         const promise = promptPassword();
-        for (const ch of ["a", "b", "c"]) {
-          stdinListeners["keypress"]?.forEach((cb) => cb(ch, { name: ch }));
-        }
+        mockLine = "a"; fireKeypress();
+        mockLine = "ab"; fireKeypress();
+        mockLine = "abc"; fireKeypress();
         resolveQ("abc");
 
         const result = await promise;
         expect(result).toBe("abc");
-        const starCalls = stdoutWriteSpy.mock.calls.filter(([arg]) => arg === "*");
-        expect(starCalls).toHaveLength(3);
+        expect(stdoutWriteSpy).toHaveBeenCalledWith("*");
+        const starCalls = stdoutWriteSpy.mock.calls.filter(([arg]) => /^\*+$/.test(arg as string));
+        expect(starCalls.reduce((sum, [arg]) => sum + (arg as string).length, 0)).toBe(3);
       });
 
-      it("handles backspace keypress by erasing a *", async () => {
+      it("handles backspace by erasing a *", async () => {
         let resolveQ!: (v: string) => void;
         mockQuestion.mockReturnValue(new Promise<string>((r) => { resolveQ = r; }));
 
         const promise = promptPassword();
-        stdinListeners["keypress"]?.forEach((cb) => cb("a", { name: "a" }));
-        stdinListeners["keypress"]?.forEach((cb) => cb("b", { name: "b" }));
-        stdinListeners["keypress"]?.forEach((cb) => cb(undefined, { name: "backspace" }));
+        mockLine = "ab"; fireKeypress();
+        mockLine = "a"; fireKeypress();
+        resolveQ("a");
+
+        const result = await promise;
+        expect(result).toBe("a");
+        expect(stdoutWriteSpy).toHaveBeenCalledWith("\b \b");
+      });
+
+      it("handles delete key by erasing a *", async () => {
+        let resolveQ!: (v: string) => void;
+        mockQuestion.mockReturnValue(new Promise<string>((r) => { resolveQ = r; }));
+
+        const promise = promptPassword();
+        mockLine = "ab"; fireKeypress();
+        mockLine = "a"; fireKeypress(); // delete key removes char
         resolveQ("a");
 
         const result = await promise;
@@ -142,7 +163,7 @@ describe("prompt", () => {
         mockQuestion.mockReturnValue(new Promise<string>((r) => { resolveQ = r; }));
 
         const promise = promptPassword();
-        stdinListeners["keypress"]?.forEach((cb) => cb(undefined, { name: "backspace" }));
+        mockLine = ""; fireKeypress();
         resolveQ("");
 
         const result = await promise;
@@ -150,33 +171,45 @@ describe("prompt", () => {
         expect(stdoutWriteSpy).not.toHaveBeenCalledWith("\b \b");
       });
 
-      it("ignores Enter keypress for display", async () => {
+      it("handles paste with multiple characters at once", async () => {
         let resolveQ!: (v: string) => void;
         mockQuestion.mockReturnValue(new Promise<string>((r) => { resolveQ = r; }));
 
         const promise = promptPassword();
-        stdinListeners["keypress"]?.forEach((cb) => cb("x", { name: "x" }));
-        stdinListeners["keypress"]?.forEach((cb) => cb(undefined, { name: "return" }));
-        resolveQ("x");
-
-        await promise;
-        const starCalls = stdoutWriteSpy.mock.calls.filter(([arg]) => arg === "*");
-        expect(starCalls).toHaveLength(1);
-      });
-
-      it("ignores ctrl key combos for display", async () => {
-        let resolveQ!: (v: string) => void;
-        mockQuestion.mockReturnValue(new Promise<string>((r) => { resolveQ = r; }));
-
-        const promise = promptPassword();
-        stdinListeners["keypress"]?.forEach((cb) => cb("\x01", { name: "a", ctrl: true }));
-        stdinListeners["keypress"]?.forEach((cb) => cb("z", { name: "z" }));
-        resolveQ("z");
+        mockLine = "pasted"; fireKeypress();
+        resolveQ("pasted");
 
         const result = await promise;
-        expect(result).toBe("z");
-        const starCalls = stdoutWriteSpy.mock.calls.filter(([arg]) => arg === "*");
-        expect(starCalls).toHaveLength(1);
+        expect(result).toBe("pasted");
+        expect(stdoutWriteSpy).toHaveBeenCalledWith("******");
+      });
+
+      it("displays one * for a surrogate-pair character", async () => {
+        let resolveQ!: (v: string) => void;
+        mockQuestion.mockReturnValue(new Promise<string>((r) => { resolveQ = r; }));
+
+        const promise = promptPassword();
+        mockLine = "🔑"; fireKeypress();
+        resolveQ("🔑");
+
+        await promise;
+        expect(stdoutWriteSpy).toHaveBeenCalledWith("*");
+      });
+
+      it("no-op when rl.line length unchanged", async () => {
+        let resolveQ!: (v: string) => void;
+        mockQuestion.mockReturnValue(new Promise<string>((r) => { resolveQ = r; }));
+
+        const promise = promptPassword();
+        mockLine = "a"; fireKeypress();
+        stdoutWriteSpy.mockClear();
+        // Same length, different content (e.g. cursor move) — no mask change
+        mockLine = "b"; fireKeypress();
+        resolveQ("b");
+
+        await promise;
+        expect(stdoutWriteSpy).not.toHaveBeenCalledWith("*");
+        expect(stdoutWriteSpy).not.toHaveBeenCalledWith("\b \b");
       });
 
       it("uses custom label", async () => {


### PR DESCRIPTION
## Summary
- パスワード入力時、`*` マスクが正しく表示されないバグを修正
- `promptEmail()` が内部で `createInterface` → `emitKeypressEvents` を stdin に適用し、その後の `promptPassword()` の raw mode `data` リスナーが正常に動作しなくなっていた
- `promptPassword` を readline + muted `Writable` + `keypress` イベントベースに全面書き直し、タイプ・ペーストどちらでも文字数分の `*` が表示されるように修正

## Test plan
- [x] lint / typecheck / test 全パス (702 tests)
- [ ] ターミナルで `geonic auth login` を実行し、パスワードを1文字ずつ入力して `*` が文字数分表示されることを確認
- [ ] パスワードをクリップボードからペーストし、`*` が文字数分表示されることを確認
- [ ] Backspace でマスク文字が1文字ずつ消えることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

**バージョン 0.12.1**

* **バグ修正**
  * パスワード入力フィールドで複数文字をペーストした場合に、単一の「*」のみが表示される問題を修正しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->