### PR TITLE
release: v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-05-14
+
 ### 2026-05-13
 - **Fix**: アップデート通知のメッセージを `npm i -g @geolonia/geonicdb-cli` から `geonic cli update` に変更 — CLI 内蔵のアップデートコマンドを案内するように (#124)
 - **Fix**: `geonic cli update` 実行後に同セッション末尾でアップデート通知が再表示される問題を修正 — `update` コマンド成功時に通知出力を抑制 (#124)
@@ -234,7 +236,8 @@
 ### 2026-02-26
 - **Docs**: README にインストール手順・使い方・コマンドリファレンスを追加 (#1)
 
-[Unreleased]: https://github.com/geolonia/geonicdb-cli/compare/v0.15.1...HEAD
+[Unreleased]: https://github.com/geolonia/geonicdb-cli/compare/v0.16.0...HEAD
+[0.16.0]: https://github.com/geolonia/geonicdb-cli/compare/v0.15.1...v0.16.0
 [0.15.1]: https://github.com/geolonia/geonicdb-cli/compare/v0.15.0...v0.15.1
 [0.15.0]: https://github.com/geolonia/geonicdb-cli/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/geolonia/geonicdb-cli/compare/v0.13.0...v0.14.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolonia/geonicdb-cli",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolonia/geonicdb-cli",
-      "version": "0.15.1",
+      "version": "0.16.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolonia/geonicdb-cli",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "description": "A CLI client for the GeonicDB",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- version bump: 0.15.1 → 0.16.0
- CHANGELOG: Unreleased → 0.16.0 セクション化、比較リンク追加

## Included since v0.15.1

### 2026-05-13
- **Fix**: アップデート通知のメッセージを `npm i -g @geolonia/geonicdb-cli` から `geonic cli update` に変更 — CLI 内蔵のアップデートコマンドを案内するように (#124)
- **Fix**: `geonic cli update` 実行後に同セッション末尾でアップデート通知が再表示される問題を修正 — `update` コマンド成功時に通知出力を抑制 (#124)
- **Feat**: `profile create` に `--tenant <tenant>` オプションを追加 — プロファイル作成時にテナント ID/名を初期値として束縛できるように (#123)
- **Breaking**: `auth login` の複数テナント所属時の挙動を変更 — 対話プロンプトによるテナント選択を廃止し、`--tenant-id` または `-s/--service` の明示指定を必須化。未指定で複数所属を検出した場合は利用可能テナント一覧を表示してエラー終了する (#123)
- **Refactor**: `src/prompt.ts` から `promptTenantSelection` / `TenantChoice` を削除。`src/commands/auth.ts` は `types.ts` の `TenantInfo` を参照するように統一 (#123)

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (735 tests passed)
- [x] `npm run build`
- [ ] CI (lint / typecheck / test / build / e2e) green
- [ ] After merge: `git tag v0.16.0 && git push origin v0.16.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * バージョン 0.16.0 をリリースしました。チェンジログとパッケージバージョン情報を更新しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/geolonia/geonicdb-cli/pull/125)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->