### PR TITLE
docs(admin users create): use primaryTenantId in help description and examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ## [Unreleased]
 
 ### 2026-05-08
-- **Docs**: `admin users create` のヘルプ description / examples で旧フィールド名 `tenantId` を使っていた箇所を `primaryTenantId` に修正。サーバ側 `CreateUserInputSchema` (`.strict()`) は `primaryTenantId` のみを受理しており、ヘルプ通りに書くと `400 Unrecognized key: "tenantId"` で失敗していた。回帰防止としてヘルプ文字列・examples を `primaryTenantId` で検証するユニットテストを追加 (#118, #TBD)
+- **Docs**: `admin users create` のヘルプ description / examples で旧フィールド名 `tenantId` を使っていた箇所を `primaryTenantId` に修正。サーバ側 `CreateUserInputSchema` (`.strict()`) は `primaryTenantId` のみを受理しており、ヘルプ通りに書くと `400 Unrecognized key: "tenantId"` で失敗していた。回帰防止としてヘルプ文字列・examples を `primaryTenantId` で検証するユニットテストを追加 (#118, #120)
 
 ## [0.15.0] - 2026-04-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## [Unreleased]
 
+### 2026-05-08
+- **Docs**: `admin users create` のヘルプ description / examples で旧フィールド名 `tenantId` を使っていた箇所を `primaryTenantId` に修正。サーバ側 `CreateUserInputSchema` (`.strict()`) は `primaryTenantId` のみを受理しており、ヘルプ通りに書くと `400 Unrecognized key: "tenantId"` で失敗していた。回帰防止としてヘルプ文字列・examples を `primaryTenantId` で検証するユニットテストを追加 (#118, #TBD)
+
 ## [0.15.0] - 2026-04-30
 
 ### 2026-04-30

--- a/src/commands/admin/users.ts
+++ b/src/commands/admin/users.ts
@@ -83,10 +83,10 @@ export function registerUsersCommand(parent: Command): void {
         '    "email": "user@example.com",\n' +
         '    "password": "SecurePassword123!",\n' +
         '    "role": "tenant_admin",\n' +
-        '    "tenantId": "<tenant-id>"\n' +
+        '    "primaryTenantId": "<tenant-id>"\n' +
         "  }\n\n" +
         "Roles: super_admin, tenant_admin, user\n" +
-        "tenantId is required for tenant_admin and user roles.",
+        "primaryTenantId is required for tenant_admin and user roles.",
     )
     .action(
       withErrorHandler(async (json: unknown, _opts: unknown, cmd: Command) => {
@@ -104,11 +104,11 @@ export function registerUsersCommand(parent: Command): void {
   addExamples(create, [
     {
       description: "Create a tenant admin",
-      command: `geonic admin users create '{"email":"admin@example.com","password":"SecurePass12345!","role":"tenant_admin","tenantId":"<tenant-id>"}'`,
+      command: `geonic admin users create '{"email":"admin@example.com","password":"SecurePass12345!","role":"tenant_admin","primaryTenantId":"<tenant-id>"}'`,
     },
     {
       description: "Create a user for a tenant",
-      command: `geonic admin users create '{"email":"user@example.com","password":"SecurePass12345!","role":"user","tenantId":"<tenant-id>"}'`,
+      command: `geonic admin users create '{"email":"user@example.com","password":"SecurePass12345!","role":"user","primaryTenantId":"<tenant-id>"}'`,
     },
     {
       description: "Create from a JSON file",

--- a/tests/admin-users.test.ts
+++ b/tests/admin-users.test.ts
@@ -38,9 +38,11 @@ vi.mock("../src/commands/help.js", () => ({
   addNotes: vi.fn(),
 }));
 
+import type { Command } from "commander";
 import { createClient, getFormat, outputResponse } from "../src/helpers.js";
 import { parseJsonInput } from "../src/input.js";
 import { printSuccess } from "../src/output.js";
+import { addExamples } from "../src/commands/help.js";
 import { registerUsersCommand } from "../src/commands/admin/users.js";
 
 describe("admin users commands", () => {
@@ -106,6 +108,40 @@ describe("admin users commands", () => {
       expect(client.rawRequest).toHaveBeenCalledWith("POST", "/admin/users", { body });
       expect(outputResponse).toHaveBeenCalled();
       expect(printSuccess).toHaveBeenCalledWith("User created.");
+    });
+
+    // #118: server schema accepts only `primaryTenantId`. Help and examples must reflect that.
+    it("references primaryTenantId (not legacy tenantId) in description", () => {
+      const program = makeProgram();
+      const createCmd = program.commands
+        .find((c) => c.name() === "admin")!
+        .commands.find((c) => c.name() === "users")!
+        .commands.find((c) => c.name() === "create")!;
+      const desc = createCmd.description();
+      expect(desc).toContain('"primaryTenantId":');
+      expect(desc).toContain("primaryTenantId is required");
+      expect(desc).not.toContain('"tenantId":');
+      expect(desc).not.toContain("tenantId is required");
+    });
+
+    it("uses primaryTenantId in registered example payloads", () => {
+      makeProgram();
+      const addExamplesMock = vi.mocked(addExamples);
+      const createCalls = addExamplesMock.mock.calls.filter(
+        ([cmd]) => (cmd as Command).name() === "create",
+      );
+      expect(createCalls.length).toBeGreaterThan(0);
+      const examples = createCalls.flatMap(
+        ([, exs]) => exs as ReadonlyArray<{ description: string; command: string }>,
+      );
+      const roleSpecificExamples = examples.filter(
+        (e) => e.command.includes('"role":"tenant_admin"') || e.command.includes('"role":"user"'),
+      );
+      expect(roleSpecificExamples.length).toBeGreaterThan(0);
+      for (const ex of roleSpecificExamples) {
+        expect(ex.command).toContain('"primaryTenantId":');
+        expect(ex.command).not.toContain('"tenantId":');
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

`geonic admin users create` のヘルプ description / examples が旧フィールド名 `tenantId` を使っていた箇所を `primaryTenantId` に修正。サーバ側 `CreateUserInputSchema` (`.strict()`) は `primaryTenantId` のみ受理するため、ヘルプ通りに書くと `400 Unrecognized key: "tenantId"` で失敗していた。

Closes #118

## Changes

- `src/commands/admin/users.ts`:
  - L86, L89 (description 文): `tenantId` → `primaryTenantId`
  - L107, L111 (`addExamples` payload): `"tenantId":"<tenant-id>"` → `"primaryTenantId":"<tenant-id>"`
- `tests/admin-users.test.ts`: 回帰防止のユニットテストを 2 件追加
- `CHANGELOG.md`: `[Unreleased]` に Docs エントリ追加

## TDD

実装変更前に test を追加して red 確認 → 修正で green、の手順:

```
$ vitest run tests/admin-users.test.ts (after test addition, before src fix)
 FAIL  admin users commands > users create > references primaryTenantId (not legacy tenantId) in description
 FAIL  admin users commands > users create > uses primaryTenantId in registered example payloads
 Tests  2 failed | 10 passed (12)

$ vitest run tests/admin-users.test.ts (after src fix)
 ✓ tests/admin-users.test.ts (12 tests) 6ms
 Tests  12 passed (12)
```

## Test plan

- [x] `npm test` 全 35 spec / 735 tests pass
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [ ] CI 通過確認

## Notes

description 文と addExamples の payload の両方を検証するため:

- description は `commander` の `Command.description()` 経由で取得
- examples は既存テストで mock されている `addExamples` の `mock.calls` から取得し、`role` 別 payload 全件で検証