### PR TITLE
feat: list 系コマンドに --limit / --offset を追加 (#112)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 ## [Unreleased]
 
 ### 2026-04-27
-- **Feat**: ページング未対応だった `list` 系コマンドに `--limit` / `--offset` フラグを追加 — `types list`, `rules list`, `catalog datasets list`, `custom-data-models list`, `me policies list`, `me api-keys list`, `me oauth-clients list`, `admin tenants list`, `admin users list`, `admin api-keys list`, `admin oauth-clients list`, `admin policies list` で全件取得可能に (#112)
+- **Feat**: ページング未対応だった `list` 系コマンドに `--limit` / `--offset` フラグを追加 — `types list`, `rules list`, `catalog datasets list`, `custom-data-models list`, `me policies list`, `me api-keys list`, `me oauth-clients list`, `admin tenants list`, `admin users list`, `admin api-keys list`, `admin oauth-clients list`, `admin policies list` で全件取得可能に (#113)
+- **Refactor**: ページング処理を `helpers.ts` の `parseNonNegativeInt` / `buildPaginationParams` に共通化。負数や非整数を CLI 側で早期に弾くようバリデーションを追加 (#113)
 
 ## [0.13.0] - 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## [Unreleased]
 
+### 2026-04-27
+- **Feat**: ページング未対応だった `list` 系コマンドに `--limit` / `--offset` フラグを追加 — `types list`, `rules list`, `catalog datasets list`, `custom-data-models list`, `me policies list`, `me api-keys list`, `me oauth-clients list`, `admin tenants list`, `admin users list`, `admin api-keys list`, `admin oauth-clients list`, `admin policies list` で全件取得可能に (#112)
+
 ## [0.13.0] - 2026-04-24
 
 ### 2026-04-24

--- a/README.md
+++ b/README.md
@@ -85,6 +85,19 @@ Options are resolved in this order (first wins):
 2. Config file (`~/.config/geonic/config.json`)
 3. Defaults (`format=json`)
 
+## Pagination
+
+All `list` subcommands accept `--limit <n>` and `--offset <n>` to paginate through results:
+
+```bash
+geonic types list --limit 50 --offset 100
+geonic admin users list --limit 100 --offset 0
+```
+
+Supported on: `entities list`, `temporal entities list`, `subscriptions list`, `registrations list`, `snapshots list`, `types list`, `rules list`, `catalog datasets list`, `custom-data-models list`, `me policies list`, `me api-keys list`, `me oauth-clients list`, and all `admin <resource> list` commands.
+
+Server-side maximum limits: 1000 for NGSI endpoints, 100 for admin endpoints. Omit both flags to use server defaults.
+
 ## Commands
 
 ### help — Get help on commands

--- a/src/commands/admin/api-keys.ts
+++ b/src/commands/admin/api-keys.ts
@@ -109,13 +109,17 @@ export function registerApiKeysCommand(parent: Command): void {
     .command("list")
     .description("List all API keys, showing name, tenant, policy, and status (key values are masked)")
     .option("--tenant-id <id>", "Filter by tenant ID")
+    .option("--limit <n>", "Maximum number of results", parseInt)
+    .option("--offset <n>", "Skip N results", parseInt)
     .action(
       withErrorHandler(async (_opts: unknown, cmd: Command) => {
-        const opts = cmd.opts() as { tenantId?: string };
+        const opts = cmd.opts() as { tenantId?: string; limit?: number; offset?: number };
         const client = createClient(cmd);
         const format = getFormat(cmd);
         const params: Record<string, string> = {};
         if (opts.tenantId) params.tenantId = opts.tenantId;
+        if (opts.limit !== undefined) params.limit = String(opts.limit);
+        if (opts.offset !== undefined) params.offset = String(opts.offset);
         const response = await client.rawRequest("GET", "/admin/api-keys", {
           params,
         });
@@ -137,6 +141,10 @@ export function registerApiKeysCommand(parent: Command): void {
     {
       description: "List API keys for a specific tenant",
       command: "geonic admin api-keys list --tenant-id <tenant-id>",
+    },
+    {
+      description: "List with pagination",
+      command: "geonic admin api-keys list --limit 50 --offset 100",
     },
   ]);
 

--- a/src/commands/admin/api-keys.ts
+++ b/src/commands/admin/api-keys.ts
@@ -1,5 +1,5 @@
 import type { Command } from "commander";
-import { withErrorHandler, createClient, resolveOptions, getFormat, outputResponse } from "../../helpers.js";
+import { withErrorHandler, createClient, resolveOptions, getFormat, outputResponse, parseNonNegativeInt, buildPaginationParams } from "../../helpers.js";
 import { loadConfig, saveConfig } from "../../config.js";
 import { parseJsonInput } from "../../input.js";
 import { printApiKeyBox, printError } from "../../output.js";
@@ -109,17 +109,15 @@ export function registerApiKeysCommand(parent: Command): void {
     .command("list")
     .description("List all API keys, showing name, tenant, policy, and status (key values are masked)")
     .option("--tenant-id <id>", "Filter by tenant ID")
-    .option("--limit <n>", "Maximum number of results", parseInt)
-    .option("--offset <n>", "Skip N results", parseInt)
+    .option("--limit <n>", "Maximum number of results", parseNonNegativeInt)
+    .option("--offset <n>", "Skip N results", parseNonNegativeInt)
     .action(
       withErrorHandler(async (_opts: unknown, cmd: Command) => {
         const opts = cmd.opts() as { tenantId?: string; limit?: number; offset?: number };
         const client = createClient(cmd);
         const format = getFormat(cmd);
-        const params: Record<string, string> = {};
+        const params: Record<string, string> = buildPaginationParams(opts);
         if (opts.tenantId) params.tenantId = opts.tenantId;
-        if (opts.limit !== undefined) params.limit = String(opts.limit);
-        if (opts.offset !== undefined) params.offset = String(opts.offset);
         const response = await client.rawRequest("GET", "/admin/api-keys", {
           params,
         });

--- a/src/commands/admin/oauth-clients.ts
+++ b/src/commands/admin/oauth-clients.ts
@@ -13,11 +13,19 @@ export function registerOAuthClientsCommand(parent: Command): void {
   const list = oauthClients
     .command("list")
     .description("List all registered OAuth clients and their configurations")
+    .option("--limit <n>", "Maximum number of results", parseInt)
+    .option("--offset <n>", "Skip N results", parseInt)
     .action(
       withErrorHandler(async (_opts: unknown, cmd: Command) => {
         const client = createClient(cmd);
         const format = getFormat(cmd);
-        const response = await client.rawRequest("GET", "/admin/oauth-clients");
+        const cmdOpts = cmd.opts();
+
+        const params: Record<string, string> = {};
+        if (cmdOpts.limit !== undefined) params["limit"] = String(cmdOpts.limit);
+        if (cmdOpts.offset !== undefined) params["offset"] = String(cmdOpts.offset);
+
+        const response = await client.rawRequest("GET", "/admin/oauth-clients", { params });
         outputResponse(response, format);
       }),
     );
@@ -30,6 +38,10 @@ export function registerOAuthClientsCommand(parent: Command): void {
     {
       description: "List OAuth clients in table format",
       command: "geonic admin oauth-clients list --format table",
+    },
+    {
+      description: "List with pagination",
+      command: "geonic admin oauth-clients list --limit 50 --offset 100",
     },
   ]);
 

--- a/src/commands/admin/oauth-clients.ts
+++ b/src/commands/admin/oauth-clients.ts
@@ -1,5 +1,5 @@
 import type { Command } from "commander";
-import { withErrorHandler, createClient, getFormat, outputResponse } from "../../helpers.js";
+import { withErrorHandler, createClient, getFormat, outputResponse, parseNonNegativeInt, buildPaginationParams } from "../../helpers.js";
 import { parseJsonInput } from "../../input.js";
 import { printSuccess } from "../../output.js";
 import { addExamples } from "../help.js";
@@ -13,17 +13,13 @@ export function registerOAuthClientsCommand(parent: Command): void {
   const list = oauthClients
     .command("list")
     .description("List all registered OAuth clients and their configurations")
-    .option("--limit <n>", "Maximum number of results", parseInt)
-    .option("--offset <n>", "Skip N results", parseInt)
+    .option("--limit <n>", "Maximum number of results", parseNonNegativeInt)
+    .option("--offset <n>", "Skip N results", parseNonNegativeInt)
     .action(
       withErrorHandler(async (_opts: unknown, cmd: Command) => {
         const client = createClient(cmd);
         const format = getFormat(cmd);
-        const cmdOpts = cmd.opts();
-
-        const params: Record<string, string> = {};
-        if (cmdOpts.limit !== undefined) params["limit"] = String(cmdOpts.limit);
-        if (cmdOpts.offset !== undefined) params["offset"] = String(cmdOpts.offset);
+        const params = buildPaginationParams(cmd.opts());
 
         const response = await client.rawRequest("GET", "/admin/oauth-clients", { params });
         outputResponse(response, format);

--- a/src/commands/admin/policies.ts
+++ b/src/commands/admin/policies.ts
@@ -1,5 +1,5 @@
 import type { Command } from "commander";
-import { withErrorHandler, createClient, getFormat, outputResponse } from "../../helpers.js";
+import { withErrorHandler, createClient, getFormat, outputResponse, parseNonNegativeInt, buildPaginationParams } from "../../helpers.js";
 import { parseJsonInput } from "../../input.js";
 import { printSuccess } from "../../output.js";
 import { addExamples } from "../help.js";
@@ -13,17 +13,13 @@ export function registerPoliciesCommand(parent: Command): void {
   const list = policies
     .command("list")
     .description("List all access control policies, showing their status and priority")
-    .option("--limit <n>", "Maximum number of results", parseInt)
-    .option("--offset <n>", "Skip N results", parseInt)
+    .option("--limit <n>", "Maximum number of results", parseNonNegativeInt)
+    .option("--offset <n>", "Skip N results", parseNonNegativeInt)
     .action(
       withErrorHandler(async (_opts: unknown, cmd: Command) => {
         const client = createClient(cmd);
         const format = getFormat(cmd);
-        const cmdOpts = cmd.opts();
-
-        const params: Record<string, string> = {};
-        if (cmdOpts.limit !== undefined) params["limit"] = String(cmdOpts.limit);
-        if (cmdOpts.offset !== undefined) params["offset"] = String(cmdOpts.offset);
+        const params = buildPaginationParams(cmd.opts());
 
         const response = await client.rawRequest("GET", "/admin/policies", { params });
         outputResponse(response, format);

--- a/src/commands/admin/policies.ts
+++ b/src/commands/admin/policies.ts
@@ -13,11 +13,19 @@ export function registerPoliciesCommand(parent: Command): void {
   const list = policies
     .command("list")
     .description("List all access control policies, showing their status and priority")
+    .option("--limit <n>", "Maximum number of results", parseInt)
+    .option("--offset <n>", "Skip N results", parseInt)
     .action(
       withErrorHandler(async (_opts: unknown, cmd: Command) => {
         const client = createClient(cmd);
         const format = getFormat(cmd);
-        const response = await client.rawRequest("GET", "/admin/policies");
+        const cmdOpts = cmd.opts();
+
+        const params: Record<string, string> = {};
+        if (cmdOpts.limit !== undefined) params["limit"] = String(cmdOpts.limit);
+        if (cmdOpts.offset !== undefined) params["offset"] = String(cmdOpts.offset);
+
+        const response = await client.rawRequest("GET", "/admin/policies", { params });
         outputResponse(response, format);
       }),
     );
@@ -30,6 +38,10 @@ export function registerPoliciesCommand(parent: Command): void {
     {
       description: "List policies in table format for an overview",
       command: "geonic admin policies list --format table",
+    },
+    {
+      description: "List with pagination",
+      command: "geonic admin policies list --limit 50 --offset 100",
     },
   ]);
 

--- a/src/commands/admin/tenants.ts
+++ b/src/commands/admin/tenants.ts
@@ -13,11 +13,19 @@ export function registerTenantsCommand(parent: Command): void {
   const list = tenants
     .command("list")
     .description("List all tenants in the system, including their status and configuration")
+    .option("--limit <n>", "Maximum number of results", parseInt)
+    .option("--offset <n>", "Skip N results", parseInt)
     .action(
       withErrorHandler(async (_opts: unknown, cmd: Command) => {
         const client = createClient(cmd);
         const format = getFormat(cmd);
-        const response = await client.rawRequest("GET", "/admin/tenants");
+        const cmdOpts = cmd.opts();
+
+        const params: Record<string, string> = {};
+        if (cmdOpts.limit !== undefined) params["limit"] = String(cmdOpts.limit);
+        if (cmdOpts.offset !== undefined) params["offset"] = String(cmdOpts.offset);
+
+        const response = await client.rawRequest("GET", "/admin/tenants", { params });
         outputResponse(response, format);
       }),
     );
@@ -30,6 +38,10 @@ export function registerTenantsCommand(parent: Command): void {
     {
       description: "List tenants in table format",
       command: "geonic admin tenants list --format table",
+    },
+    {
+      description: "List with pagination",
+      command: "geonic admin tenants list --limit 50 --offset 100",
     },
   ]);
 

--- a/src/commands/admin/tenants.ts
+++ b/src/commands/admin/tenants.ts
@@ -1,5 +1,5 @@
 import type { Command } from "commander";
-import { withErrorHandler, createClient, getFormat, outputResponse } from "../../helpers.js";
+import { withErrorHandler, createClient, getFormat, outputResponse, parseNonNegativeInt, buildPaginationParams } from "../../helpers.js";
 import { parseJsonInput } from "../../input.js";
 import { printSuccess } from "../../output.js";
 import { addExamples } from "../help.js";
@@ -13,17 +13,13 @@ export function registerTenantsCommand(parent: Command): void {
   const list = tenants
     .command("list")
     .description("List all tenants in the system, including their status and configuration")
-    .option("--limit <n>", "Maximum number of results", parseInt)
-    .option("--offset <n>", "Skip N results", parseInt)
+    .option("--limit <n>", "Maximum number of results", parseNonNegativeInt)
+    .option("--offset <n>", "Skip N results", parseNonNegativeInt)
     .action(
       withErrorHandler(async (_opts: unknown, cmd: Command) => {
         const client = createClient(cmd);
         const format = getFormat(cmd);
-        const cmdOpts = cmd.opts();
-
-        const params: Record<string, string> = {};
-        if (cmdOpts.limit !== undefined) params["limit"] = String(cmdOpts.limit);
-        if (cmdOpts.offset !== undefined) params["offset"] = String(cmdOpts.offset);
+        const params = buildPaginationParams(cmd.opts());
 
         const response = await client.rawRequest("GET", "/admin/tenants", { params });
         outputResponse(response, format);

--- a/src/commands/admin/users.ts
+++ b/src/commands/admin/users.ts
@@ -1,5 +1,5 @@
 import type { Command } from "commander";
-import { withErrorHandler, createClient, getFormat, outputResponse } from "../../helpers.js";
+import { withErrorHandler, createClient, getFormat, outputResponse, parseNonNegativeInt, buildPaginationParams } from "../../helpers.js";
 import { parseJsonInput } from "../../input.js";
 import { printSuccess } from "../../output.js";
 import { addExamples } from "../help.js";
@@ -13,17 +13,13 @@ export function registerUsersCommand(parent: Command): void {
   const list = users
     .command("list")
     .description("List all users across tenants, showing email, role, and status")
-    .option("--limit <n>", "Maximum number of results", parseInt)
-    .option("--offset <n>", "Skip N results", parseInt)
+    .option("--limit <n>", "Maximum number of results", parseNonNegativeInt)
+    .option("--offset <n>", "Skip N results", parseNonNegativeInt)
     .action(
       withErrorHandler(async (_opts: unknown, cmd: Command) => {
         const client = createClient(cmd);
         const format = getFormat(cmd);
-        const cmdOpts = cmd.opts();
-
-        const params: Record<string, string> = {};
-        if (cmdOpts.limit !== undefined) params["limit"] = String(cmdOpts.limit);
-        if (cmdOpts.offset !== undefined) params["offset"] = String(cmdOpts.offset);
+        const params = buildPaginationParams(cmd.opts());
 
         const response = await client.rawRequest("GET", "/admin/users", { params });
         outputResponse(response, format);

--- a/src/commands/admin/users.ts
+++ b/src/commands/admin/users.ts
@@ -13,11 +13,19 @@ export function registerUsersCommand(parent: Command): void {
   const list = users
     .command("list")
     .description("List all users across tenants, showing email, role, and status")
+    .option("--limit <n>", "Maximum number of results", parseInt)
+    .option("--offset <n>", "Skip N results", parseInt)
     .action(
       withErrorHandler(async (_opts: unknown, cmd: Command) => {
         const client = createClient(cmd);
         const format = getFormat(cmd);
-        const response = await client.rawRequest("GET", "/admin/users");
+        const cmdOpts = cmd.opts();
+
+        const params: Record<string, string> = {};
+        if (cmdOpts.limit !== undefined) params["limit"] = String(cmdOpts.limit);
+        if (cmdOpts.offset !== undefined) params["offset"] = String(cmdOpts.offset);
+
+        const response = await client.rawRequest("GET", "/admin/users", { params });
         outputResponse(response, format);
       }),
     );
@@ -34,6 +42,10 @@ export function registerUsersCommand(parent: Command): void {
     {
       description: "List users for a specific tenant",
       command: "geonic admin users list --service <tenant-id>",
+    },
+    {
+      description: "List with pagination",
+      command: "geonic admin users list --limit 50 --offset 100",
     },
   ]);
 

--- a/src/commands/catalog.ts
+++ b/src/commands/catalog.ts
@@ -1,5 +1,5 @@
 import type { Command } from "commander";
-import { withErrorHandler, createClient, getFormat, outputResponse } from "../helpers.js";
+import { withErrorHandler, createClient, getFormat, outputResponse, parseNonNegativeInt, buildPaginationParams } from "../helpers.js";
 import { addExamples } from "./help.js";
 
 export function registerCatalogCommand(program: Command): void {
@@ -40,17 +40,13 @@ export function registerCatalogCommand(program: Command): void {
   const datasetsList = datasets
     .command("list")
     .description("List all datasets published in the catalog")
-    .option("--limit <n>", "Maximum number of results", parseInt)
-    .option("--offset <n>", "Skip N results", parseInt)
+    .option("--limit <n>", "Maximum number of results", parseNonNegativeInt)
+    .option("--offset <n>", "Skip N results", parseNonNegativeInt)
     .action(
       withErrorHandler(async (_opts: unknown, cmd: Command) => {
         const client = createClient(cmd);
         const format = getFormat(cmd);
-        const cmdOpts = cmd.opts();
-
-        const params: Record<string, string> = {};
-        if (cmdOpts.limit !== undefined) params["limit"] = String(cmdOpts.limit);
-        if (cmdOpts.offset !== undefined) params["offset"] = String(cmdOpts.offset);
+        const params = buildPaginationParams(cmd.opts());
 
         const response = await client.rawRequest("GET", "/catalog/datasets", { params });
         outputResponse(response, format);

--- a/src/commands/catalog.ts
+++ b/src/commands/catalog.ts
@@ -40,11 +40,19 @@ export function registerCatalogCommand(program: Command): void {
   const datasetsList = datasets
     .command("list")
     .description("List all datasets published in the catalog")
+    .option("--limit <n>", "Maximum number of results", parseInt)
+    .option("--offset <n>", "Skip N results", parseInt)
     .action(
       withErrorHandler(async (_opts: unknown, cmd: Command) => {
         const client = createClient(cmd);
         const format = getFormat(cmd);
-        const response = await client.rawRequest("GET", "/catalog/datasets");
+        const cmdOpts = cmd.opts();
+
+        const params: Record<string, string> = {};
+        if (cmdOpts.limit !== undefined) params["limit"] = String(cmdOpts.limit);
+        if (cmdOpts.offset !== undefined) params["offset"] = String(cmdOpts.offset);
+
+        const response = await client.rawRequest("GET", "/catalog/datasets", { params });
         outputResponse(response, format);
       }),
     );
@@ -57,6 +65,10 @@ export function registerCatalogCommand(program: Command): void {
     {
       description: "Browse datasets in table format",
       command: "geonic catalog datasets list --format table",
+    },
+    {
+      description: "List with pagination",
+      command: "geonic catalog datasets list --limit 50 --offset 100",
     },
   ]);
 

--- a/src/commands/me-api-keys.ts
+++ b/src/commands/me-api-keys.ts
@@ -1,5 +1,5 @@
 import type { Command } from "commander";
-import { withErrorHandler, createClient, resolveOptions, getFormat, outputResponse } from "../helpers.js";
+import { withErrorHandler, createClient, resolveOptions, getFormat, outputResponse, parseNonNegativeInt, buildPaginationParams } from "../helpers.js";
 import { loadConfig, saveConfig } from "../config.js";
 import { parseJsonInput } from "../input.js";
 import { printApiKeyBox, printError } from "../output.js";
@@ -66,17 +66,13 @@ export function addMeApiKeysSubcommand(me: Command): void {
   const list = apiKeys
     .command("list")
     .description("List your API keys")
-    .option("--limit <n>", "Maximum number of results", parseInt)
-    .option("--offset <n>", "Skip N results", parseInt)
+    .option("--limit <n>", "Maximum number of results", parseNonNegativeInt)
+    .option("--offset <n>", "Skip N results", parseNonNegativeInt)
     .action(
       withErrorHandler(async (_opts: unknown, cmd: Command) => {
         const client = createClient(cmd);
         const format = getFormat(cmd);
-        const cmdOpts = cmd.opts();
-
-        const params: Record<string, string> = {};
-        if (cmdOpts.limit !== undefined) params["limit"] = String(cmdOpts.limit);
-        if (cmdOpts.offset !== undefined) params["offset"] = String(cmdOpts.offset);
+        const params = buildPaginationParams(cmd.opts());
 
         const response = await client.rawRequest("GET", "/me/api-keys", { params });
         response.data = cleanApiKeyData(response.data);

--- a/src/commands/me-api-keys.ts
+++ b/src/commands/me-api-keys.ts
@@ -66,11 +66,19 @@ export function addMeApiKeysSubcommand(me: Command): void {
   const list = apiKeys
     .command("list")
     .description("List your API keys")
+    .option("--limit <n>", "Maximum number of results", parseInt)
+    .option("--offset <n>", "Skip N results", parseInt)
     .action(
       withErrorHandler(async (_opts: unknown, cmd: Command) => {
         const client = createClient(cmd);
         const format = getFormat(cmd);
-        const response = await client.rawRequest("GET", "/me/api-keys");
+        const cmdOpts = cmd.opts();
+
+        const params: Record<string, string> = {};
+        if (cmdOpts.limit !== undefined) params["limit"] = String(cmdOpts.limit);
+        if (cmdOpts.offset !== undefined) params["offset"] = String(cmdOpts.offset);
+
+        const response = await client.rawRequest("GET", "/me/api-keys", { params });
         response.data = cleanApiKeyData(response.data);
         outputResponse(response, format);
         console.error("※ API キー値は作成時 (create) またはリフレッシュ時 (refresh) にのみ表示されます。");
@@ -85,6 +93,10 @@ export function addMeApiKeysSubcommand(me: Command): void {
     {
       description: "List in table format for a quick overview",
       command: "geonic me api-keys list --format table",
+    },
+    {
+      description: "List with pagination",
+      command: "geonic me api-keys list --limit 50 --offset 100",
     },
   ]);
 

--- a/src/commands/me-oauth-clients.ts
+++ b/src/commands/me-oauth-clients.ts
@@ -15,11 +15,19 @@ export function addMeOAuthClientsSubcommand(me: Command): void {
   const list = oauthClients
     .command("list")
     .description("List your OAuth clients")
+    .option("--limit <n>", "Maximum number of results", parseInt)
+    .option("--offset <n>", "Skip N results", parseInt)
     .action(
       withErrorHandler(async (_opts: unknown, cmd: Command) => {
         const client = createClient(cmd);
         const format = getFormat(cmd);
-        const response = await client.rawRequest("GET", "/me/oauth-clients");
+        const cmdOpts = cmd.opts();
+
+        const params: Record<string, string> = {};
+        if (cmdOpts.limit !== undefined) params["limit"] = String(cmdOpts.limit);
+        if (cmdOpts.offset !== undefined) params["offset"] = String(cmdOpts.offset);
+
+        const response = await client.rawRequest("GET", "/me/oauth-clients", { params });
         outputResponse(response, format);
       }),
     );
@@ -32,6 +40,10 @@ export function addMeOAuthClientsSubcommand(me: Command): void {
     {
       description: "List in table format for a quick overview",
       command: "geonic me oauth-clients list --format table",
+    },
+    {
+      description: "List with pagination",
+      command: "geonic me oauth-clients list --limit 50 --offset 100",
     },
   ]);
 

--- a/src/commands/me-oauth-clients.ts
+++ b/src/commands/me-oauth-clients.ts
@@ -1,5 +1,5 @@
 import type { Command } from "commander";
-import { withErrorHandler, createClient, resolveOptions, getFormat, outputResponse } from "../helpers.js";
+import { withErrorHandler, createClient, resolveOptions, getFormat, outputResponse, parseNonNegativeInt, buildPaginationParams } from "../helpers.js";
 import { loadConfig, saveConfig, validateUrl } from "../config.js";
 import { parseJsonInput } from "../input.js";
 import { printSuccess, printError, printInfo, printWarning } from "../output.js";
@@ -15,17 +15,13 @@ export function addMeOAuthClientsSubcommand(me: Command): void {
   const list = oauthClients
     .command("list")
     .description("List your OAuth clients")
-    .option("--limit <n>", "Maximum number of results", parseInt)
-    .option("--offset <n>", "Skip N results", parseInt)
+    .option("--limit <n>", "Maximum number of results", parseNonNegativeInt)
+    .option("--offset <n>", "Skip N results", parseNonNegativeInt)
     .action(
       withErrorHandler(async (_opts: unknown, cmd: Command) => {
         const client = createClient(cmd);
         const format = getFormat(cmd);
-        const cmdOpts = cmd.opts();
-
-        const params: Record<string, string> = {};
-        if (cmdOpts.limit !== undefined) params["limit"] = String(cmdOpts.limit);
-        if (cmdOpts.offset !== undefined) params["offset"] = String(cmdOpts.offset);
+        const params = buildPaginationParams(cmd.opts());
 
         const response = await client.rawRequest("GET", "/me/oauth-clients", { params });
         outputResponse(response, format);

--- a/src/commands/me-policies.ts
+++ b/src/commands/me-policies.ts
@@ -1,5 +1,5 @@
 import type { Command } from "commander";
-import { withErrorHandler, createClient, getFormat, outputResponse } from "../helpers.js";
+import { withErrorHandler, createClient, getFormat, outputResponse, parseNonNegativeInt, buildPaginationParams } from "../helpers.js";
 import { parseJsonInput } from "../input.js";
 import { printSuccess } from "../output.js";
 import { addExamples, addNotes } from "./help.js";
@@ -13,17 +13,13 @@ export function addMePoliciesSubcommand(me: Command): void {
   const list = policies
     .command("list")
     .description("List your personal policies")
-    .option("--limit <n>", "Maximum number of results", parseInt)
-    .option("--offset <n>", "Skip N results", parseInt)
+    .option("--limit <n>", "Maximum number of results", parseNonNegativeInt)
+    .option("--offset <n>", "Skip N results", parseNonNegativeInt)
     .action(
       withErrorHandler(async (_opts: unknown, cmd: Command) => {
         const client = createClient(cmd);
         const format = getFormat(cmd);
-        const cmdOpts = cmd.opts();
-
-        const params: Record<string, string> = {};
-        if (cmdOpts.limit !== undefined) params["limit"] = String(cmdOpts.limit);
-        if (cmdOpts.offset !== undefined) params["offset"] = String(cmdOpts.offset);
+        const params = buildPaginationParams(cmd.opts());
 
         const response = await client.rawRequest("GET", "/me/policies", { params });
         outputResponse(response, format);

--- a/src/commands/me-policies.ts
+++ b/src/commands/me-policies.ts
@@ -13,11 +13,19 @@ export function addMePoliciesSubcommand(me: Command): void {
   const list = policies
     .command("list")
     .description("List your personal policies")
+    .option("--limit <n>", "Maximum number of results", parseInt)
+    .option("--offset <n>", "Skip N results", parseInt)
     .action(
       withErrorHandler(async (_opts: unknown, cmd: Command) => {
         const client = createClient(cmd);
         const format = getFormat(cmd);
-        const response = await client.rawRequest("GET", "/me/policies");
+        const cmdOpts = cmd.opts();
+
+        const params: Record<string, string> = {};
+        if (cmdOpts.limit !== undefined) params["limit"] = String(cmdOpts.limit);
+        if (cmdOpts.offset !== undefined) params["offset"] = String(cmdOpts.offset);
+
+        const response = await client.rawRequest("GET", "/me/policies", { params });
         outputResponse(response, format);
       }),
     );
@@ -30,6 +38,10 @@ export function addMePoliciesSubcommand(me: Command): void {
     {
       description: "List in table format for a quick overview",
       command: "geonic me policies list --format table",
+    },
+    {
+      description: "List with pagination",
+      command: "geonic me policies list --limit 50 --offset 100",
     },
   ]);
 

--- a/src/commands/models.ts
+++ b/src/commands/models.ts
@@ -14,11 +14,19 @@ export function registerModelsCommand(program: Command): void {
   const list = models
     .command("list")
     .description("List all registered data models for the current tenant")
+    .option("--limit <n>", "Maximum number of results", parseInt)
+    .option("--offset <n>", "Skip N results", parseInt)
     .action(
       withErrorHandler(async (_opts: unknown, cmd: Command) => {
         const client = createClient(cmd);
         const format = getFormat(cmd);
-        const response = await client.rawRequest("GET", "/custom-data-models");
+        const cmdOpts = cmd.opts();
+
+        const params: Record<string, string> = {};
+        if (cmdOpts.limit !== undefined) params["limit"] = String(cmdOpts.limit);
+        if (cmdOpts.offset !== undefined) params["offset"] = String(cmdOpts.offset);
+
+        const response = await client.rawRequest("GET", "/custom-data-models", { params });
         outputResponse(response, format);
       }),
     );
@@ -31,6 +39,10 @@ export function registerModelsCommand(program: Command): void {
     {
       description: "Browse available data models in table format",
       command: "geonic models list --format table",
+    },
+    {
+      description: "List with pagination",
+      command: "geonic models list --limit 50 --offset 100",
     },
   ]);
 

--- a/src/commands/models.ts
+++ b/src/commands/models.ts
@@ -1,5 +1,5 @@
 import type { Command } from "commander";
-import { withErrorHandler, createClient, getFormat, outputResponse } from "../helpers.js";
+import { withErrorHandler, createClient, getFormat, outputResponse, parseNonNegativeInt, buildPaginationParams } from "../helpers.js";
 import { parseJsonInput } from "../input.js";
 import { printSuccess } from "../output.js";
 import { addExamples } from "./help.js";
@@ -14,17 +14,13 @@ export function registerModelsCommand(program: Command): void {
   const list = models
     .command("list")
     .description("List all registered data models for the current tenant")
-    .option("--limit <n>", "Maximum number of results", parseInt)
-    .option("--offset <n>", "Skip N results", parseInt)
+    .option("--limit <n>", "Maximum number of results", parseNonNegativeInt)
+    .option("--offset <n>", "Skip N results", parseNonNegativeInt)
     .action(
       withErrorHandler(async (_opts: unknown, cmd: Command) => {
         const client = createClient(cmd);
         const format = getFormat(cmd);
-        const cmdOpts = cmd.opts();
-
-        const params: Record<string, string> = {};
-        if (cmdOpts.limit !== undefined) params["limit"] = String(cmdOpts.limit);
-        if (cmdOpts.offset !== undefined) params["offset"] = String(cmdOpts.offset);
+        const params = buildPaginationParams(cmd.opts());
 
         const response = await client.rawRequest("GET", "/custom-data-models", { params });
         outputResponse(response, format);

--- a/src/commands/rules.ts
+++ b/src/commands/rules.ts
@@ -1,5 +1,5 @@
 import type { Command } from "commander";
-import { withErrorHandler, createClient, getFormat, outputResponse } from "../helpers.js";
+import { withErrorHandler, createClient, getFormat, outputResponse, parseNonNegativeInt, buildPaginationParams } from "../helpers.js";
 import { parseJsonInput } from "../input.js";
 import { printSuccess } from "../output.js";
 import { addExamples } from "./help.js";
@@ -13,17 +13,13 @@ export function registerRulesCommand(program: Command): void {
   const list = rules
     .command("list")
     .description("List all configured rules and their current status")
-    .option("--limit <n>", "Maximum number of results", parseInt)
-    .option("--offset <n>", "Skip N results", parseInt)
+    .option("--limit <n>", "Maximum number of results", parseNonNegativeInt)
+    .option("--offset <n>", "Skip N results", parseNonNegativeInt)
     .action(
       withErrorHandler(async (_opts: unknown, cmd: Command) => {
         const client = createClient(cmd);
         const format = getFormat(cmd);
-        const cmdOpts = cmd.opts();
-
-        const params: Record<string, string> = {};
-        if (cmdOpts.limit !== undefined) params["limit"] = String(cmdOpts.limit);
-        if (cmdOpts.offset !== undefined) params["offset"] = String(cmdOpts.offset);
+        const params = buildPaginationParams(cmd.opts());
 
         const response = await client.rawRequest("GET", "/rules", { params });
         outputResponse(response, format);

--- a/src/commands/rules.ts
+++ b/src/commands/rules.ts
@@ -13,11 +13,19 @@ export function registerRulesCommand(program: Command): void {
   const list = rules
     .command("list")
     .description("List all configured rules and their current status")
+    .option("--limit <n>", "Maximum number of results", parseInt)
+    .option("--offset <n>", "Skip N results", parseInt)
     .action(
       withErrorHandler(async (_opts: unknown, cmd: Command) => {
         const client = createClient(cmd);
         const format = getFormat(cmd);
-        const response = await client.rawRequest("GET", "/rules");
+        const cmdOpts = cmd.opts();
+
+        const params: Record<string, string> = {};
+        if (cmdOpts.limit !== undefined) params["limit"] = String(cmdOpts.limit);
+        if (cmdOpts.offset !== undefined) params["offset"] = String(cmdOpts.offset);
+
+        const response = await client.rawRequest("GET", "/rules", { params });
         outputResponse(response, format);
       }),
     );
@@ -30,6 +38,10 @@ export function registerRulesCommand(program: Command): void {
     {
       description: "List rules in table format to review status at a glance",
       command: "geonic rules list --format table",
+    },
+    {
+      description: "List with pagination",
+      command: "geonic rules list --limit 50 --offset 100",
     },
   ]);
 

--- a/src/commands/types.ts
+++ b/src/commands/types.ts
@@ -4,6 +4,8 @@ import {
   createClient,
   getFormat,
   outputResponse,
+  parseNonNegativeInt,
+  buildPaginationParams,
 } from "../helpers.js";
 import { addExamples } from "./help.js";
 
@@ -16,17 +18,13 @@ export function registerTypesCommand(program: Command): void {
   const list = types
     .command("list")
     .description("List all entity types currently stored in the broker")
-    .option("--limit <n>", "Maximum number of results", parseInt)
-    .option("--offset <n>", "Skip N results", parseInt)
+    .option("--limit <n>", "Maximum number of results", parseNonNegativeInt)
+    .option("--offset <n>", "Skip N results", parseNonNegativeInt)
     .action(
       withErrorHandler(async (_opts: unknown, cmd: Command) => {
         const client = createClient(cmd);
         const format = getFormat(cmd);
-        const cmdOpts = cmd.opts();
-
-        const params: Record<string, string> = {};
-        if (cmdOpts.limit !== undefined) params["limit"] = String(cmdOpts.limit);
-        if (cmdOpts.offset !== undefined) params["offset"] = String(cmdOpts.offset);
+        const params = buildPaginationParams(cmd.opts());
 
         const response = await client.get("/types", params);
         outputResponse(response, format);

--- a/src/commands/types.ts
+++ b/src/commands/types.ts
@@ -16,12 +16,19 @@ export function registerTypesCommand(program: Command): void {
   const list = types
     .command("list")
     .description("List all entity types currently stored in the broker")
+    .option("--limit <n>", "Maximum number of results", parseInt)
+    .option("--offset <n>", "Skip N results", parseInt)
     .action(
       withErrorHandler(async (_opts: unknown, cmd: Command) => {
         const client = createClient(cmd);
         const format = getFormat(cmd);
+        const cmdOpts = cmd.opts();
 
-        const response = await client.get("/types");
+        const params: Record<string, string> = {};
+        if (cmdOpts.limit !== undefined) params["limit"] = String(cmdOpts.limit);
+        if (cmdOpts.offset !== undefined) params["offset"] = String(cmdOpts.offset);
+
+        const response = await client.get("/types", params);
         outputResponse(response, format);
       }),
     );
@@ -34,6 +41,10 @@ export function registerTypesCommand(program: Command): void {
     {
       description: "List entity types in table format for a quick overview",
       command: "geonic types list --format table",
+    },
+    {
+      description: "List with pagination",
+      command: "geonic types list --limit 50 --offset 100",
     },
   ]);
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,4 +1,4 @@
-import { Command } from "commander";
+import { Command, InvalidArgumentError } from "commander";
 import { loadConfig, saveConfig, validateUrl } from "./config.js";
 import { DryRunSignal, GdbClient, GdbClientError } from "./client.js";
 import { printError, printOutput, printCount } from "./output.js";
@@ -85,6 +85,32 @@ export function outputResponse(
   if (response.data !== undefined && response.data !== "") {
     printOutput(response.data, format);
   }
+}
+
+/**
+ * Commander.js option parser for `--limit` / `--offset` style flags.
+ * Rejects non-integer or negative values with InvalidArgumentError so
+ * Commander surfaces a clear failure before the request is built.
+ */
+export function parseNonNegativeInt(value: string): number {
+  if (!/^\d+$/.test(value)) {
+    throw new InvalidArgumentError("Must be a non-negative integer.");
+  }
+  return Number(value);
+}
+
+/**
+ * Build a pagination query-param record from parsed CLI options.
+ * Centralizes the limit/offset → string conversion shared by every list command.
+ */
+export function buildPaginationParams(opts: {
+  limit?: number;
+  offset?: number;
+}): Record<string, string> {
+  const params: Record<string, string> = {};
+  if (opts.limit !== undefined) params["limit"] = String(opts.limit);
+  if (opts.offset !== undefined) params["offset"] = String(opts.offset);
+  return params;
 }
 
 /**

--- a/tests/admin-api-keys.test.ts
+++ b/tests/admin-api-keys.test.ts
@@ -8,6 +8,13 @@ vi.mock("../src/helpers.js", () => ({
   outputResponse: vi.fn(),
   withErrorHandler: (fn: (...args: unknown[]) => unknown) => fn,
   resolveOptions: vi.fn().mockReturnValue({ profile: "default" }),
+  parseNonNegativeInt: (value: string): number => Number(value),
+  buildPaginationParams: (opts: { limit?: number; offset?: number }): Record<string, string> => {
+    const params: Record<string, string> = {};
+    if (opts.limit !== undefined) params["limit"] = String(opts.limit);
+    if (opts.offset !== undefined) params["offset"] = String(opts.offset);
+    return params;
+  },
 }));
 
 vi.mock("../src/input.js", () => ({

--- a/tests/admin-api-keys.test.ts
+++ b/tests/admin-api-keys.test.ts
@@ -8,7 +8,10 @@ vi.mock("../src/helpers.js", () => ({
   outputResponse: vi.fn(),
   withErrorHandler: (fn: (...args: unknown[]) => unknown) => fn,
   resolveOptions: vi.fn().mockReturnValue({ profile: "default" }),
-  parseNonNegativeInt: (value: string): number => Number(value),
+  parseNonNegativeInt: (value: string): number => {
+    if (!/^\d+$/.test(value)) throw new Error("Invalid non-negative integer");
+    return Number(value);
+  },
   buildPaginationParams: (opts: { limit?: number; offset?: number }): Record<string, string> => {
     const params: Record<string, string> = {};
     if (opts.limit !== undefined) params["limit"] = String(opts.limit);

--- a/tests/admin-oauth-clients.test.ts
+++ b/tests/admin-oauth-clients.test.ts
@@ -8,7 +8,10 @@ vi.mock("../src/helpers.js", () => ({
   outputResponse: vi.fn(),
   withErrorHandler: (fn: (...args: unknown[]) => unknown) => fn,
   resolveOptions: vi.fn(),
-  parseNonNegativeInt: (value: string): number => Number(value),
+  parseNonNegativeInt: (value: string): number => {
+    if (!/^\d+$/.test(value)) throw new Error("Invalid non-negative integer");
+    return Number(value);
+  },
   buildPaginationParams: (opts: { limit?: number; offset?: number }): Record<string, string> => {
     const params: Record<string, string> = {};
     if (opts.limit !== undefined) params["limit"] = String(opts.limit);

--- a/tests/admin-oauth-clients.test.ts
+++ b/tests/admin-oauth-clients.test.ts
@@ -8,6 +8,13 @@ vi.mock("../src/helpers.js", () => ({
   outputResponse: vi.fn(),
   withErrorHandler: (fn: (...args: unknown[]) => unknown) => fn,
   resolveOptions: vi.fn(),
+  parseNonNegativeInt: (value: string): number => Number(value),
+  buildPaginationParams: (opts: { limit?: number; offset?: number }): Record<string, string> => {
+    const params: Record<string, string> = {};
+    if (opts.limit !== undefined) params["limit"] = String(opts.limit);
+    if (opts.offset !== undefined) params["offset"] = String(opts.offset);
+    return params;
+  },
 }));
 
 vi.mock("../src/input.js", () => ({

--- a/tests/admin-oauth-clients.test.ts
+++ b/tests/admin-oauth-clients.test.ts
@@ -56,8 +56,17 @@ describe("admin oauth-clients commands", () => {
       client.rawRequest.mockResolvedValue(mockResponse([{ id: "c1" }]));
       const program = makeProgram();
       await runCommand(program, ["admin", "oauth-clients", "list"]);
-      expect(client.rawRequest).toHaveBeenCalledWith("GET", "/admin/oauth-clients");
+      expect(client.rawRequest).toHaveBeenCalledWith("GET", "/admin/oauth-clients", { params: {} });
       expect(outputResponse).toHaveBeenCalled();
+    });
+
+    it("forwards --limit and --offset", async () => {
+      client.rawRequest.mockResolvedValue(mockResponse([]));
+      const program = makeProgram();
+      await runCommand(program, ["admin", "oauth-clients", "list", "--limit", "10", "--offset", "5"]);
+      expect(client.rawRequest).toHaveBeenCalledWith("GET", "/admin/oauth-clients", {
+        params: { limit: "10", offset: "5" },
+      });
     });
   });
 

--- a/tests/admin-policies.test.ts
+++ b/tests/admin-policies.test.ts
@@ -55,8 +55,17 @@ describe("admin policies commands", () => {
       client.rawRequest.mockResolvedValue(mockResponse([{ id: "p1" }]));
       const program = makeProgram();
       await runCommand(program, ["admin", "policies", "list"]);
-      expect(client.rawRequest).toHaveBeenCalledWith("GET", "/admin/policies");
+      expect(client.rawRequest).toHaveBeenCalledWith("GET", "/admin/policies", { params: {} });
       expect(outputResponse).toHaveBeenCalled();
+    });
+
+    it("forwards --limit and --offset", async () => {
+      client.rawRequest.mockResolvedValue(mockResponse([]));
+      const program = makeProgram();
+      await runCommand(program, ["admin", "policies", "list", "--limit", "10", "--offset", "5"]);
+      expect(client.rawRequest).toHaveBeenCalledWith("GET", "/admin/policies", {
+        params: { limit: "10", offset: "5" },
+      });
     });
   });
 

--- a/tests/admin-policies.test.ts
+++ b/tests/admin-policies.test.ts
@@ -8,7 +8,10 @@ vi.mock("../src/helpers.js", () => ({
   outputResponse: vi.fn(),
   withErrorHandler: (fn: (...args: unknown[]) => unknown) => fn,
   resolveOptions: vi.fn(),
-  parseNonNegativeInt: (value: string): number => Number(value),
+  parseNonNegativeInt: (value: string): number => {
+    if (!/^\d+$/.test(value)) throw new Error("Invalid non-negative integer");
+    return Number(value);
+  },
   buildPaginationParams: (opts: { limit?: number; offset?: number }): Record<string, string> => {
     const params: Record<string, string> = {};
     if (opts.limit !== undefined) params["limit"] = String(opts.limit);

--- a/tests/admin-policies.test.ts
+++ b/tests/admin-policies.test.ts
@@ -8,6 +8,13 @@ vi.mock("../src/helpers.js", () => ({
   outputResponse: vi.fn(),
   withErrorHandler: (fn: (...args: unknown[]) => unknown) => fn,
   resolveOptions: vi.fn(),
+  parseNonNegativeInt: (value: string): number => Number(value),
+  buildPaginationParams: (opts: { limit?: number; offset?: number }): Record<string, string> => {
+    const params: Record<string, string> = {};
+    if (opts.limit !== undefined) params["limit"] = String(opts.limit);
+    if (opts.offset !== undefined) params["offset"] = String(opts.offset);
+    return params;
+  },
 }));
 
 vi.mock("../src/input.js", () => ({

--- a/tests/admin-tenants.test.ts
+++ b/tests/admin-tenants.test.ts
@@ -55,8 +55,17 @@ describe("admin tenants commands", () => {
       client.rawRequest.mockResolvedValue(mockResponse([{ id: "t1" }]));
       const program = makeProgram();
       await runCommand(program, ["admin", "tenants", "list"]);
-      expect(client.rawRequest).toHaveBeenCalledWith("GET", "/admin/tenants");
+      expect(client.rawRequest).toHaveBeenCalledWith("GET", "/admin/tenants", { params: {} });
       expect(outputResponse).toHaveBeenCalled();
+    });
+
+    it("forwards --limit and --offset", async () => {
+      client.rawRequest.mockResolvedValue(mockResponse([]));
+      const program = makeProgram();
+      await runCommand(program, ["admin", "tenants", "list", "--limit", "10", "--offset", "5"]);
+      expect(client.rawRequest).toHaveBeenCalledWith("GET", "/admin/tenants", {
+        params: { limit: "10", offset: "5" },
+      });
     });
   });
 

--- a/tests/admin-tenants.test.ts
+++ b/tests/admin-tenants.test.ts
@@ -8,7 +8,10 @@ vi.mock("../src/helpers.js", () => ({
   outputResponse: vi.fn(),
   withErrorHandler: (fn: (...args: unknown[]) => unknown) => fn,
   resolveOptions: vi.fn(),
-  parseNonNegativeInt: (value: string): number => Number(value),
+  parseNonNegativeInt: (value: string): number => {
+    if (!/^\d+$/.test(value)) throw new Error("Invalid non-negative integer");
+    return Number(value);
+  },
   buildPaginationParams: (opts: { limit?: number; offset?: number }): Record<string, string> => {
     const params: Record<string, string> = {};
     if (opts.limit !== undefined) params["limit"] = String(opts.limit);

--- a/tests/admin-tenants.test.ts
+++ b/tests/admin-tenants.test.ts
@@ -8,6 +8,13 @@ vi.mock("../src/helpers.js", () => ({
   outputResponse: vi.fn(),
   withErrorHandler: (fn: (...args: unknown[]) => unknown) => fn,
   resolveOptions: vi.fn(),
+  parseNonNegativeInt: (value: string): number => Number(value),
+  buildPaginationParams: (opts: { limit?: number; offset?: number }): Record<string, string> => {
+    const params: Record<string, string> = {};
+    if (opts.limit !== undefined) params["limit"] = String(opts.limit);
+    if (opts.offset !== undefined) params["offset"] = String(opts.offset);
+    return params;
+  },
 }));
 
 vi.mock("../src/input.js", () => ({

--- a/tests/admin-users.test.ts
+++ b/tests/admin-users.test.ts
@@ -8,7 +8,10 @@ vi.mock("../src/helpers.js", () => ({
   outputResponse: vi.fn(),
   withErrorHandler: (fn: (...args: unknown[]) => unknown) => fn,
   resolveOptions: vi.fn(),
-  parseNonNegativeInt: (value: string): number => Number(value),
+  parseNonNegativeInt: (value: string): number => {
+    if (!/^\d+$/.test(value)) throw new Error("Invalid non-negative integer");
+    return Number(value);
+  },
   buildPaginationParams: (opts: { limit?: number; offset?: number }): Record<string, string> => {
     const params: Record<string, string> = {};
     if (opts.limit !== undefined) params["limit"] = String(opts.limit);

--- a/tests/admin-users.test.ts
+++ b/tests/admin-users.test.ts
@@ -55,8 +55,17 @@ describe("admin users commands", () => {
       client.rawRequest.mockResolvedValue(mockResponse([{ id: "u1" }]));
       const program = makeProgram();
       await runCommand(program, ["admin", "users", "list"]);
-      expect(client.rawRequest).toHaveBeenCalledWith("GET", "/admin/users");
+      expect(client.rawRequest).toHaveBeenCalledWith("GET", "/admin/users", { params: {} });
       expect(outputResponse).toHaveBeenCalled();
+    });
+
+    it("forwards --limit and --offset", async () => {
+      client.rawRequest.mockResolvedValue(mockResponse([]));
+      const program = makeProgram();
+      await runCommand(program, ["admin", "users", "list", "--limit", "10", "--offset", "5"]);
+      expect(client.rawRequest).toHaveBeenCalledWith("GET", "/admin/users", {
+        params: { limit: "10", offset: "5" },
+      });
     });
   });
 

--- a/tests/admin-users.test.ts
+++ b/tests/admin-users.test.ts
@@ -8,6 +8,13 @@ vi.mock("../src/helpers.js", () => ({
   outputResponse: vi.fn(),
   withErrorHandler: (fn: (...args: unknown[]) => unknown) => fn,
   resolveOptions: vi.fn(),
+  parseNonNegativeInt: (value: string): number => Number(value),
+  buildPaginationParams: (opts: { limit?: number; offset?: number }): Record<string, string> => {
+    const params: Record<string, string> = {};
+    if (opts.limit !== undefined) params["limit"] = String(opts.limit);
+    if (opts.offset !== undefined) params["offset"] = String(opts.offset);
+    return params;
+  },
 }));
 
 vi.mock("../src/input.js", () => ({

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -8,7 +8,10 @@ vi.mock("../src/helpers.js", () => ({
   outputResponse: vi.fn(),
   withErrorHandler: (fn: (...args: unknown[]) => unknown) => fn,
   resolveOptions: vi.fn(),
-  parseNonNegativeInt: (value: string): number => Number(value),
+  parseNonNegativeInt: (value: string): number => {
+    if (!/^\d+$/.test(value)) throw new Error("Invalid non-negative integer");
+    return Number(value);
+  },
   buildPaginationParams: (opts: { limit?: number; offset?: number }): Record<string, string> => {
     const params: Record<string, string> = {};
     if (opts.limit !== undefined) params["limit"] = String(opts.limit);

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -8,6 +8,13 @@ vi.mock("../src/helpers.js", () => ({
   outputResponse: vi.fn(),
   withErrorHandler: (fn: (...args: unknown[]) => unknown) => fn,
   resolveOptions: vi.fn(),
+  parseNonNegativeInt: (value: string): number => Number(value),
+  buildPaginationParams: (opts: { limit?: number; offset?: number }): Record<string, string> => {
+    const params: Record<string, string> = {};
+    if (opts.limit !== undefined) params["limit"] = String(opts.limit);
+    if (opts.offset !== undefined) params["offset"] = String(opts.offset);
+    return params;
+  },
 }));
 
 vi.mock("../src/input.js", () => ({

--- a/tests/catalog.test.ts
+++ b/tests/catalog.test.ts
@@ -33,8 +33,17 @@ describe("catalog command", () => {
       mockClient.rawRequest.mockResolvedValue(mockResponse([{ id: "ds1" }]));
       await runCommand(program, ["catalog", "datasets", "list"]);
 
-      expect(mockClient.rawRequest).toHaveBeenCalledWith("GET", "/catalog/datasets");
+      expect(mockClient.rawRequest).toHaveBeenCalledWith("GET", "/catalog/datasets", { params: {} });
       expect(outputResponse).toHaveBeenCalledWith(expect.anything(), "json");
+    });
+
+    it("forwards --limit and --offset", async () => {
+      mockClient.rawRequest.mockResolvedValue(mockResponse([{ id: "ds1" }]));
+      await runCommand(program, ["catalog", "datasets", "list", "--limit", "10", "--offset", "5"]);
+
+      expect(mockClient.rawRequest).toHaveBeenCalledWith("GET", "/catalog/datasets", {
+        params: { limit: "10", offset: "5" },
+      });
     });
   });
 

--- a/tests/me-api-keys.test.ts
+++ b/tests/me-api-keys.test.ts
@@ -8,6 +8,13 @@ vi.mock("../src/helpers.js", () => ({
   outputResponse: vi.fn(),
   withErrorHandler: (fn: (...args: unknown[]) => unknown) => fn,
   resolveOptions: vi.fn().mockReturnValue({ profile: "default" }),
+  parseNonNegativeInt: (value: string): number => Number(value),
+  buildPaginationParams: (opts: { limit?: number; offset?: number }): Record<string, string> => {
+    const params: Record<string, string> = {};
+    if (opts.limit !== undefined) params["limit"] = String(opts.limit);
+    if (opts.offset !== undefined) params["offset"] = String(opts.offset);
+    return params;
+  },
 }));
 
 vi.mock("../src/input.js", () => ({

--- a/tests/me-api-keys.test.ts
+++ b/tests/me-api-keys.test.ts
@@ -8,7 +8,10 @@ vi.mock("../src/helpers.js", () => ({
   outputResponse: vi.fn(),
   withErrorHandler: (fn: (...args: unknown[]) => unknown) => fn,
   resolveOptions: vi.fn().mockReturnValue({ profile: "default" }),
-  parseNonNegativeInt: (value: string): number => Number(value),
+  parseNonNegativeInt: (value: string): number => {
+    if (!/^\d+$/.test(value)) throw new Error("Invalid non-negative integer");
+    return Number(value);
+  },
   buildPaginationParams: (opts: { limit?: number; offset?: number }): Record<string, string> => {
     const params: Record<string, string> = {};
     if (opts.limit !== undefined) params["limit"] = String(opts.limit);

--- a/tests/me-api-keys.test.ts
+++ b/tests/me-api-keys.test.ts
@@ -75,11 +75,20 @@ describe("me api-keys commands", () => {
       client.rawRequest.mockResolvedValue(mockResponse([{ keyId: "k1" }]));
       const program = makeProgram();
       await runCommand(program, ["me", "api-keys", "list"]);
-      expect(client.rawRequest).toHaveBeenCalledWith("GET", "/me/api-keys");
+      expect(client.rawRequest).toHaveBeenCalledWith("GET", "/me/api-keys", { params: {} });
       expect(outputResponse).toHaveBeenCalled();
       expect(consoleSpy).toHaveBeenCalledWith(
         expect.stringContaining("API キー値は作成時"),
       );
+    });
+
+    it("forwards --limit and --offset", async () => {
+      client.rawRequest.mockResolvedValue(mockResponse([]));
+      const program = makeProgram();
+      await runCommand(program, ["me", "api-keys", "list", "--limit", "10", "--offset", "5"]);
+      expect(client.rawRequest).toHaveBeenCalledWith("GET", "/me/api-keys", {
+        params: { limit: "10", offset: "5" },
+      });
     });
 
     it("outputs dpopRequired field in list response", async () => {

--- a/tests/me-oauth-clients.test.ts
+++ b/tests/me-oauth-clients.test.ts
@@ -72,8 +72,17 @@ describe("me oauth-clients commands", () => {
       client.rawRequest.mockResolvedValue(mockResponse([{ clientId: "c1" }]));
       const program = makeProgram();
       await runCommand(program, ["me", "oauth-clients", "list"]);
-      expect(client.rawRequest).toHaveBeenCalledWith("GET", "/me/oauth-clients");
+      expect(client.rawRequest).toHaveBeenCalledWith("GET", "/me/oauth-clients", { params: {} });
       expect(outputResponse).toHaveBeenCalled();
+    });
+
+    it("forwards --limit and --offset", async () => {
+      client.rawRequest.mockResolvedValue(mockResponse([]));
+      const program = makeProgram();
+      await runCommand(program, ["me", "oauth-clients", "list", "--limit", "10", "--offset", "5"]);
+      expect(client.rawRequest).toHaveBeenCalledWith("GET", "/me/oauth-clients", {
+        params: { limit: "10", offset: "5" },
+      });
     });
   });
 

--- a/tests/me-oauth-clients.test.ts
+++ b/tests/me-oauth-clients.test.ts
@@ -8,7 +8,10 @@ vi.mock("../src/helpers.js", () => ({
   outputResponse: vi.fn(),
   withErrorHandler: (fn: (...args: unknown[]) => unknown) => fn,
   resolveOptions: vi.fn(),
-  parseNonNegativeInt: (value: string): number => Number(value),
+  parseNonNegativeInt: (value: string): number => {
+    if (!/^\d+$/.test(value)) throw new Error("Invalid non-negative integer");
+    return Number(value);
+  },
   buildPaginationParams: (opts: { limit?: number; offset?: number }): Record<string, string> => {
     const params: Record<string, string> = {};
     if (opts.limit !== undefined) params["limit"] = String(opts.limit);

--- a/tests/me-oauth-clients.test.ts
+++ b/tests/me-oauth-clients.test.ts
@@ -8,6 +8,13 @@ vi.mock("../src/helpers.js", () => ({
   outputResponse: vi.fn(),
   withErrorHandler: (fn: (...args: unknown[]) => unknown) => fn,
   resolveOptions: vi.fn(),
+  parseNonNegativeInt: (value: string): number => Number(value),
+  buildPaginationParams: (opts: { limit?: number; offset?: number }): Record<string, string> => {
+    const params: Record<string, string> = {};
+    if (opts.limit !== undefined) params["limit"] = String(opts.limit);
+    if (opts.offset !== undefined) params["offset"] = String(opts.offset);
+    return params;
+  },
 }));
 
 vi.mock("../src/input.js", () => ({

--- a/tests/me-password.test.ts
+++ b/tests/me-password.test.ts
@@ -8,7 +8,10 @@ vi.mock("../src/helpers.js", () => ({
   outputResponse: vi.fn(),
   withErrorHandler: (fn: (...args: unknown[]) => unknown) => fn,
   resolveOptions: vi.fn(),
-  parseNonNegativeInt: (value: string): number => Number(value),
+  parseNonNegativeInt: (value: string): number => {
+    if (!/^\d+$/.test(value)) throw new Error("Invalid non-negative integer");
+    return Number(value);
+  },
   buildPaginationParams: (opts: { limit?: number; offset?: number }): Record<string, string> => {
     const params: Record<string, string> = {};
     if (opts.limit !== undefined) params["limit"] = String(opts.limit);

--- a/tests/me-password.test.ts
+++ b/tests/me-password.test.ts
@@ -8,6 +8,13 @@ vi.mock("../src/helpers.js", () => ({
   outputResponse: vi.fn(),
   withErrorHandler: (fn: (...args: unknown[]) => unknown) => fn,
   resolveOptions: vi.fn(),
+  parseNonNegativeInt: (value: string): number => Number(value),
+  buildPaginationParams: (opts: { limit?: number; offset?: number }): Record<string, string> => {
+    const params: Record<string, string> = {};
+    if (opts.limit !== undefined) params["limit"] = String(opts.limit);
+    if (opts.offset !== undefined) params["offset"] = String(opts.offset);
+    return params;
+  },
 }));
 
 vi.mock("../src/input.js", () => ({

--- a/tests/me-policies.test.ts
+++ b/tests/me-policies.test.ts
@@ -8,7 +8,10 @@ vi.mock("../src/helpers.js", () => ({
   outputResponse: vi.fn(),
   withErrorHandler: (fn: (...args: unknown[]) => unknown) => fn,
   resolveOptions: vi.fn(),
-  parseNonNegativeInt: (value: string): number => Number(value),
+  parseNonNegativeInt: (value: string): number => {
+    if (!/^\d+$/.test(value)) throw new Error("Invalid non-negative integer");
+    return Number(value);
+  },
   buildPaginationParams: (opts: { limit?: number; offset?: number }): Record<string, string> => {
     const params: Record<string, string> = {};
     if (opts.limit !== undefined) params["limit"] = String(opts.limit);

--- a/tests/me-policies.test.ts
+++ b/tests/me-policies.test.ts
@@ -70,8 +70,17 @@ describe("me policies commands", () => {
       client.rawRequest.mockResolvedValue(mockResponse([{ policyId: "p1" }]));
       const program = makeProgram();
       await runCommand(program, ["me", "policies", "list"]);
-      expect(client.rawRequest).toHaveBeenCalledWith("GET", "/me/policies");
+      expect(client.rawRequest).toHaveBeenCalledWith("GET", "/me/policies", { params: {} });
       expect(outputResponse).toHaveBeenCalled();
+    });
+
+    it("forwards --limit and --offset", async () => {
+      client.rawRequest.mockResolvedValue(mockResponse([]));
+      const program = makeProgram();
+      await runCommand(program, ["me", "policies", "list", "--limit", "10", "--offset", "5"]);
+      expect(client.rawRequest).toHaveBeenCalledWith("GET", "/me/policies", {
+        params: { limit: "10", offset: "5" },
+      });
     });
   });
 

--- a/tests/me-policies.test.ts
+++ b/tests/me-policies.test.ts
@@ -8,6 +8,13 @@ vi.mock("../src/helpers.js", () => ({
   outputResponse: vi.fn(),
   withErrorHandler: (fn: (...args: unknown[]) => unknown) => fn,
   resolveOptions: vi.fn(),
+  parseNonNegativeInt: (value: string): number => Number(value),
+  buildPaginationParams: (opts: { limit?: number; offset?: number }): Record<string, string> => {
+    const params: Record<string, string> = {};
+    if (opts.limit !== undefined) params["limit"] = String(opts.limit);
+    if (opts.offset !== undefined) params["offset"] = String(opts.offset);
+    return params;
+  },
 }));
 
 vi.mock("../src/input.js", () => ({

--- a/tests/models.test.ts
+++ b/tests/models.test.ts
@@ -25,7 +25,7 @@ describe("models (custom-data-models) command", () => {
       mockClient.rawRequest.mockResolvedValue(mockResponse([{ id: "model1" }]));
       await runCommand(program, ["custom-data-models", "list"]);
 
-      expect(mockClient.rawRequest).toHaveBeenCalledWith("GET", "/custom-data-models");
+      expect(mockClient.rawRequest).toHaveBeenCalledWith("GET", "/custom-data-models", { params: {} });
       expect(outputResponse).toHaveBeenCalledWith(expect.anything(), "json");
     });
 
@@ -33,7 +33,16 @@ describe("models (custom-data-models) command", () => {
       mockClient.rawRequest.mockResolvedValue(mockResponse([]));
       await runCommand(program, ["models", "list"]);
 
-      expect(mockClient.rawRequest).toHaveBeenCalledWith("GET", "/custom-data-models");
+      expect(mockClient.rawRequest).toHaveBeenCalledWith("GET", "/custom-data-models", { params: {} });
+    });
+
+    it("forwards --limit and --offset", async () => {
+      mockClient.rawRequest.mockResolvedValue(mockResponse([]));
+      await runCommand(program, ["models", "list", "--limit", "10", "--offset", "5"]);
+
+      expect(mockClient.rawRequest).toHaveBeenCalledWith("GET", "/custom-data-models", {
+        params: { limit: "10", offset: "5" },
+      });
     });
   });
 

--- a/tests/rules.test.ts
+++ b/tests/rules.test.ts
@@ -25,8 +25,17 @@ describe("rules command", () => {
       mockClient.rawRequest.mockResolvedValue(mockResponse([{ id: "rule1" }]));
       await runCommand(program, ["rules", "list"]);
 
-      expect(mockClient.rawRequest).toHaveBeenCalledWith("GET", "/rules");
+      expect(mockClient.rawRequest).toHaveBeenCalledWith("GET", "/rules", { params: {} });
       expect(outputResponse).toHaveBeenCalledWith(expect.anything(), "json");
+    });
+
+    it("forwards --limit and --offset", async () => {
+      mockClient.rawRequest.mockResolvedValue(mockResponse([{ id: "rule1" }]));
+      await runCommand(program, ["rules", "list", "--limit", "10", "--offset", "5"]);
+
+      expect(mockClient.rawRequest).toHaveBeenCalledWith("GET", "/rules", {
+        params: { limit: "10", offset: "5" },
+      });
     });
   });
 

--- a/tests/setup-command-mocks.ts
+++ b/tests/setup-command-mocks.ts
@@ -15,7 +15,10 @@ vi.mock("../src/helpers.js", () => ({
   getFormat: vi.fn(),
   outputResponse: vi.fn(),
   withErrorHandler: (fn: (...args: unknown[]) => unknown) => fn,
-  parseNonNegativeInt: (value: string): number => Number(value),
+  parseNonNegativeInt: (value: string): number => {
+    if (!/^\d+$/.test(value)) throw new Error("Invalid non-negative integer");
+    return Number(value);
+  },
   buildPaginationParams: (opts: { limit?: number; offset?: number }): Record<string, string> => {
     const params: Record<string, string> = {};
     if (opts.limit !== undefined) params["limit"] = String(opts.limit);

--- a/tests/setup-command-mocks.ts
+++ b/tests/setup-command-mocks.ts
@@ -15,6 +15,13 @@ vi.mock("../src/helpers.js", () => ({
   getFormat: vi.fn(),
   outputResponse: vi.fn(),
   withErrorHandler: (fn: (...args: unknown[]) => unknown) => fn,
+  parseNonNegativeInt: (value: string): number => Number(value),
+  buildPaginationParams: (opts: { limit?: number; offset?: number }): Record<string, string> => {
+    const params: Record<string, string> = {};
+    if (opts.limit !== undefined) params["limit"] = String(opts.limit);
+    if (opts.offset !== undefined) params["offset"] = String(opts.offset);
+    return params;
+  },
 }));
 
 vi.mock("../src/input.js", () => ({

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -7,6 +7,13 @@ vi.mock("../src/helpers.js", () => ({
   getFormat: vi.fn(),
   outputResponse: vi.fn(),
   withErrorHandler: (fn: (...args: unknown[]) => unknown) => fn,
+  parseNonNegativeInt: (value: string): number => Number(value),
+  buildPaginationParams: (opts: { limit?: number; offset?: number }): Record<string, string> => {
+    const params: Record<string, string> = {};
+    if (opts.limit !== undefined) params["limit"] = String(opts.limit);
+    if (opts.offset !== undefined) params["offset"] = String(opts.offset);
+    return params;
+  },
 }));
 
 vi.mock("../src/output.js", () => ({

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -43,8 +43,18 @@ describe("types command", () => {
       mockClient.get.mockResolvedValue(mockResponse([{ id: "Sensor" }]));
       await runCommand(program, ["types", "list"]);
 
-      expect(mockClient.get).toHaveBeenCalledWith("/types");
+      expect(mockClient.get).toHaveBeenCalledWith("/types", {});
       expect(outputResponse).toHaveBeenCalledWith(expect.anything(), "json");
+    });
+
+    it("forwards --limit and --offset", async () => {
+      mockClient.get.mockResolvedValue(mockResponse([{ id: "Sensor" }]));
+      await runCommand(program, ["types", "list", "--limit", "10", "--offset", "5"]);
+
+      expect(mockClient.get).toHaveBeenCalledWith("/types", {
+        limit: "10",
+        offset: "5",
+      });
     });
   });
 

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -7,7 +7,10 @@ vi.mock("../src/helpers.js", () => ({
   getFormat: vi.fn(),
   outputResponse: vi.fn(),
   withErrorHandler: (fn: (...args: unknown[]) => unknown) => fn,
-  parseNonNegativeInt: (value: string): number => Number(value),
+  parseNonNegativeInt: (value: string): number => {
+    if (!/^\d+$/.test(value)) throw new Error("Invalid non-negative integer");
+    return Number(value);
+  },
   buildPaginationParams: (opts: { limit?: number; offset?: number }): Record<string, string> => {
     const params: Record<string, string> = {};
     if (opts.limit !== undefined) params["limit"] = String(opts.limit);


### PR DESCRIPTION
## Summary

- ページング未対応だった 12 個の `list` コマンドに `--limit` / `--offset` フラグを追加
- 本体側はすべて `parsePaginationParams()` で対応済みだが、CLI が取りこぼしていたためデフォルト件数を超えるデータが閲覧不能だった
- README に Pagination セクションを追加し、全対応コマンド一覧とサーバー側 maxLimit (NGSI 1000 / Admin 100) を記載

Closes #112

## 対象コマンド

**NGSI-LD 系:** `types list`
**機能系:** `rules list`, `catalog datasets list`, `custom-data-models list`
**Me 系:** `me policies list`, `me api-keys list`, `me oauth-clients list`
**Admin 系:** `admin tenants list`, `admin users list`, `admin api-keys list`, `admin oauth-clients list`, `admin policies list`

参考実装は `subscriptions list` / `registrations list` に揃えた。

## スコープ外

issue で当初挙げていた `attrs list` は `/entities/{id}/attrs` (単一エンティティの属性一覧) のためページング不要。スコープから除外。

なお、broker 全体の属性一覧 `/attributes` (`attributesController.listAttributes`) は CLI 側に未実装。これは別 issue で扱う。

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (720 tests pass、各コマンドにペアリング検証テスト追加)
- [x] `geonic <cmd> list --help` で `--limit` / `--offset` が表示されること
- [x] `geonic help <cmd> list` で pagination 使用例が表示されること

## Documentation

- CLI help (wp-cli 形式 `addExamples`): 全 12 コマンドに使用例追加
- `--option()` description: 各フラグに説明追加
- README.md: Pagination セクション新設
- CHANGELOG.md: Unreleased に記載

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 複数の list コマンドでページネーションを追加。`--limit` / `--offset` で取得件数と開始位置を指定可能に。
  * CLI 側で負の値や非整数のページネーション引数を早期に拒否する入力検証を導入。

* **ドキュメント**
  * README と CHANGELOG にページネーションの使用例、サーバー側の最大制限や既定値の挙動を追記。

* **テスト**
  * 各 list コマンドのページネーション挙動を検証するテストを追加・更新。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->