### PR TITLE
fix(cli): direct users to `geonic cli update` and suppress redundant notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@
 ## [Unreleased]
 
 ### 2026-05-13
-- **Fix**: アップデート通知のメッセージを `npm i -g @geolonia/geonicdb-cli` から `geonic cli update` に変更 — CLI 内蔵のアップデートコマンドを案内するように
-- **Fix**: `geonic cli update` 実行後に同セッション末尾でアップデート通知が再表示される問題を修正 — `update` コマンド成功時に通知出力を抑制
+- **Fix**: アップデート通知のメッセージを `npm i -g @geolonia/geonicdb-cli` から `geonic cli update` に変更 — CLI 内蔵のアップデートコマンドを案内するように (#124)
+- **Fix**: `geonic cli update` 実行後に同セッション末尾でアップデート通知が再表示される問題を修正 — `update` コマンド成功時に通知出力を抑制 (#124)
 - **Feat**: `profile create` に `--tenant <tenant>` オプションを追加 — プロファイル作成時にテナント ID/名を初期値として束縛できるように。`--url` (グローバルフラグ) と組み合わせて、同じアカウントの別テナントごとに独立したプロファイルを一度に生成可能 (例: `geonic profile create miya --tenant miya` / `geonic profile create geolonia --tenant geolonia`) (#123)
 - **Breaking**: `auth login` の複数テナント所属時の挙動を変更 — 対話プロンプトによるテナント選択を廃止し、`--tenant-id` または `-s/--service` の明示指定を必須化。未指定で複数所属を検出した場合は利用可能テナント一覧を表示してエラー終了する。プロファイル設定で `service`/`tenantId` を保持していれば自動解決される (#123)
 - **Refactor**: `src/prompt.ts` から `promptTenantSelection` / `TenantChoice` を削除。`src/commands/auth.ts` は `types.ts` の `TenantInfo` を参照するように統一 (#123)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 ## [Unreleased]
 
 ### 2026-05-13
+- **Fix**: アップデート通知のメッセージを `npm i -g @geolonia/geonicdb-cli` から `geonic cli update` に変更 — CLI 内蔵のアップデートコマンドを案内するように
+- **Fix**: `geonic cli update` 実行後に同セッション末尾でアップデート通知が再表示される問題を修正 — `update` コマンド成功時に通知出力を抑制
 - **Feat**: `profile create` に `--tenant <tenant>` オプションを追加 — プロファイル作成時にテナント ID/名を初期値として束縛できるように。`--url` (グローバルフラグ) と組み合わせて、同じアカウントの別テナントごとに独立したプロファイルを一度に生成可能 (例: `geonic profile create miya --tenant miya` / `geonic profile create geolonia --tenant geolonia`) (#123)
 - **Breaking**: `auth login` の複数テナント所属時の挙動を変更 — 対話プロンプトによるテナント選択を廃止し、`--tenant-id` または `-s/--service` の明示指定を必須化。未指定で複数所属を検出した場合は利用可能テナント一覧を表示してエラー終了する。プロファイル設定で `service`/`tenantId` を保持していれば自動解決される (#123)
 - **Refactor**: `src/prompt.ts` から `promptTenantSelection` / `TenantChoice` を削除。`src/commands/auth.ts` は `types.ts` の `TenantInfo` を参照するように統一 (#123)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolonia/geonicdb-cli",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolonia/geonicdb-cli",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/src/commands/cli.ts
+++ b/src/commands/cli.ts
@@ -3,6 +3,7 @@ import { createRequire } from "node:module";
 import type { Command, Option } from "commander";
 import { printInfo, printSuccess } from "../output.js";
 import { withErrorHandler, resolveOptions } from "../helpers.js";
+import { suppressUpdateNotification } from "../update-notifier.js";
 import { addExamples } from "./help.js";
 
 function findOption(
@@ -297,6 +298,7 @@ export function registerCliCommand(program: Command): void {
         }
         printInfo("Updating @geolonia/geonicdb-cli...");
         execSync(updateCommand, { stdio: "inherit" });
+        suppressUpdateNotification();
         printSuccess("Update complete.");
       }),
     );

--- a/src/update-notifier.ts
+++ b/src/update-notifier.ts
@@ -96,7 +96,7 @@ function getCurrentVersion(): string {
 
 export function formatUpdateBox(current: string, latest: string): string {
   const message = `Update available: ${current} → ${latest}`;
-  const install = `Run ${chalk.cyan(`npm i -g ${PACKAGE_NAME}`)} to update`;
+  const install = `Run ${chalk.cyan(`geonic cli update`)} to update`;
   const lines = [message, install];
   const maxLen = Math.max(
     ...lines.map((l) => stripAnsi(l).length),
@@ -162,7 +162,14 @@ export async function startUpdateCheck(): Promise<UpdateCheckResult | null> {
   return null;
 }
 
+let notificationSuppressed = false;
+
+export function suppressUpdateNotification(): void {
+  notificationSuppressed = true;
+}
+
 export function printUpdateNotification(result: UpdateCheckResult | null): void {
+  if (notificationSuppressed) return;
   if (!result) return;
   const box = formatUpdateBox(result.currentVersion, result.latestVersion);
   process.stderr.write("\n" + box + "\n");

--- a/tests/update-notifier.test.ts
+++ b/tests/update-notifier.test.ts
@@ -125,7 +125,7 @@ describe("formatUpdateBox", () => {
     expect(box).toContain("0.1.0");
     expect(box).toContain("1.0.0");
     expect(box).toContain("Update available");
-    expect(box).toContain("npm i -g @geolonia/geonicdb-cli");
+    expect(box).toContain("geonic cli update");
     expect(box).toContain("╭");
     expect(box).toContain("╰");
   });
@@ -419,9 +419,13 @@ describe("startUpdateCheck", () => {
 
 describe("printUpdateNotification", () => {
   let printUpdateNotification: typeof import("../src/update-notifier.js").printUpdateNotification;
+  let suppressUpdateNotification: typeof import("../src/update-notifier.js").suppressUpdateNotification;
 
   beforeEach(async () => {
-    ({ printUpdateNotification } = await import("../src/update-notifier.js"));
+    vi.resetModules();
+    ({ printUpdateNotification, suppressUpdateNotification } = await import(
+      "../src/update-notifier.js"
+    ));
   });
 
   it("writes box to stderr when result is provided", () => {
@@ -453,6 +457,13 @@ describe("printUpdateNotification", () => {
   it("does nothing when result is null", () => {
     const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
     printUpdateNotification(null);
+    expect(writeSpy).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when suppressed", () => {
+    const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    suppressUpdateNotification();
+    printUpdateNotification({ currentVersion: "0.1.0", latestVersion: "1.0.0" });
     expect(writeSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- **アップデート通知の案内文を変更**: `npm i -g @geolonia/geonicdb-cli` から `geonic cli update` に変更し、CLI 内蔵の更新コマンドへ誘導
- **アップデート実行後の通知重複を解消**: `geonic cli update` 実行後に同じプロセス末尾で通知ボックスが再表示される問題を修正

## 背景

`src/index.ts` は `startUpdateCheck()` を `parseAsync()` と並列で実行し、コマンド完了後に `printUpdateNotification()` を呼ぶ構造。
`geonic cli update` を実行した場合、`startUpdateCheck()` は事前にキャッシュ or fetch で `updateResult` を取得済みで、`npm update -g` 完了後にコマンドが終了 → そのまま通知ボックスが表示される、という流れになっていた。

## 設計

- `update-notifier.ts` にモジュールスコープの抑制フラグを追加し、`suppressUpdateNotification()` で立てる
- `geonic cli update` の action 内で `execSync` 成功直後に `suppressUpdateNotification()` を呼ぶ
- キャッシュファイルは触らない方針 — 新バイナリの `currentVersion` で次回起動時の `compareSemver` が自然に `false` になるため、通常チェックには干渉しない

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — 735 passed
  - `formatUpdateBox` のメッセージ assertion を `geonic cli update` に更新
  - `printUpdateNotification` の抑制ケースを追加
- [x] `npm run build` — success
- [ ] 手元で `geonic cli update` を実行し、通知が再表示されないことを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 更新完了後に通知が再度表示される問題を修正しました
  * 更新通知メッセージを「`npm i -g @geolonia/geonicdb-cli`」から「`geonic cli update`」に変更しました

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/geolonia/geonicdb-cli/pull/124)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->