### PR TITLE
release: v0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## [Unreleased]
 
+## [0.16.1] - 2026-05-15
+
 ### 2026-05-14
 - **Fix**: `auth login` / `auth login --client-credentials` / `auth token-exchange --save` で `--url <URL>` を渡してログインしても URL がプロファイルに永続化されず、後続コマンドで `No URL configured` エラーになっていた問題を修正。トークン保存時に URL も一緒に保存するように。空のプロファイルに切り替えてからログインするフロー (`profile create miya` → `profile use miya` → `auth login --url <URL>` → `me`) で発生していた (#126)
 - **Fix**: `me oauth-clients create`、`me api-keys create`、`admin api-keys create/refresh` で `--url` 渡し時に同様の URL 永続化漏れがあった箇所も合わせて修正 (#126)
@@ -241,7 +243,8 @@
 ### 2026-02-26
 - **Docs**: README にインストール手順・使い方・コマンドリファレンスを追加 (#1)
 
-[Unreleased]: https://github.com/geolonia/geonicdb-cli/compare/v0.16.0...HEAD
+[Unreleased]: https://github.com/geolonia/geonicdb-cli/compare/v0.16.1...HEAD
+[0.16.1]: https://github.com/geolonia/geonicdb-cli/compare/v0.16.0...v0.16.1
 [0.16.0]: https://github.com/geolonia/geonicdb-cli/compare/v0.15.1...v0.16.0
 [0.15.1]: https://github.com/geolonia/geonicdb-cli/compare/v0.15.0...v0.15.1
 [0.15.0]: https://github.com/geolonia/geonicdb-cli/compare/v0.14.0...v0.15.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolonia/geonicdb-cli",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolonia/geonicdb-cli",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolonia/geonicdb-cli",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "A CLI client for the GeonicDB",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

v0.16.1 リリース。

### Fix
- `auth login` / `auth login --client-credentials` / `auth token-exchange --save` で `--url <URL>` を渡してログインしても URL がプロファイルに永続化されない問題を修正 (#126)
- `me oauth-clients create`、`me api-keys create`、`admin api-keys create/refresh` の `--url` 永続化漏れも合わせて修正 (#126)

### Test
- `auth login` の URL 永続化を直接検証する回帰防止テストを追加 (#126)

詳細は [CHANGELOG.md](./CHANGELOG.md) 参照。

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (736 件 pass)
- [x] `npm run build`
- [ ] マージ後、`v0.16.1` タグを main に push して publish.yml で npm に公開

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * バージョンを0.16.1へ更新しました。
  * リリース情報の記録を整備しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/geolonia/geonicdb-cli/pull/127)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->