### PR TITLE
release: v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ## [0.15.0] - 2026-04-30
 
 ### 2026-04-30
-- **Feat**: `admin tenants create` / `admin tenants update` に `--allowed-origins` フラグを追加 — テナント単位の CORS origin 制御 (`Tenant.settings.allowedOrigins`, geonicdb #1069 対応) を専用フラグで設定可能に。`api-keys` の `--origins` と同じカンマ区切り命名規則を踏襲し、空文字列で `[]`（全 deny）、`*` で wildcard 許可を表現 (#115)
+- **Feat**: `admin tenants create` / `admin tenants update` に `--allowed-origins` フラグを追加 — テナント単位の CORS origin 制御 (`Tenant.settings.allowedOrigins`, geonicdb #1069 対応) を専用フラグで設定可能に。`api-keys` の `--origins` と同じカンマ区切り命名規則を踏襲し、空文字列で `[]`（全 deny）、`*` で wildcard 許可を表現 (#115, #116)
 
 ## [0.14.0] - 2026-04-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-04-30
+
 ### 2026-04-30
 - **Feat**: `admin tenants create` / `admin tenants update` に `--allowed-origins` フラグを追加 — テナント単位の CORS origin 制御 (`Tenant.settings.allowedOrigins`, geonicdb #1069 対応) を専用フラグで設定可能に。`api-keys` の `--origins` と同じカンマ区切り命名規則を踏襲し、空文字列で `[]`（全 deny）、`*` で wildcard 許可を表現 (#115)
 
@@ -219,7 +221,8 @@
 ### 2026-02-26
 - **Docs**: README にインストール手順・使い方・コマンドリファレンスを追加 (#1)
 
-[Unreleased]: https://github.com/geolonia/geonicdb-cli/compare/v0.14.0...HEAD
+[Unreleased]: https://github.com/geolonia/geonicdb-cli/compare/v0.15.0...HEAD
+[0.15.0]: https://github.com/geolonia/geonicdb-cli/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/geolonia/geonicdb-cli/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/geolonia/geonicdb-cli/compare/v0.12.1...v0.13.0
 [0.12.1]: https://github.com/geolonia/geonicdb-cli/compare/v0.12.0...v0.12.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolonia/geonicdb-cli",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolonia/geonicdb-cli",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolonia/geonicdb-cli",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "A CLI client for the GeonicDB",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- version bump: 0.14.0 → 0.15.0
- CHANGELOG: Unreleased → 0.15.0 セクション化、比較リンク追加

## Included since v0.14.0
- **Feat**: `admin tenants create` / `admin tenants update` に `--allowed-origins` フラグを追加 — テナント単位の CORS origin 制御 (`Tenant.settings.allowedOrigins`, geonicdb #1069 対応) (#115, #116)

## After merge
```bash
git tag v0.15.0 && git push origin v0.15.0
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * バージョン 0.15.0 をリリースしました（2026-04-30）。
  * チェンジログに 0.15.0 セクションを追加し、既存の項目で関連Issue参照を追記しました。
  * チェンジログの比較リンクを更新して未リリース範囲と 0.15.0 の差分を明示しました。
  * パッケージのバージョンを 0.15.0 に更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->