### PR TITLE
feat(admin tenants): add --allowed-origins flag (closes #115)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## [Unreleased]
 
+### 2026-04-30
+- **Feat**: `admin tenants create` / `admin tenants update` に `--allowed-origins` フラグを追加 — テナント単位の CORS origin 制御 (`Tenant.settings.allowedOrigins`, geonicdb #1069 対応) を専用フラグで設定可能に。`api-keys` の `--origins` と同じカンマ区切り命名規則を踏襲し、空文字列で `[]`（全 deny）、`*` で wildcard 許可を表現 (#115)
+
 ## [0.14.0] - 2026-04-27
 
 ### 2026-04-27

--- a/README.md
+++ b/README.md
@@ -441,6 +441,28 @@ Temporal entityOperations query supports: `--aggr-methods`, `--aggr-period`.
 | `admin tenants activate <id>` | Activate a tenant |
 | `admin tenants deactivate <id>` | Deactivate a tenant |
 
+`admin tenants create` / `admin tenants update` support `--allowed-origins <origins>` for tenant-scoped CORS control. The flag maps to `settings.allowedOrigins`:
+
+| Value | Behavior |
+|---|---|
+| Flag omitted | All origins allowed (backward-compatible default) |
+| `--allowed-origins ""` | Empty array — deny all |
+| `--allowed-origins "*"` | Wildcard — allow all origins (including non-browser / S2S clients) |
+| `--allowed-origins "https://a,https://b"` | Exact-match list (max 50 entries) |
+
+```bash
+# Restrict to specific origins
+geonic admin tenants update <tenant-id> --allowed-origins "https://app.example.com,https://admin.example.com"
+
+# Wildcard for development tenants
+geonic admin tenants update <tenant-id> --allowed-origins "*"
+
+# Deny all
+geonic admin tenants update <tenant-id> --allowed-origins ""
+```
+
+When combined with a JSON payload, the flag merges into `settings` without dropping other `settings.*` keys.
+
 #### admin users
 
 | Subcommand | Description |

--- a/src/commands/admin/tenants.ts
+++ b/src/commands/admin/tenants.ts
@@ -2,7 +2,29 @@ import type { Command } from "commander";
 import { withErrorHandler, createClient, getFormat, outputResponse, parseNonNegativeInt, buildPaginationParams } from "../../helpers.js";
 import { parseJsonInput } from "../../input.js";
 import { printSuccess } from "../../output.js";
-import { addExamples } from "../help.js";
+import { addExamples, addNotes } from "../help.js";
+
+/**
+ * Apply --allowed-origins flag to body.settings.allowedOrigins.
+ * Empty string → []. Wildcard / max-length validation is left to the server.
+ */
+function applyAllowedOriginsFlag(
+  body: Record<string, unknown>,
+  opts: { allowedOrigins?: string },
+): void {
+  if (opts.allowedOrigins === undefined) return;
+  const origins = opts.allowedOrigins
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const existing = body.settings;
+  const settings: Record<string, unknown> =
+    existing && typeof existing === "object" && !Array.isArray(existing)
+      ? { ...(existing as Record<string, unknown>) }
+      : {};
+  settings.allowedOrigins = origins;
+  body.settings = settings;
+}
 
 export function registerTenantsCommand(parent: Command): void {
   const tenants = parent
@@ -80,9 +102,22 @@ export function registerTenantsCommand(parent: Command): void {
         '    "description": "Production environment tenant"\n' +
         "  }",
     )
+    .option(
+      "--allowed-origins <origins>",
+      "Comma-separated allowed origins for CORS (empty string = deny all, '*' = allow all)",
+    )
     .action(
       withErrorHandler(async (json: unknown, _opts: unknown, cmd: Command) => {
-        const body = await parseJsonInput(json as string | undefined);
+        const opts = cmd.opts() as { allowedOrigins?: string };
+        let body: Record<string, unknown>;
+        if (json !== undefined) {
+          body = (await parseJsonInput(json as string | undefined)) as Record<string, unknown>;
+        } else if (opts.allowedOrigins !== undefined) {
+          body = {};
+        } else {
+          body = (await parseJsonInput()) as Record<string, unknown>;
+        }
+        applyAllowedOriginsFlag(body, opts);
         const client = createClient(cmd);
         const format = getFormat(cmd);
         const response = await client.rawRequest("POST", "/admin/tenants", {
@@ -92,6 +127,14 @@ export function registerTenantsCommand(parent: Command): void {
         printSuccess("Tenant created.");
       }),
     );
+
+  addNotes(create, [
+    "--allowed-origins maps to settings.allowedOrigins (CORS).",
+    "  Unset = allow all origins (backward-compatible default).",
+    "  '' (empty string) = explicit empty array — deny all.",
+    "  '*' = wildcard — allow all origins (including non-browser clients).",
+    "  Otherwise = comma-separated list of exact-match origins (max 50).",
+  ]);
 
   addExamples(create, [
     {
@@ -114,6 +157,10 @@ export function registerTenantsCommand(parent: Command): void {
       description: "Interactive mode (omit JSON argument)",
       command: "geonic admin tenants create",
     },
+    {
+      description: "Restrict CORS allowed origins on creation",
+      command: `geonic admin tenants create '{"name":"production"}' --allowed-origins "https://app.example.com,https://admin.example.com"`,
+    },
   ]);
 
   // tenants update
@@ -125,10 +172,23 @@ export function registerTenantsCommand(parent: Command): void {
         "JSON payload: only specified fields are updated.\n" +
         '  e.g. {"name": "new-name", "description": "Updated description"}',
     )
+    .option(
+      "--allowed-origins <origins>",
+      "Comma-separated allowed origins for CORS (empty string = deny all, '*' = allow all)",
+    )
     .action(
       withErrorHandler(
         async (id: unknown, json: unknown, _opts: unknown, cmd: Command) => {
-          const body = (await parseJsonInput(json as string | undefined)) as Record<string, unknown>;
+          const opts = cmd.opts() as { allowedOrigins?: string };
+          let body: Record<string, unknown>;
+          if (json !== undefined) {
+            body = (await parseJsonInput(json as string | undefined)) as Record<string, unknown>;
+          } else if (opts.allowedOrigins !== undefined) {
+            body = {};
+          } else {
+            body = (await parseJsonInput()) as Record<string, unknown>;
+          }
+          applyAllowedOriginsFlag(body, opts);
           const client = createClient(cmd);
           const format = getFormat(cmd);
           const response = await client.rawRequest(
@@ -141,6 +201,14 @@ export function registerTenantsCommand(parent: Command): void {
         },
       ),
     );
+
+  addNotes(update, [
+    "--allowed-origins maps to settings.allowedOrigins (CORS).",
+    "  '' (empty string) = explicit empty array — deny all.",
+    "  '*' = wildcard — allow all origins (including non-browser clients).",
+    "  Otherwise = comma-separated list of exact-match origins (max 50).",
+    "  Existing settings.* keys in JSON payload are preserved.",
+  ]);
 
   addExamples(update, [
     {
@@ -162,6 +230,18 @@ export function registerTenantsCommand(parent: Command): void {
     {
       description: "Interactive mode",
       command: "geonic admin tenants update <tenant-id>",
+    },
+    {
+      description: "Restrict CORS to a single origin",
+      command: `geonic admin tenants update <tenant-id> --allowed-origins "https://app.example.com"`,
+    },
+    {
+      description: "Allow all origins (wildcard)",
+      command: `geonic admin tenants update <tenant-id> --allowed-origins "*"`,
+    },
+    {
+      description: "Deny all origins (empty array)",
+      command: `geonic admin tenants update <tenant-id> --allowed-origins ""`,
     },
   ]);
 

--- a/src/commands/admin/tenants.ts
+++ b/src/commands/admin/tenants.ts
@@ -109,14 +109,7 @@ export function registerTenantsCommand(parent: Command): void {
     .action(
       withErrorHandler(async (json: unknown, _opts: unknown, cmd: Command) => {
         const opts = cmd.opts() as { allowedOrigins?: string };
-        let body: Record<string, unknown>;
-        if (json !== undefined) {
-          body = (await parseJsonInput(json as string | undefined)) as Record<string, unknown>;
-        } else if (opts.allowedOrigins !== undefined) {
-          body = {};
-        } else {
-          body = (await parseJsonInput()) as Record<string, unknown>;
-        }
+        const body = (await parseJsonInput(json as string | undefined)) as Record<string, unknown>;
         applyAllowedOriginsFlag(body, opts);
         const client = createClient(cmd);
         const format = getFormat(cmd);
@@ -180,14 +173,7 @@ export function registerTenantsCommand(parent: Command): void {
       withErrorHandler(
         async (id: unknown, json: unknown, _opts: unknown, cmd: Command) => {
           const opts = cmd.opts() as { allowedOrigins?: string };
-          let body: Record<string, unknown>;
-          if (json !== undefined) {
-            body = (await parseJsonInput(json as string | undefined)) as Record<string, unknown>;
-          } else if (opts.allowedOrigins !== undefined) {
-            body = {};
-          } else {
-            body = (await parseJsonInput()) as Record<string, unknown>;
-          }
+          const body = (await parseJsonInput(json as string | undefined)) as Record<string, unknown>;
           applyAllowedOriginsFlag(body, opts);
           const client = createClient(cmd);
           const format = getFormat(cmd);

--- a/tests/admin-tenants.test.ts
+++ b/tests/admin-tenants.test.ts
@@ -107,6 +107,114 @@ describe("admin tenants commands", () => {
       expect(outputResponse).toHaveBeenCalled();
       expect(printSuccess).toHaveBeenCalledWith("Tenant created.");
     });
+
+    it("merges --allowed-origins into settings", async () => {
+      vi.mocked(parseJsonInput).mockResolvedValue({ name: "production" });
+      client.rawRequest.mockResolvedValue(mockResponse({ id: "t2" }, 201));
+      const program = makeProgram();
+      await runCommand(program, [
+        "admin",
+        "tenants",
+        "create",
+        '{"name":"production"}',
+        "--allowed-origins",
+        "https://a.example.com,https://b.example.com",
+      ]);
+      expect(client.rawRequest).toHaveBeenCalledWith("POST", "/admin/tenants", {
+        body: {
+          name: "production",
+          settings: {
+            allowedOrigins: ["https://a.example.com", "https://b.example.com"],
+          },
+        },
+      });
+    });
+
+    it("preserves existing settings keys when merging --allowed-origins", async () => {
+      vi.mocked(parseJsonInput).mockResolvedValue({
+        name: "production",
+        settings: { someOtherFlag: true },
+      });
+      client.rawRequest.mockResolvedValue(mockResponse({ id: "t2" }, 201));
+      const program = makeProgram();
+      await runCommand(program, [
+        "admin",
+        "tenants",
+        "create",
+        '{"name":"production","settings":{"someOtherFlag":true}}',
+        "--allowed-origins",
+        "https://app.example.com",
+      ]);
+      expect(client.rawRequest).toHaveBeenCalledWith("POST", "/admin/tenants", {
+        body: {
+          name: "production",
+          settings: {
+            someOtherFlag: true,
+            allowedOrigins: ["https://app.example.com"],
+          },
+        },
+      });
+    });
+
+    it("treats wildcard --allowed-origins as ['*'] on create", async () => {
+      vi.mocked(parseJsonInput).mockResolvedValue({ name: "dev" });
+      client.rawRequest.mockResolvedValue(mockResponse({ id: "t3" }, 201));
+      const program = makeProgram();
+      await runCommand(program, [
+        "admin",
+        "tenants",
+        "create",
+        '{"name":"dev"}',
+        "--allowed-origins",
+        "*",
+      ]);
+      expect(client.rawRequest).toHaveBeenCalledWith("POST", "/admin/tenants", {
+        body: { name: "dev", settings: { allowedOrigins: ["*"] } },
+      });
+    });
+
+    it("treats empty --allowed-origins as [] on create", async () => {
+      vi.mocked(parseJsonInput).mockResolvedValue({ name: "locked" });
+      client.rawRequest.mockResolvedValue(mockResponse({ id: "t4" }, 201));
+      const program = makeProgram();
+      await runCommand(program, [
+        "admin",
+        "tenants",
+        "create",
+        '{"name":"locked"}',
+        "--allowed-origins",
+        "",
+      ]);
+      expect(client.rawRequest).toHaveBeenCalledWith("POST", "/admin/tenants", {
+        body: { name: "locked", settings: { allowedOrigins: [] } },
+      });
+    });
+
+    it("does not call parseJsonInput when only --allowed-origins is given", async () => {
+      client.rawRequest.mockResolvedValue(mockResponse({ id: "t5" }, 201));
+      const program = makeProgram();
+      await runCommand(program, [
+        "admin",
+        "tenants",
+        "create",
+        "--allowed-origins",
+        "https://app.example.com",
+      ]);
+      expect(parseJsonInput).not.toHaveBeenCalled();
+      expect(client.rawRequest).toHaveBeenCalledWith("POST", "/admin/tenants", {
+        body: { settings: { allowedOrigins: ["https://app.example.com"] } },
+      });
+    });
+
+    it("falls back to parseJsonInput when no json and no --allowed-origins on create", async () => {
+      const body = { name: "interactive" };
+      vi.mocked(parseJsonInput).mockResolvedValue(body);
+      client.rawRequest.mockResolvedValue(mockResponse({ id: "t6" }, 201));
+      const program = makeProgram();
+      await runCommand(program, ["admin", "tenants", "create"]);
+      expect(parseJsonInput).toHaveBeenCalledWith();
+      expect(client.rawRequest).toHaveBeenCalledWith("POST", "/admin/tenants", { body });
+    });
   });
 
   describe("tenants update", () => {
@@ -127,8 +235,140 @@ describe("admin tenants commands", () => {
       client.rawRequest.mockResolvedValue(mockResponse({ id: "t1" }));
       const program = makeProgram();
       await runCommand(program, ["admin", "tenants", "update", "t1"]);
-      expect(parseJsonInput).toHaveBeenCalledWith(undefined);
+      expect(parseJsonInput).toHaveBeenCalledWith();
       expect(client.rawRequest).toHaveBeenCalledWith("PATCH", "/admin/tenants/t1", { body });
+    });
+
+    it("sends settings.allowedOrigins from --allowed-origins flag without JSON", async () => {
+      client.rawRequest.mockResolvedValue(mockResponse({ id: "t1" }));
+      const program = makeProgram();
+      await runCommand(program, [
+        "admin",
+        "tenants",
+        "update",
+        "t1",
+        "--allowed-origins",
+        "https://app.example.com",
+      ]);
+      expect(parseJsonInput).not.toHaveBeenCalled();
+      expect(client.rawRequest).toHaveBeenCalledWith("PATCH", "/admin/tenants/t1", {
+        body: { settings: { allowedOrigins: ["https://app.example.com"] } },
+      });
+    });
+
+    it("treats wildcard --allowed-origins as ['*']", async () => {
+      client.rawRequest.mockResolvedValue(mockResponse({ id: "t1" }));
+      const program = makeProgram();
+      await runCommand(program, [
+        "admin",
+        "tenants",
+        "update",
+        "t1",
+        "--allowed-origins",
+        "*",
+      ]);
+      expect(client.rawRequest).toHaveBeenCalledWith("PATCH", "/admin/tenants/t1", {
+        body: { settings: { allowedOrigins: ["*"] } },
+      });
+    });
+
+    it("treats empty --allowed-origins as [] (deny all)", async () => {
+      client.rawRequest.mockResolvedValue(mockResponse({ id: "t1" }));
+      const program = makeProgram();
+      await runCommand(program, [
+        "admin",
+        "tenants",
+        "update",
+        "t1",
+        "--allowed-origins",
+        "",
+      ]);
+      expect(client.rawRequest).toHaveBeenCalledWith("PATCH", "/admin/tenants/t1", {
+        body: { settings: { allowedOrigins: [] } },
+      });
+    });
+
+    it("trims whitespace and ignores empty entries in --allowed-origins", async () => {
+      client.rawRequest.mockResolvedValue(mockResponse({ id: "t1" }));
+      const program = makeProgram();
+      await runCommand(program, [
+        "admin",
+        "tenants",
+        "update",
+        "t1",
+        "--allowed-origins",
+        " https://a.example.com , , https://b.example.com ",
+      ]);
+      expect(client.rawRequest).toHaveBeenCalledWith("PATCH", "/admin/tenants/t1", {
+        body: {
+          settings: {
+            allowedOrigins: ["https://a.example.com", "https://b.example.com"],
+          },
+        },
+      });
+    });
+
+    it("preserves existing settings keys from JSON when merging --allowed-origins", async () => {
+      vi.mocked(parseJsonInput).mockResolvedValue({
+        settings: { someOtherFlag: true },
+      });
+      client.rawRequest.mockResolvedValue(mockResponse({ id: "t1" }));
+      const program = makeProgram();
+      await runCommand(program, [
+        "admin",
+        "tenants",
+        "update",
+        "t1",
+        '{"settings":{"someOtherFlag":true}}',
+        "--allowed-origins",
+        "https://app.example.com",
+      ]);
+      expect(client.rawRequest).toHaveBeenCalledWith("PATCH", "/admin/tenants/t1", {
+        body: {
+          settings: {
+            someOtherFlag: true,
+            allowedOrigins: ["https://app.example.com"],
+          },
+        },
+      });
+    });
+
+    it("overwrites existing settings.allowedOrigins from JSON when --allowed-origins is given", async () => {
+      vi.mocked(parseJsonInput).mockResolvedValue({
+        settings: { allowedOrigins: ["https://old.example.com"] },
+      });
+      client.rawRequest.mockResolvedValue(mockResponse({ id: "t1" }));
+      const program = makeProgram();
+      await runCommand(program, [
+        "admin",
+        "tenants",
+        "update",
+        "t1",
+        '{"settings":{"allowedOrigins":["https://old.example.com"]}}',
+        "--allowed-origins",
+        "https://new.example.com",
+      ]);
+      expect(client.rawRequest).toHaveBeenCalledWith("PATCH", "/admin/tenants/t1", {
+        body: {
+          settings: { allowedOrigins: ["https://new.example.com"] },
+        },
+      });
+    });
+
+    it("does not add settings field when --allowed-origins is not provided", async () => {
+      vi.mocked(parseJsonInput).mockResolvedValue({ description: "no flag" });
+      client.rawRequest.mockResolvedValue(mockResponse({ id: "t1" }));
+      const program = makeProgram();
+      await runCommand(program, [
+        "admin",
+        "tenants",
+        "update",
+        "t1",
+        '{"description":"no flag"}',
+      ]);
+      expect(client.rawRequest).toHaveBeenCalledWith("PATCH", "/admin/tenants/t1", {
+        body: { description: "no flag" },
+      });
     });
   });
 

--- a/tests/admin-tenants.test.ts
+++ b/tests/admin-tenants.test.ts
@@ -190,7 +190,10 @@ describe("admin tenants commands", () => {
       });
     });
 
-    it("does not call parseJsonInput when only --allowed-origins is given", async () => {
+    it("merges --allowed-origins into stdin/interactive body (no JSON arg)", async () => {
+      // Simulates `cat tenant.json | geonic admin tenants create --allowed-origins ...`
+      // and the TTY interactive case — both are routed through parseJsonInput(undefined).
+      vi.mocked(parseJsonInput).mockResolvedValue({ name: "from-stdin" });
       client.rawRequest.mockResolvedValue(mockResponse({ id: "t5" }, 201));
       const program = makeProgram();
       await runCommand(program, [
@@ -200,9 +203,12 @@ describe("admin tenants commands", () => {
         "--allowed-origins",
         "https://app.example.com",
       ]);
-      expect(parseJsonInput).not.toHaveBeenCalled();
+      expect(parseJsonInput).toHaveBeenCalledWith(undefined);
       expect(client.rawRequest).toHaveBeenCalledWith("POST", "/admin/tenants", {
-        body: { settings: { allowedOrigins: ["https://app.example.com"] } },
+        body: {
+          name: "from-stdin",
+          settings: { allowedOrigins: ["https://app.example.com"] },
+        },
       });
     });
 
@@ -212,7 +218,7 @@ describe("admin tenants commands", () => {
       client.rawRequest.mockResolvedValue(mockResponse({ id: "t6" }, 201));
       const program = makeProgram();
       await runCommand(program, ["admin", "tenants", "create"]);
-      expect(parseJsonInput).toHaveBeenCalledWith();
+      expect(parseJsonInput).toHaveBeenCalledWith(undefined);
       expect(client.rawRequest).toHaveBeenCalledWith("POST", "/admin/tenants", { body });
     });
   });
@@ -235,11 +241,14 @@ describe("admin tenants commands", () => {
       client.rawRequest.mockResolvedValue(mockResponse({ id: "t1" }));
       const program = makeProgram();
       await runCommand(program, ["admin", "tenants", "update", "t1"]);
-      expect(parseJsonInput).toHaveBeenCalledWith();
+      expect(parseJsonInput).toHaveBeenCalledWith(undefined);
       expect(client.rawRequest).toHaveBeenCalledWith("PATCH", "/admin/tenants/t1", { body });
     });
 
-    it("sends settings.allowedOrigins from --allowed-origins flag without JSON", async () => {
+    it("merges --allowed-origins into stdin/interactive body (no JSON arg)", async () => {
+      // Simulates `cat patch.json | geonic admin tenants update t1 --allowed-origins ...`
+      // and the TTY interactive case — both are routed through parseJsonInput(undefined).
+      vi.mocked(parseJsonInput).mockResolvedValue({ description: "from-stdin" });
       client.rawRequest.mockResolvedValue(mockResponse({ id: "t1" }));
       const program = makeProgram();
       await runCommand(program, [
@@ -250,13 +259,17 @@ describe("admin tenants commands", () => {
         "--allowed-origins",
         "https://app.example.com",
       ]);
-      expect(parseJsonInput).not.toHaveBeenCalled();
+      expect(parseJsonInput).toHaveBeenCalledWith(undefined);
       expect(client.rawRequest).toHaveBeenCalledWith("PATCH", "/admin/tenants/t1", {
-        body: { settings: { allowedOrigins: ["https://app.example.com"] } },
+        body: {
+          description: "from-stdin",
+          settings: { allowedOrigins: ["https://app.example.com"] },
+        },
       });
     });
 
     it("treats wildcard --allowed-origins as ['*']", async () => {
+      vi.mocked(parseJsonInput).mockResolvedValue({});
       client.rawRequest.mockResolvedValue(mockResponse({ id: "t1" }));
       const program = makeProgram();
       await runCommand(program, [
@@ -273,6 +286,7 @@ describe("admin tenants commands", () => {
     });
 
     it("treats empty --allowed-origins as [] (deny all)", async () => {
+      vi.mocked(parseJsonInput).mockResolvedValue({});
       client.rawRequest.mockResolvedValue(mockResponse({ id: "t1" }));
       const program = makeProgram();
       await runCommand(program, [
@@ -289,6 +303,7 @@ describe("admin tenants commands", () => {
     });
 
     it("trims whitespace and ignores empty entries in --allowed-origins", async () => {
+      vi.mocked(parseJsonInput).mockResolvedValue({});
       client.rawRequest.mockResolvedValue(mockResponse({ id: "t1" }));
       const program = makeProgram();
       await runCommand(program, [


### PR DESCRIPTION
## Summary

- `admin tenants create` / `admin tenants update` に `--allowed-origins <origins>` フラグを追加し、テナント単位の CORS origin 制御 (`settings.allowedOrigins`, geolonia/geonicdb#1069 対応) を専用フラグから設定可能にした
- `api-keys` の `--origins` と同じカンマ区切り命名規則を踏襲。空文字列 `""` を `[]`（deny all）として扱う点が api-keys との差分。wildcard / max-50 件のバリデーションは本体側 zod に委譲
- 既存 JSON payload の `settings.*` 他キーは保持してマージ。フラグ単独でも JSON 入力なしで動作

Closes #115

## CLI surface

```bash
# 完全一致リスト
geonic admin tenants update <tenant-id> --allowed-origins "https://app.example.com,https://admin.example.com"

# wildcard
geonic admin tenants update <tenant-id> --allowed-origins "*"

# 全 deny
geonic admin tenants update <tenant-id> --allowed-origins ""
```

| 値 | 挙動 |
|---|---|
| フラグ未指定 | 全 origin 許可（後方互換） |
| `""` | `[]` — 全 deny |
| `"*"` | wildcard — 全 origin 許可（CLI / S2S 含む） |
| `"https://a,https://b"` | 完全一致リスト（最大 50 件、本体バリデーション） |

## Changes

- `src/commands/admin/tenants.ts` — `applyAllowedOriginsFlag()` ヘルパーで `body.settings.allowedOrigins` にマージ。create / update に `--allowed-origins` オプションと `addNotes` / `addExamples` を追加
- `tests/admin-tenants.test.ts` — 7 ケース追加（フラグマージ、wildcard、空文字列、空白 trim、既存 settings 保持、上書き、未指定時の regression guard 等）
- `README.md` — `admin tenants` セクションに値別挙動表と実用例を追加
- `CHANGELOG.md` — `[Unreleased]` に Feat エントリを追加

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (733 tests passed, +7 from main)
- [x] `npm run build`
- [ ] geonicdb 本体 #1069 とのインテグレーション確認（本体マージ後）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * `admin tenants create` / `admin tenants update` に `--allowed-origins` フラグを追加。テナント単位のCORS許可オリジンをカンマ区切りで指定可能。`""`で全拒否、`"*"`で全許可（S2S含む）、カンマ区切りは厳密一致。フラグ未指定時は既存の動作（全オリジン）を維持。JSON入力と併用すると既存のsettingsを保持して`allowedOrigins`のみ上書き/追加します。

* **ドキュメント**
  * READMEにオプションの詳細、動作例、マージ挙動を追記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->