### PR TITLE
fix(auth): persist --url to profile when saving auth credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@
 ## [Unreleased]
 
 ### 2026-05-14
-- **Fix**: `auth login` / `auth login --client-credentials` / `auth token-exchange --save` で `--url <URL>` を渡してログインしても URL がプロファイルに永続化されず、後続コマンドで `No URL configured` エラーになっていた問題を修正。トークン保存時に URL も一緒に保存するように。空のプロファイルに切り替えてからログインするフロー (`profile create miya` → `profile use miya` → `auth login --url <URL>` → `me`) で発生していた (#PR)
-- **Fix**: `me oauth-clients create`、`me api-keys create`、`admin api-keys create/refresh` で `--url` 渡し時に同様の URL 永続化漏れがあった箇所も合わせて修正 (#PR)
-- **Test**: `auth login` の URL 永続化を直接検証する回帰防止テストを追加 (#PR)
+- **Fix**: `auth login` / `auth login --client-credentials` / `auth token-exchange --save` で `--url <URL>` を渡してログインしても URL がプロファイルに永続化されず、後続コマンドで `No URL configured` エラーになっていた問題を修正。トークン保存時に URL も一緒に保存するように。空のプロファイルに切り替えてからログインするフロー (`profile create miya` → `profile use miya` → `auth login --url <URL>` → `me`) で発生していた (#126)
+- **Fix**: `me oauth-clients create`、`me api-keys create`、`admin api-keys create/refresh` で `--url` 渡し時に同様の URL 永続化漏れがあった箇所も合わせて修正 (#126)
+- **Test**: `auth login` の URL 永続化を直接検証する回帰防止テストを追加 (#126)
 
 ## [0.16.0] - 2026-05-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 
 ## [Unreleased]
 
+### 2026-05-14
+- **Fix**: `auth login` / `auth login --client-credentials` / `auth token-exchange --save` で `--url <URL>` を渡してログインしても URL がプロファイルに永続化されず、後続コマンドで `No URL configured` エラーになっていた問題を修正。トークン保存時に URL も一緒に保存するように。空のプロファイルに切り替えてからログインするフロー (`profile create miya` → `profile use miya` → `auth login --url <URL>` → `me`) で発生していた (#PR)
+- **Fix**: `me oauth-clients create`、`me api-keys create`、`admin api-keys create/refresh` で `--url` 渡し時に同様の URL 永続化漏れがあった箇所も合わせて修正 (#PR)
+- **Test**: `auth login` の URL 永続化を直接検証する回帰防止テストを追加 (#PR)
+
 ## [0.16.0] - 2026-05-14
 
 ### 2026-05-13

--- a/src/commands/admin/api-keys.ts
+++ b/src/commands/admin/api-keys.ts
@@ -1,6 +1,6 @@
 import type { Command } from "commander";
 import { withErrorHandler, createClient, resolveOptions, getFormat, outputResponse, parseNonNegativeInt, buildPaginationParams } from "../../helpers.js";
-import { loadConfig, saveConfig } from "../../config.js";
+import { loadConfig, saveConfig, validateUrl } from "../../config.js";
 import { parseJsonInput } from "../../input.js";
 import { printApiKeyBox, printError } from "../../output.js";
 import { addExamples, addNotes } from "../help.js";
@@ -70,6 +70,7 @@ function handleSaveKey(
   }
   try {
     const config = loadConfig(globalOpts.profile);
+    if (globalOpts.url) config.url = validateUrl(globalOpts.url);
     config.apiKey = key;
     saveConfig(config, globalOpts.profile);
     console.error("API key saved to config. X-Api-Key header will be sent automatically.");

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -63,6 +63,7 @@ function createLoginCommand(): Command {
           });
 
           const config = loadConfig(globalOpts.profile);
+          config.url = validateUrl(globalOpts.url);
           config.token = result.access_token;
           delete config.refreshToken;
           saveConfig(config, globalOpts.profile);
@@ -167,6 +168,7 @@ function createLoginCommand(): Command {
         }
 
         const config = loadConfig(globalOpts.profile);
+        config.url = validateUrl(globalOpts.url);
         config.token = token;
         if (refreshToken) {
           config.refreshToken = refreshToken;
@@ -408,6 +410,7 @@ function createTokenExchangeCommand(): Command {
 
         if (exchangeOpts.save) {
           const config = loadConfig(globalOpts.profile);
+          config.url = baseUrl;
           config.token = tokenData.access_token;
           saveConfig(config, globalOpts.profile);
           printSuccess("Token exchange successful. Token saved to config.");

--- a/src/commands/me-api-keys.ts
+++ b/src/commands/me-api-keys.ts
@@ -1,6 +1,6 @@
 import type { Command } from "commander";
 import { withErrorHandler, createClient, resolveOptions, getFormat, outputResponse, parseNonNegativeInt, buildPaginationParams } from "../helpers.js";
-import { loadConfig, saveConfig } from "../config.js";
+import { loadConfig, saveConfig, validateUrl } from "../config.js";
 import { parseJsonInput } from "../input.js";
 import { printApiKeyBox, printError } from "../output.js";
 import { addExamples, addNotes } from "./help.js";
@@ -28,6 +28,7 @@ function handleSaveKey(
   }
   try {
     const config = loadConfig(globalOpts.profile);
+    if (globalOpts.url) config.url = validateUrl(globalOpts.url);
     config.apiKey = key;
     saveConfig(config, globalOpts.profile);
     console.error("API key saved to config. X-Api-Key header will be sent automatically.");

--- a/src/commands/me-oauth-clients.ts
+++ b/src/commands/me-oauth-clients.ts
@@ -99,6 +99,7 @@ export function addMeOAuthClientsSubcommand(me: Command): void {
           });
 
           const config = loadConfig(globalOpts.profile);
+          config.url = baseUrl;
           config.clientId = clientId;
           config.clientSecret = clientSecret;
           config.token = tokenResult.access_token;

--- a/tests/admin-api-keys.test.ts
+++ b/tests/admin-api-keys.test.ts
@@ -42,6 +42,7 @@ vi.mock("../src/commands/help.js", () => ({
 vi.mock("../src/config.js", () => ({
   loadConfig: vi.fn().mockImplementation(() => ({})),
   saveConfig: vi.fn(),
+  validateUrl: vi.fn((url: string) => url.replace(/\/+$/, "") + "/"),
 }));
 
 import { createClient, getFormat, outputResponse, resolveOptions } from "../src/helpers.js";

--- a/tests/admin-api-keys.test.ts
+++ b/tests/admin-api-keys.test.ts
@@ -273,7 +273,7 @@ describe("admin api-keys commands", () => {
         ]);
 
         expect(saveConfig).toHaveBeenCalledWith(
-          expect.objectContaining({ apiKey: "gdb_saved123" }),
+          expect.objectContaining({ apiKey: "gdb_saved123", url: "https://example.com/" }),
           "default",
         );
         expect(consoleSpy).toHaveBeenCalledWith(
@@ -571,7 +571,7 @@ describe("admin api-keys commands", () => {
       ]);
 
       expect(saveConfig).toHaveBeenCalledWith(
-        expect.objectContaining({ apiKey: "gdb_refreshed" }),
+        expect.objectContaining({ apiKey: "gdb_refreshed", url: "https://example.com/" }),
         "default",
       );
       expect(consoleSpy).toHaveBeenCalledWith(

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -122,7 +122,7 @@ describe("auth commands", () => {
         scope: undefined,
       });
       expect(saveConfig).toHaveBeenCalledWith(
-        expect.objectContaining({ token: "oauth-token-123" }),
+        expect.objectContaining({ token: "oauth-token-123", url: "http://localhost:3000/" }),
         "default",
       );
       expect(printSuccess).toHaveBeenCalledWith(expect.stringContaining("Login successful"));
@@ -309,7 +309,7 @@ describe("auth commands", () => {
       const program = makeProgram();
       await runCommand(program, ["auth", "login"]);
       expect(saveConfig).toHaveBeenCalledWith(
-        expect.objectContaining({ token: "tok", refreshToken: "ref" }),
+        expect.objectContaining({ token: "tok", refreshToken: "ref", url: "http://localhost:3000/" }),
         "default",
       );
     });
@@ -384,6 +384,35 @@ describe("auth commands", () => {
         expect.objectContaining({ token: "legacy-token" }),
         "default",
       );
+    });
+
+    // Regression: logging in with --url against an empty profile must persist the
+    // URL alongside the token. Previously the URL was used only for the in-flight
+    // request and discarded, leaving the profile in a state where subsequent
+    // commands failed with "No URL configured".
+    it("persists --url to the profile on successful login (regression)", async () => {
+      vi.mocked(loadConfig).mockReturnValue({});
+      vi.mocked(resolveOptions).mockReturnValue({
+        url: "https://geonicdb.geolonia.com",
+        profile: "miya",
+        format: "json",
+      } as never);
+      vi.mocked(isInteractive).mockReturnValue(true);
+      vi.mocked(promptEmail).mockResolvedValue("miya@geolonia.com");
+      vi.mocked(promptPassword).mockResolvedValue("password1234");
+      client.rawRequest.mockResolvedValue(mockResponse({ accessToken: "tok" }));
+
+      const program = makeProgram();
+      await runCommand(program, [
+        "auth", "login",
+        "--url", "https://geonicdb.geolonia.com",
+      ]);
+
+      const savedConfig = vi.mocked(saveConfig).mock.calls[0][0] as Record<string, unknown>;
+      const savedProfile = vi.mocked(saveConfig).mock.calls[0][1];
+      expect(savedConfig.url).toBe("https://geonicdb.geolonia.com/");
+      expect(savedConfig.token).toBe("tok");
+      expect(savedProfile).toBe("miya");
     });
   });
 
@@ -915,7 +944,7 @@ describe("auth commands", () => {
       const program = makeProgram();
       await runCommand(program, ["auth", "token-exchange", "--save"]);
       expect(saveConfig).toHaveBeenCalledWith(
-        expect.objectContaining({ token: "saved-jwt" }),
+        expect.objectContaining({ token: "saved-jwt", url: "http://localhost:3000/" }),
         "default",
       );
       expect(printSuccess).toHaveBeenCalledWith("Token exchange successful. Token saved to config.");

--- a/tests/me-api-keys.test.ts
+++ b/tests/me-api-keys.test.ts
@@ -239,7 +239,7 @@ describe("me api-keys commands", () => {
         ]);
 
         expect(saveConfig).toHaveBeenCalledWith(
-          expect.objectContaining({ apiKey: "gdb_saved123" }),
+          expect.objectContaining({ apiKey: "gdb_saved123", url: "https://example.com/" }),
           "default",
         );
         expect(consoleSpy).toHaveBeenCalledWith(
@@ -609,7 +609,7 @@ describe("me api-keys commands", () => {
       ]);
 
       expect(saveConfig).toHaveBeenCalledWith(
-        expect.objectContaining({ apiKey: "gdb_refreshed" }),
+        expect.objectContaining({ apiKey: "gdb_refreshed", url: "https://example.com/" }),
         "default",
       );
       expect(consoleSpy).toHaveBeenCalledWith(

--- a/tests/me-oauth-clients.test.ts
+++ b/tests/me-oauth-clients.test.ts
@@ -188,6 +188,7 @@ describe("me oauth-clients commands", () => {
             clientId: "c4",
             clientSecret: "s3cret",
             token: "new-token",
+            url: "https://example.com/",
           }),
           "default",
         );


### PR DESCRIPTION
## Summary

`geonic auth login --url <URL>` でログインに成功してもトークンしか保存されず、URL がプロファイルから抜け落ちる不具合を修正。空のプロファイルにログインしたあと、後続コマンドが軒並み `Error: No URL configured` で失敗していた。

### 再現手順 (修正前)

```bash
geonic profile create miya --tenant <id>
geonic profile use miya
geonic auth login --url https://geonicdb.geolonia.com --tenant-id <id>
# => Login successful. Token saved to config.

geonic me
# => Error: No URL configured. Use ``geonic config set url <url>`` or pass --url.
```

config.json を覗くと token/refreshToken は入っているのに url フィールドだけ無いという状態になっていた。

### 原因

`auth login` (および類似コマンド) は `globalOpts.url` を **リクエスト時にだけ** 使い、`saveConfig()` に渡す `config` オブジェクトには URL を含めていなかった。`--url` フラグは永続化されない設計だったため、空プロファイル + フラグ指定でログインすると URL が config に残らない。

### 修正対象

URL を一緒に保存するように修正:

- `src/commands/auth.ts`
  - `auth login` (email/password)
  - `auth login --client-credentials`
  - `auth token-exchange --save`
- `src/commands/me-oauth-clients.ts` — `me oauth-clients create` の自動 token 取得経路
- `src/commands/me-api-keys.ts` — `me api-keys create`
- `src/commands/admin/api-keys.ts` — `admin api-keys create` / `admin api-keys refresh`

後者3つは通常すでに URL 設定済みのプロファイルから呼ばれるため発覚しにくいが、`--url` フラグでオーバーライドした場合の整合性のため同様に対応 (`globalOpts.url` がある場合のみ上書き)。

### 再発防止

`tests/auth.test.ts` に「空プロファイル + `--url` ログイン → saveConfig に URL が含まれる」を直接検証する回帰防止テストを追加。既存テストの assertion にも URL チェックを追加。

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test` (736 件全 pass、新規 regression テスト 1 件含む)
- [ ] 実機で `profile create new → profile use new → auth login --url ... → me` が成功すること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * `--url` オプション指定時にプロファイルへの URL 永続化が正しく行われていなかった不具合を修正（`auth login`、`auth token-exchange --save`、`me oauth-clients create`、`me api-keys create`、`admin api-keys create/refresh` が対象）

* **Tests**
  * URL 永続化を検証する回帰テストを追加

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/geolonia/geonicdb-cli/pull/126)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->