### PR TITLE
feat(profile): tenant-bound profiles + explicit tenant on multi-tenant login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 
 ## [Unreleased]
 
+### 2026-05-13
+- **Feat**: `profile create` に `--tenant <tenant>` オプションを追加 — プロファイル作成時にテナント ID/名を初期値として束縛できるように。`--url` (グローバルフラグ) と組み合わせて、同じアカウントの別テナントごとに独立したプロファイルを一度に生成可能 (例: `geonic profile create miya --tenant miya` / `geonic profile create geolonia --tenant geolonia`)
+- **Breaking**: `auth login` の複数テナント所属時の挙動を変更 — 対話プロンプトによるテナント選択を廃止し、`--tenant-id` または `-s/--service` の明示指定を必須化。未指定で複数所属を検出した場合は利用可能テナント一覧を表示してエラー終了する。プロファイル設定で `service`/`tenantId` を保持していれば自動解決される
+- **Refactor**: `src/prompt.ts` から `promptTenantSelection` / `TenantChoice` を削除。`src/commands/auth.ts` は `types.ts` の `TenantInfo` を参照するように統一
+
 ## [0.15.1] - 2026-05-11
 
 ### 2026-05-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@
 ## [Unreleased]
 
 ### 2026-05-13
-- **Feat**: `profile create` に `--tenant <tenant>` オプションを追加 — プロファイル作成時にテナント ID/名を初期値として束縛できるように。`--url` (グローバルフラグ) と組み合わせて、同じアカウントの別テナントごとに独立したプロファイルを一度に生成可能 (例: `geonic profile create miya --tenant miya` / `geonic profile create geolonia --tenant geolonia`)
-- **Breaking**: `auth login` の複数テナント所属時の挙動を変更 — 対話プロンプトによるテナント選択を廃止し、`--tenant-id` または `-s/--service` の明示指定を必須化。未指定で複数所属を検出した場合は利用可能テナント一覧を表示してエラー終了する。プロファイル設定で `service`/`tenantId` を保持していれば自動解決される
-- **Refactor**: `src/prompt.ts` から `promptTenantSelection` / `TenantChoice` を削除。`src/commands/auth.ts` は `types.ts` の `TenantInfo` を参照するように統一
+- **Feat**: `profile create` に `--tenant <tenant>` オプションを追加 — プロファイル作成時にテナント ID/名を初期値として束縛できるように。`--url` (グローバルフラグ) と組み合わせて、同じアカウントの別テナントごとに独立したプロファイルを一度に生成可能 (例: `geonic profile create miya --tenant miya` / `geonic profile create geolonia --tenant geolonia`) (#123)
+- **Breaking**: `auth login` の複数テナント所属時の挙動を変更 — 対話プロンプトによるテナント選択を廃止し、`--tenant-id` または `-s/--service` の明示指定を必須化。未指定で複数所属を検出した場合は利用可能テナント一覧を表示してエラー終了する。プロファイル設定で `service`/`tenantId` を保持していれば自動解決される (#123)
+- **Refactor**: `src/prompt.ts` から `promptTenantSelection` / `TenantChoice` を削除。`src/commands/auth.ts` は `types.ts` の `TenantInfo` を参照するように統一 (#123)
 
 ## [0.15.1] - 2026-05-11
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ geonic help [<command>] [<subcommand>]
 |---|---|
 | `profile list` | List all profiles |
 | `profile use <name>` | Switch active profile |
-| `profile create <name> [--tenant <id>] [--url <url>]` | Create a new profile, optionally bound to a tenant and URL |
+| `profile create <name> [--tenant <id\|name>] [--url <url>]` | Create a new profile, optionally bound to a tenant and URL |
 | `profile delete <name>` | Delete a profile |
 | `profile show [name]` | Show profile settings |
 
@@ -160,8 +160,8 @@ geonic auth login
 
 | Option | Description |
 |---|---|
-| `--tenant-id <id>` | Log in to a specific tenant (tenant ID) |
-| `-s, --service <name>` | Log in to a specific tenant (tenant ID or name) |
+| `--tenant-id <id>` | Log in to a specific tenant. Value is sent to the server as-is (server resolves) |
+| `-s, --service <id\|name>` | Log in to a specific tenant. Resolved client-side against the account's available tenants by ID or name |
 
 **Multi-tenant support**: When you belong to multiple tenants, `auth login` requires explicit tenant selection via `--tenant-id` or `-s/--service`. There is no interactive picker — if neither flag is provided and the account has multiple tenants, the command lists the available tenants and exits with an error.
 

--- a/README.md
+++ b/README.md
@@ -121,9 +121,25 @@ geonic help [<command>] [<subcommand>]
 |---|---|
 | `profile list` | List all profiles |
 | `profile use <name>` | Switch active profile |
-| `profile create <name>` | Create a new profile |
+| `profile create <name> [--tenant <id>] [--url <url>]` | Create a new profile, optionally bound to a tenant and URL |
 | `profile delete <name>` | Delete a profile |
 | `profile show [name]` | Show profile settings |
+
+When the same account belongs to multiple tenants, create one profile per tenant and switch between them with `profile use`:
+
+```bash
+# One-time setup
+geonic profile create miya --tenant miya --url https://geonicdb.geolonia.com
+geonic profile create geolonia --tenant geolonia --url https://geonicdb.geolonia.com
+geonic --profile miya auth login
+geonic --profile geolonia auth login
+
+# Daily use
+geonic profile use miya       # operate as miya tenant
+geonic profile use geolonia   # operate as geolonia tenant
+```
+
+`--tenant <id>` accepts either a tenant ID or a tenant name. The value is stored as both `service` (sent in `NGSILD-Tenant` headers) and `tenantId` on the profile, so subsequent `auth login` calls resolve to that tenant automatically.
 
 ### auth — Authentication
 
@@ -144,21 +160,23 @@ geonic auth login
 
 | Option | Description |
 |---|---|
-| `--tenant-id <id>` | Log in to a specific tenant |
+| `--tenant-id <id>` | Log in to a specific tenant (tenant ID) |
+| `-s, --service <name>` | Log in to a specific tenant (tenant ID or name) |
 
-**Multi-tenant support**: When you belong to multiple tenants, `auth login` displays the list and lets you select one interactively. Use `--tenant-id` to skip the prompt.
+**Multi-tenant support**: When you belong to multiple tenants, `auth login` requires explicit tenant selection via `--tenant-id` or `-s/--service`. There is no interactive picker — if neither flag is provided and the account has multiple tenants, the command lists the available tenants and exits with an error.
+
+A common workflow is to create one profile per tenant (`geonic profile create <name> --tenant <tenant>`); the tenant binding is persisted on the profile, so plain `geonic --profile <name> auth login` resolves to the correct tenant automatically.
 
 ```text
 $ geonic auth login
 Email: user@example.com
 Password: ********
-Login successful. Token saved to config.
+Error: Multiple tenants are available for this account. Specify one with --tenant-id <id> or -s/--service <name>:
+  - my_city (tid-aaa) [tenant_admin]
+  - another_city (tid-bbb) [user]
 
-Available tenants:
-  * 1) my_city (tenant_admin) ← current
-    2) another_city (user)
-
-Select tenant number (Enter to keep current):
+$ geonic auth login --tenant-id tid-aaa
+Login successful (tenant: my_city). Token saved to config.
 ```
 
 #### OAuth Client Credentials

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -9,8 +9,8 @@ import {
 } from "../helpers.js";
 import { loadConfig, saveConfig, getCurrentProfile, validateUrl } from "../config.js";
 import { printSuccess, printError, printInfo, printWarning } from "../output.js";
-import { isInteractive, promptEmail, promptPassword, promptTenantSelection } from "../prompt.js";
-import type { TenantChoice } from "../prompt.js";
+import { isInteractive, promptEmail, promptPassword } from "../prompt.js";
+import type { TenantInfo } from "../types.js";
 import { getTokenStatus, formatDuration } from "../token.js";
 import { clientCredentialsGrant } from "../oauth.js";
 import { addExamples } from "./help.js";
@@ -119,12 +119,11 @@ function createLoginCommand(): Command {
           process.exit(1);
         }
 
-        // Handle multi-tenant: show available tenants and prompt for selection
-        const availableTenants = data.availableTenants as TenantChoice[] | undefined;
+        // Multi-tenant: require explicit tenant selection (no interactive prompt)
+        const availableTenants = data.availableTenants as TenantInfo[] | undefined;
         let finalTenantId = data.tenantId as string | undefined;
 
         if (availableTenants && availableTenants.length > 1 && !requestTenantId) {
-          // If --service was provided, resolve tenant by name or ID match
           let resolvedTenantId: string | undefined;
           if (serviceFlag) {
             const match = availableTenants.find(
@@ -141,11 +140,16 @@ function createLoginCommand(): Command {
           }
 
           if (!resolvedTenantId) {
-            resolvedTenantId = await promptTenantSelection(availableTenants, finalTenantId);
+            const list = availableTenants
+              .map((t) => `  - ${t.name ?? t.tenantId} (${t.tenantId}) [${t.role}]`)
+              .join("\n");
+            printError(
+              `Multiple tenants are available for this account. Specify one with --tenant-id <id> or -s/--service <name>:\n${list}`,
+            );
+            process.exit(1);
           }
 
-          if (resolvedTenantId && resolvedTenantId !== finalTenantId) {
-            // Re-login with selected tenant
+          if (resolvedTenantId !== finalTenantId) {
             const reloginResponse = await client.rawRequest("POST", "/auth/login", {
               body: { email, password, tenantId: resolvedTenantId },
               skipTenantHeader: true,

--- a/src/commands/profile.ts
+++ b/src/commands/profile.ts
@@ -98,10 +98,22 @@ export function registerProfileCommands(program: Command): void {
   const profileCreate = profile
     .command("create <name>")
     .description("Create a new named profile for a separate environment or tenant")
-    .action((name: string) => {
+    .option("--tenant <tenant>", "Bind this profile to a tenant ID or service name")
+    .action(function (this: Command, name: string) {
       try {
-        createProfile(name);
-        printSuccess(`Profile "${name}" created.`);
+        const localOpts = this.opts() as { tenant?: string };
+        const globalOpts = this.optsWithGlobals() as { url?: string };
+        const init: { service?: string; tenantId?: string; url?: string } = {};
+        if (globalOpts.url) {
+          init.url = validateUrl(globalOpts.url);
+        }
+        if (localOpts.tenant) {
+          init.service = localOpts.tenant;
+          init.tenantId = localOpts.tenant;
+        }
+        createProfile(name, init);
+        const tenantLabel = localOpts.tenant ? ` (tenant: ${localOpts.tenant})` : "";
+        printSuccess(`Profile "${name}" created${tenantLabel}.`);
       } catch (err) {
         printError((err as Error).message);
         process.exit(1);
@@ -114,8 +126,12 @@ export function registerProfileCommands(program: Command): void {
       command: "geonic profile create staging",
     },
     {
-      description: "Create a profile for a different tenant",
-      command: "geonic profile create tenant-b",
+      description: "Create a profile bound to a specific tenant",
+      command: "geonic profile create miya --tenant miya",
+    },
+    {
+      description: "Create a profile for a different tenant with its own URL",
+      command: "geonic profile create geolonia --tenant geolonia --url https://geonicdb.geolonia.com",
     },
   ]);
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -157,12 +157,12 @@ export function setCurrentProfile(name: string): void {
   saveConfigFile(configFile);
 }
 
-export function createProfile(name: string): void {
+export function createProfile(name: string, init?: Partial<GdbConfig>): void {
   const configFile = loadConfigFile();
   if (name in configFile.profiles) {
     throw new Error(`Profile "${name}" already exists.`);
   }
-  configFile.profiles[name] = {};
+  configFile.profiles[name] = { ...(init ?? {}) };
   saveConfigFile(configFile);
 }
 

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -95,37 +95,3 @@ export async function promptPassword(label = "Password"): Promise<string> {
   }
 }
 
-export interface TenantChoice {
-  tenantId: string;
-  name?: string;
-  role: string;
-}
-
-export async function promptTenantSelection(
-  tenants: TenantChoice[],
-  currentTenantId?: string,
-): Promise<string | undefined> {
-  const rl = createInterface({ input: process.stdin, output: process.stdout });
-  try {
-    console.log("\nAvailable tenants:");
-    for (let i = 0; i < tenants.length; i++) {
-      const t = tenants[i];
-      const current = t.tenantId === currentTenantId ? " ← current" : "";
-      const marker = t.tenantId === currentTenantId ? "  *" : "   ";
-      const label = t.name ? `${t.name} (${t.tenantId})` : t.tenantId;
-      console.log(`${marker} ${i + 1}) ${label} [${t.role}]${current}`);
-    }
-    for (;;) {
-      const answer = await rl.question("\nSelect tenant number (Enter to keep current): ");
-      const trimmed = answer.trim();
-      if (!trimmed) return undefined;
-      const index = parseInt(trimmed, 10) - 1;
-      if (index >= 0 && index < tenants.length) {
-        return tenants[index].tenantId;
-      }
-      console.log(`Invalid selection. Please enter a number between 1 and ${tenants.length}.`);
-    }
-  } finally {
-    rl.close();
-  }
-}

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -49,7 +49,6 @@ vi.mock("../src/prompt.js", () => ({
   isInteractive: vi.fn(),
   promptEmail: vi.fn(),
   promptPassword: vi.fn(),
-  promptTenantSelection: vi.fn(),
 }));
 
 vi.mock("../src/token.js", () => ({
@@ -64,7 +63,7 @@ vi.mock("../src/oauth.js", () => ({
 import { createClient, getFormat, outputResponse, resolveOptions } from "../src/helpers.js";
 import { printSuccess, printError, printInfo, printWarning } from "../src/output.js";
 import { loadConfig, saveConfig, getCurrentProfile, validateUrl } from "../src/config.js";
-import { isInteractive, promptEmail, promptPassword, promptTenantSelection } from "../src/prompt.js";
+import { isInteractive, promptEmail, promptPassword } from "../src/prompt.js";
 import { getTokenStatus, formatDuration } from "../src/token.js";
 import { clientCredentialsGrant } from "../src/oauth.js";
 import { registerAuthCommands } from "../src/commands/auth.js";
@@ -395,7 +394,7 @@ describe("auth commands", () => {
       vi.mocked(promptPassword).mockResolvedValue("pass123");
     });
 
-    it("shows tenant selection when availableTenants has multiple entries", async () => {
+    it("errors out when multiple tenants are available and none is specified", async () => {
       const tenants = [
         { tenantId: "city_a", role: "tenant_admin" },
         { tenantId: "city_b", role: "user" },
@@ -403,43 +402,26 @@ describe("auth commands", () => {
       client.rawRequest.mockResolvedValue(
         mockResponse({ accessToken: "tok", tenantId: "city_a", availableTenants: tenants }),
       );
-      vi.mocked(promptTenantSelection).mockResolvedValue(undefined);
       const program = makeProgram();
-      await runCommand(program, ["auth", "login"]);
-      expect(promptTenantSelection).toHaveBeenCalledWith(tenants, "city_a");
-      expect(saveConfig).toHaveBeenCalledWith(
-        expect.objectContaining({ token: "tok", service: "city_a" }),
-        "default",
+      await expect(
+        runCommand(program, ["auth", "login"]),
+      ).rejects.toThrow("process.exit");
+      expect(printError).toHaveBeenCalledWith(
+        expect.stringContaining("Multiple tenants are available"),
       );
+      // Lists available tenants in the error
+      expect(printError).toHaveBeenCalledWith(
+        expect.stringContaining("city_a"),
+      );
+      expect(printError).toHaveBeenCalledWith(
+        expect.stringContaining("city_b"),
+      );
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      // Must not save anything
+      expect(saveConfig).not.toHaveBeenCalled();
     });
 
-    it("re-logins with selected tenant when user picks a different one", async () => {
-      const tenants = [
-        { tenantId: "city_a", role: "tenant_admin" },
-        { tenantId: "city_b", role: "user" },
-      ];
-      client.rawRequest
-        .mockResolvedValueOnce(
-          mockResponse({ accessToken: "tok-a", tenantId: "city_a", availableTenants: tenants }),
-        )
-        .mockResolvedValueOnce(
-          mockResponse({ accessToken: "tok-b", refreshToken: "ref-b", tenantId: "city_b" }),
-        );
-      vi.mocked(promptTenantSelection).mockResolvedValue("city_b");
-      const program = makeProgram();
-      await runCommand(program, ["auth", "login"]);
-      expect(client.rawRequest).toHaveBeenCalledTimes(2);
-      expect(client.rawRequest).toHaveBeenLastCalledWith("POST", "/auth/login", {
-        body: { email: "user@example.com", password: "pass123", tenantId: "city_b" },
-        skipTenantHeader: true,
-      });
-      expect(saveConfig).toHaveBeenCalledWith(
-        expect.objectContaining({ token: "tok-b", refreshToken: "ref-b", service: "city_b" }),
-        "default",
-      );
-    });
-
-    it("skips tenant selection when --tenant-id is explicitly provided", async () => {
+    it("succeeds when --tenant-id is explicitly provided", async () => {
       const tenants = [
         { tenantId: "city_a", role: "tenant_admin" },
         { tenantId: "city_b", role: "user" },
@@ -449,68 +431,36 @@ describe("auth commands", () => {
       );
       const program = makeProgram();
       await runCommand(program, ["auth", "login", "--tenant-id", "city_a"]);
-      expect(promptTenantSelection).not.toHaveBeenCalled();
+      expect(client.rawRequest).toHaveBeenCalledWith("POST", "/auth/login", {
+        body: { email: "user@example.com", password: "pass123", tenantId: "city_a" },
+        skipTenantHeader: true,
+      });
+      expect(saveConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ token: "tok", service: "city_a" }),
+        "default",
+      );
     });
 
-    it("skips tenant selection when only one tenant is available", async () => {
+    it("succeeds without explicit tenant when only one tenant is available", async () => {
       const tenants = [{ tenantId: "city_a", role: "tenant_admin" }];
       client.rawRequest.mockResolvedValue(
         mockResponse({ accessToken: "tok", tenantId: "city_a", availableTenants: tenants }),
       );
       const program = makeProgram();
       await runCommand(program, ["auth", "login"]);
-      expect(promptTenantSelection).not.toHaveBeenCalled();
-    });
-
-    it("prints error and exits when re-login returns no token", async () => {
-      const tenants = [
-        { tenantId: "city_a", role: "tenant_admin" },
-        { tenantId: "city_b", role: "user" },
-      ];
-      client.rawRequest
-        .mockResolvedValueOnce(
-          mockResponse({ accessToken: "tok-a", tenantId: "city_a", availableTenants: tenants }),
-        )
-        .mockResolvedValueOnce(
-          mockResponse({ message: "ok" }), // no token
-        );
-      vi.mocked(promptTenantSelection).mockResolvedValue("city_b");
-      const program = makeProgram();
-      await expect(
-        runCommand(program, ["auth", "login"]),
-      ).rejects.toThrow("process.exit");
-      expect(printError).toHaveBeenCalledWith("Re-login failed: no token received for selected tenant.");
-      expect(exitSpy).toHaveBeenCalledWith(1);
-    });
-
-    it("keeps original token when user selects current tenant", async () => {
-      const tenants = [
-        { tenantId: "city_a", role: "tenant_admin" },
-        { tenantId: "city_b", role: "user" },
-      ];
-      client.rawRequest.mockResolvedValue(
-        mockResponse({ accessToken: "tok-a", tenantId: "city_a", availableTenants: tenants }),
-      );
-      vi.mocked(promptTenantSelection).mockResolvedValue("city_a");
-      const program = makeProgram();
-      await runCommand(program, ["auth", "login"]);
-      // Should not re-login since selectedTenantId === currentTenantId
-      expect(client.rawRequest).toHaveBeenCalledTimes(1);
       expect(saveConfig).toHaveBeenCalledWith(
-        expect.objectContaining({ token: "tok-a", service: "city_a" }),
+        expect.objectContaining({ token: "tok", service: "city_a" }),
         "default",
       );
     });
 
-    it("saves tenantId and availableTenants to config", async () => {
+    it("saves availableTenants list when login succeeds with one tenant", async () => {
       const tenants = [
         { tenantId: "city_a", name: "Smart City A", role: "tenant_admin" },
-        { tenantId: "city_b", role: "user" },
       ];
       client.rawRequest.mockResolvedValue(
         mockResponse({ accessToken: "tok", tenantId: "city_a", availableTenants: tenants }),
       );
-      vi.mocked(promptTenantSelection).mockResolvedValue(undefined);
       const program = makeProgram();
       await runCommand(program, ["auth", "login"]);
       expect(saveConfig).toHaveBeenCalledWith(
@@ -518,14 +468,13 @@ describe("auth commands", () => {
           tenantId: "city_a",
           availableTenants: [
             { tenantId: "city_a", name: "Smart City A", role: "tenant_admin" },
-            { tenantId: "city_b", role: "user" },
           ],
         }),
         "default",
       );
     });
 
-    it("resolves tenant by name via --service flag", async () => {
+    it("resolves tenant by name via --service flag and re-logins", async () => {
       const tenants = [
         { tenantId: "tid-aaa", name: "demo_smartcity", role: "tenant_admin" },
         { tenantId: "tid-bbb", name: "demo_bousai", role: "user" },
@@ -546,9 +495,6 @@ describe("auth commands", () => {
         );
       const program = makeProgram();
       await runCommand(program, ["auth", "login"]);
-      // Should NOT prompt — resolved by --service name
-      expect(promptTenantSelection).not.toHaveBeenCalled();
-      // Should re-login with resolved tenantId
       expect(client.rawRequest).toHaveBeenLastCalledWith("POST", "/auth/login", {
         body: { email: "user@example.com", password: "pass123", tenantId: "tid-bbb" },
         skipTenantHeader: true,
@@ -580,7 +526,6 @@ describe("auth commands", () => {
         );
       const program = makeProgram();
       await runCommand(program, ["auth", "login"]);
-      expect(promptTenantSelection).not.toHaveBeenCalled();
       expect(saveConfig).toHaveBeenCalledWith(
         expect.objectContaining({ token: "tok-b", service: "city_b" }),
         "default",
@@ -609,6 +554,33 @@ describe("auth commands", () => {
       expect(printError).toHaveBeenCalledWith(
         expect.stringContaining('Tenant "nonexistent" not found'),
       );
+    });
+
+    it("prints error and exits when re-login returns no token", async () => {
+      const tenants = [
+        { tenantId: "city_a", role: "tenant_admin" },
+        { tenantId: "city_b", role: "user" },
+      ];
+      vi.mocked(resolveOptions).mockReturnValue({
+        url: "http://localhost:3000",
+        profile: "default",
+        token: "test-token",
+        format: "json",
+        service: "city_b",
+      } as never);
+      client.rawRequest
+        .mockResolvedValueOnce(
+          mockResponse({ accessToken: "tok-a", tenantId: "city_a", availableTenants: tenants }),
+        )
+        .mockResolvedValueOnce(
+          mockResponse({ message: "ok" }), // no token
+        );
+      const program = makeProgram();
+      await expect(
+        runCommand(program, ["auth", "login"]),
+      ).rejects.toThrow("process.exit");
+      expect(printError).toHaveBeenCalledWith("Re-login failed: no token received for selected tenant.");
+      expect(exitSpy).toHaveBeenCalledWith(1);
     });
 
     it("includes tenant label in success message", async () => {

--- a/tests/commands-profile.test.ts
+++ b/tests/commands-profile.test.ts
@@ -44,6 +44,7 @@ import {
   deleteProfile,
   loadConfig,
   saveConfig,
+  validateUrl,
 } from "../src/config.js";
 import { printSuccess, printInfo, printError, printWarning } from "../src/output.js";
 import { getTokenStatus } from "../src/token.js";
@@ -208,11 +209,49 @@ describe("profile commands", () => {
   });
 
   describe("profile create", () => {
-    it("creates a new profile", async () => {
+    it("creates a new profile with no options", async () => {
       const program = makeProgram();
       await runCommand(program, ["profile", "create", "staging"]);
-      expect(createProfile).toHaveBeenCalledWith("staging");
+      expect(createProfile).toHaveBeenCalledWith("staging", {});
       expect(printSuccess).toHaveBeenCalledWith('Profile "staging" created.');
+    });
+
+    it("creates a profile bound to a tenant", async () => {
+      const program = makeProgram();
+      await runCommand(program, ["profile", "create", "miya", "--tenant", "miya"]);
+      expect(createProfile).toHaveBeenCalledWith("miya", {
+        service: "miya",
+        tenantId: "miya",
+      });
+      expect(printSuccess).toHaveBeenCalledWith('Profile "miya" created (tenant: miya).');
+    });
+
+    it("creates a profile with both tenant and url", async () => {
+      const program = makeProgram();
+      await runCommand(program, [
+        "profile", "create", "geolonia",
+        "--tenant", "geolonia",
+        "--url", "https://geonicdb.geolonia.com",
+      ]);
+      expect(createProfile).toHaveBeenCalledWith("geolonia", {
+        url: "https://geonicdb.geolonia.com/",
+        service: "geolonia",
+        tenantId: "geolonia",
+      });
+      expect(printSuccess).toHaveBeenCalledWith(
+        'Profile "geolonia" created (tenant: geolonia).',
+      );
+    });
+
+    it("creates a profile with only url", async () => {
+      const program = makeProgram();
+      await runCommand(program, [
+        "profile", "create", "staging",
+        "--url", "https://staging.example.com",
+      ]);
+      expect(createProfile).toHaveBeenCalledWith("staging", {
+        url: "https://staging.example.com/",
+      });
     });
 
     it("prints error and exits when profile already exists", async () => {
@@ -224,6 +263,32 @@ describe("profile commands", () => {
         runCommand(program, ["profile", "create", "existing"]),
       ).rejects.toThrow("process.exit");
       expect(printError).toHaveBeenCalledWith("Profile already exists");
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it("prints error and exits when --url is invalid", async () => {
+      vi.mocked(validateUrl).mockImplementationOnce(() => {
+        throw new Error('Invalid URL: "not-a-url".');
+      });
+      const program = makeProgram();
+      await expect(
+        runCommand(program, ["profile", "create", "bad", "--url", "not-a-url"]),
+      ).rejects.toThrow("process.exit");
+      expect(printError).toHaveBeenCalledWith(expect.stringContaining("Invalid URL"));
+      expect(createProfile).not.toHaveBeenCalled();
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it("prints error and exits when --tenant is given but profile already exists", async () => {
+      vi.mocked(createProfile).mockImplementation(() => {
+        throw new Error('Profile "miya" already exists.');
+      });
+      const program = makeProgram();
+      await expect(
+        runCommand(program, ["profile", "create", "miya", "--tenant", "miya"]),
+      ).rejects.toThrow("process.exit");
+      expect(printError).toHaveBeenCalledWith('Profile "miya" already exists.');
+      expect(printSuccess).not.toHaveBeenCalled();
       expect(exitSpy).toHaveBeenCalledWith(1);
     });
   });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -168,6 +168,13 @@ describe("config", () => {
       expect(() => createProfile("staging")).toThrow('Profile "staging" already exists.');
     });
 
+    it("creates a profile with initial values", () => {
+      createProfile("miya", { service: "miya", tenantId: "miya" });
+      const cfg = loadConfig("miya");
+      expect(cfg.service).toBe("miya");
+      expect(cfg.tenantId).toBe("miya");
+    });
+
     it("switches active profile", () => {
       createProfile("production");
       setCurrentProfile("production");

--- a/tests/me-password.test.ts
+++ b/tests/me-password.test.ts
@@ -59,7 +59,6 @@ vi.mock("../src/prompt.js", () => ({
   isInteractive: vi.fn().mockReturnValue(true),
   promptPassword: vi.fn(),
   promptEmail: vi.fn(),
-  promptTenantSelection: vi.fn(),
 }));
 
 import { createClient } from "../src/helpers.js";

--- a/tests/prompt.test.ts
+++ b/tests/prompt.test.ts
@@ -11,7 +11,7 @@ vi.mock("node:readline/promises", () => ({
   })),
 }));
 
-import { isInteractive, promptEmail, promptPassword, promptTenantSelection } from "../src/prompt.js";
+import { isInteractive, promptEmail, promptPassword } from "../src/prompt.js";
 
 describe("prompt", () => {
   const originalStdinIsTTY = process.stdin.isTTY;
@@ -277,107 +277,4 @@ describe("prompt", () => {
     });
   });
 
-  describe("promptTenantSelection", () => {
-    let consoleSpy: ReturnType<typeof vi.spyOn>;
-
-    beforeEach(() => {
-      consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    });
-
-    afterEach(() => {
-      consoleSpy.mockRestore();
-    });
-
-    it("returns selected tenant when user enters a valid number", async () => {
-      mockQuestion.mockResolvedValue("2");
-      const tenants = [
-        { tenantId: "city_a", role: "admin" },
-        { tenantId: "city_b", role: "user" },
-      ];
-      const result = await promptTenantSelection(tenants, "city_a");
-      expect(result).toBe("city_b");
-      expect(mockClose).toHaveBeenCalled();
-    });
-
-    it("returns undefined when user presses Enter without input", async () => {
-      mockQuestion.mockResolvedValue("");
-      const tenants = [
-        { tenantId: "city_a", role: "admin" },
-        { tenantId: "city_b", role: "user" },
-      ];
-      const result = await promptTenantSelection(tenants, "city_a");
-      expect(result).toBeUndefined();
-    });
-
-    it("returns undefined when user enters whitespace only", async () => {
-      mockQuestion.mockResolvedValue("   ");
-      const tenants = [{ tenantId: "city_a", role: "admin" }];
-      const result = await promptTenantSelection(tenants);
-      expect(result).toBeUndefined();
-    });
-
-    it("re-prompts on out-of-range number then accepts valid input", async () => {
-      mockQuestion
-        .mockResolvedValueOnce("99")
-        .mockResolvedValueOnce("1");
-      const tenants = [
-        { tenantId: "city_a", role: "admin" },
-        { tenantId: "city_b", role: "user" },
-      ];
-      const result = await promptTenantSelection(tenants, "city_a");
-      expect(result).toBe("city_a");
-      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("Invalid selection"));
-      expect(mockQuestion).toHaveBeenCalledTimes(2);
-    });
-
-    it("re-prompts on zero then accepts valid input", async () => {
-      mockQuestion
-        .mockResolvedValueOnce("0")
-        .mockResolvedValueOnce("1");
-      const tenants = [{ tenantId: "city_a", role: "admin" }];
-      const result = await promptTenantSelection(tenants);
-      expect(result).toBe("city_a");
-      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("Invalid selection"));
-    });
-
-    it("re-prompts on negative number then accepts Enter to keep current", async () => {
-      mockQuestion
-        .mockResolvedValueOnce("-1")
-        .mockResolvedValueOnce("");
-      const tenants = [{ tenantId: "city_a", role: "admin" }];
-      const result = await promptTenantSelection(tenants);
-      expect(result).toBeUndefined();
-      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("Invalid selection"));
-    });
-
-    it("displays current tenant marker", async () => {
-      mockQuestion.mockResolvedValue("");
-      const tenants = [
-        { tenantId: "city_a", role: "admin" },
-        { tenantId: "city_b", role: "user" },
-      ];
-      await promptTenantSelection(tenants, "city_a");
-      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("← current"));
-      expect(consoleSpy).toHaveBeenCalledWith(expect.stringMatching(/\*.*city_a/));
-    });
-
-    it("displays tenants without current marker when currentTenantId is not provided", async () => {
-      mockQuestion.mockResolvedValue("");
-      const tenants = [
-        { tenantId: "city_a", role: "admin" },
-        { tenantId: "city_b", role: "user" },
-      ];
-      await promptTenantSelection(tenants);
-      // No "← current" marker should appear
-      const calls = consoleSpy.mock.calls.flat().join("\n");
-      expect(calls).not.toContain("← current");
-    });
-
-    it("closes readline even when question throws", async () => {
-      mockQuestion.mockRejectedValue(new Error("readline error"));
-      const tenants = [{ tenantId: "city_a", role: "admin" }];
-      await expect(promptTenantSelection(tenants)).rejects.toThrow("readline error");
-      expect(mockClose).toHaveBeenCalled();
-    });
-  });
 });


### PR DESCRIPTION
## Summary

Adopt a one-profile-per-tenant model so the same account (e.g. `miya@geolonia.com`, who is admin of both `miya` and `geolonia` tenants) can switch tenants with `geonic profile use <name>` instead of re-logging in.

- **Feat**: `profile create <name>` now accepts `--tenant <id|name>` (and reuses the global `--url`). The tenant value is stored as both `service` and `tenantId` on the profile, so subsequent `auth login` calls resolve to that tenant automatically.
  ```bash
  geonic profile create miya --tenant miya
  geonic profile create geolonia --tenant geolonia
  geonic profile use miya       # operate as miya tenant
  geonic profile use geolonia   # operate as geolonia tenant
  ```
- **Breaking**: `auth login` no longer prompts interactively when the account belongs to multiple tenants. The user must specify `--tenant-id` or `-s/--service`. If neither is provided, the command lists the available tenants and exits with status 1. A tenant bound on the active profile is honored without further flags.
- **Refactor**: Drop `promptTenantSelection` / `TenantChoice` from `src/prompt.ts`; `src/commands/auth.ts` now references `TenantInfo` from `types.ts` so the tenant shape lives in one place.

README and CHANGELOG are updated to match.

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` — 734 tests pass (profile +5 new cases, auth multi-tenant rewritten)
- [x] `npm run build`
- [x] Manual smoke test:
  - `profile create miya --tenant miya` / `profile create geolonia --tenant geolonia --url https://geonicdb.geolonia.com` produce two distinct, tenant-bound profiles
  - `profile use miya` / `profile use geolonia` swap the active tenant; `profile show` reflects the binding
- [ ] Reviewer: confirm whether existing CI users relying on the interactive prompt need a migration note beyond CHANGELOG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * `profile create` に `--tenant` と `--url` オプションを追加し、作成時にテナント/URLを設定可能に。

* **動作変更**
  * `auth login` のマルチテナント挙動を変更。複数テナント時は対話式選択を廃止し、`--tenant-id` または `--service` の明示指定が必須（未指定時はエラー）。

* **ドキュメント**
  * README を更新し、マルチテナントの利用方法、オプションとワークフロー例を追記。

* **テスト**
  * マルチテナント関連のテストを更新・追加。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/geolonia/geonicdb-cli/pull/123)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->