### PR TITLE
release: v0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## [Unreleased]
 
+## [0.15.1] - 2026-05-11
+
 ### 2026-05-08
 - **Docs**: `admin users create` のヘルプ description / examples で旧フィールド名 `tenantId` を使っていた箇所を `primaryTenantId` に修正。サーバ側 `CreateUserInputSchema` (`.strict()`) は `primaryTenantId` のみを受理しており、ヘルプ通りに書くと `400 Unrecognized key: "tenantId"` で失敗していた。回帰防止としてヘルプ文字列・examples を `primaryTenantId` で検証するユニットテストを追加 (#118, #120)
 - **Docs**: `me api-keys` および `me oauth-clients` で create のフラグが `--policy`、update のフラグが `--policy-id` という命名非対称になっている件について、ヘルプ description と README で明示的に案内するよう修正。`--policy` の説明文に "use --policy-id on update" を、`--policy-id` の説明文に "use --policy on create" を追記。回帰防止としてヘルプ option description を Commander API 経由で検証するユニットテストを追加 (#119, #121)
@@ -225,7 +227,8 @@
 ### 2026-02-26
 - **Docs**: README にインストール手順・使い方・コマンドリファレンスを追加 (#1)
 
-[Unreleased]: https://github.com/geolonia/geonicdb-cli/compare/v0.15.0...HEAD
+[Unreleased]: https://github.com/geolonia/geonicdb-cli/compare/v0.15.1...HEAD
+[0.15.1]: https://github.com/geolonia/geonicdb-cli/compare/v0.15.0...v0.15.1
 [0.15.0]: https://github.com/geolonia/geonicdb-cli/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/geolonia/geonicdb-cli/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/geolonia/geonicdb-cli/compare/v0.12.1...v0.13.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolonia/geonicdb-cli",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "A CLI client for the GeonicDB",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- version bump: 0.15.0 → 0.15.1
- CHANGELOG: Unreleased → 0.15.1 セクション化、比較リンク追加

## Included since v0.15.0
- **Docs**: `admin users create` のヘルプ description / examples で旧フィールド名 `tenantId` を使っていた箇所を `primaryTenantId` に修正。サーバ側 `CreateUserInputSchema` (`.strict()`) は `primaryTenantId` のみを受理するため、ヘルプ通りに書くと `400 Unrecognized key: "tenantId"` で失敗していた問題を解消 (#118, #120)
- **Docs**: `me api-keys` / `me oauth-clients` で create のフラグが `--policy`、update のフラグが `--policy-id` という命名非対称をヘルプ description / README で明示。Commander API 経由でヘルプ option description を検証する回帰防止テストも追加 (#119, #121)

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (739 tests passed)
- [x] `npm run build`
- [ ] CI (lint / typecheck / test / build / e2e) green
- [ ] After merge: `git tag v0.15.1 && git push origin v0.15.1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * パッケージバージョンをv0.15.1にアップデートしました
  * リリース情報をドキュメントに反映しました

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/geolonia/geonicdb-cli/pull/122)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->