### PR TITLE
fix(entities): replace で PUT を /entities/{id} に送る (NGSI-LD 5.6.4 準拠) (#128)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## [Unreleased]
 
+### 2026-05-31
+- **Fix**: `entities replace` が PUT を `/ngsi-ld/v1/entities/{id}/attrs` に送ってサーバーの `MethodNotAllowed` で常に失敗していた問題を修正。NGSI-LD 仕様 (ETSI GS CIM 009 clause 5.6.4 Replace Entity) に従い、PUT を `/ngsi-ld/v1/entities/{id}` に送るよう変更。`@wip` でスキップしていた E2E シナリオを有効化 (#128)
+
 ## [0.16.1] - 2026-05-15
 
 ### 2026-05-14

--- a/src/commands/entities.ts
+++ b/src/commands/entities.ts
@@ -293,8 +293,12 @@ export function registerEntitiesCommand(program: Command): void {
     .summary("Replace all attributes of an entity (PUT)")
     .description(
       "Replace all attributes of an entity (PUT)\n\n" +
-        "JSON payload: all existing attributes are replaced.\n" +
-        '  e.g. {"temperature": {"type": "Property", "value": 20}}',
+        "JSON payload: a full NGSI-LD Entity Representation (id, type, attributes).\n" +
+        "  e.g. {\"id\":\"urn:ngsi-ld:Sensor:001\",\"type\":\"Sensor\"," +
+        '"temperature":{"type":"Property","value":20}}\n\n' +
+        "Per NGSI-LD spec 5.6.4 (Replace Entity), the body should be a complete\n" +
+        "Entity Representation. Server may accept attribute-only bodies but a full\n" +
+        "representation is recommended for spec compliance.",
     )
     .argument("<id>", "Entity ID")
     .argument("[json]", "JSON payload (inline, @file, - for stdin, or omit for interactive/pipe)")
@@ -315,16 +319,16 @@ export function registerEntitiesCommand(program: Command): void {
 
   addExamples(replace, [
     {
-      description: "Replace all attributes with inline JSON",
-      command: `geonic entities replace urn:ngsi-ld:Sensor:001 '{"temperature":{"type":"Property","value":20}}'`,
+      description: "Replace with full Entity Representation (recommended, spec 5.6.4)",
+      command: `geonic entities replace urn:ngsi-ld:Sensor:001 '{"id":"urn:ngsi-ld:Sensor:001","type":"Sensor","temperature":{"type":"Property","value":20}}'`,
     },
     {
       description: "Replace from a file",
-      command: "geonic entities replace urn:ngsi-ld:Sensor:001 @attrs.json",
+      command: "geonic entities replace urn:ngsi-ld:Sensor:001 @entity.json",
     },
     {
       description: "Replace from stdin pipe",
-      command: "cat attrs.json | geonic entities replace urn:ngsi-ld:Sensor:001",
+      command: "cat entity.json | geonic entities replace urn:ngsi-ld:Sensor:001",
     },
   ]);
 

--- a/src/commands/entities.ts
+++ b/src/commands/entities.ts
@@ -305,7 +305,7 @@ export function registerEntitiesCommand(program: Command): void {
           const data = await parseJsonInput(json);
 
           await client.put(
-            `/entities/${encodeURIComponent(id)}/attrs`,
+            `/entities/${encodeURIComponent(id)}`,
             data,
           );
           printSuccess("Entity replaced.");

--- a/tests/e2e/features/entities.feature
+++ b/tests/e2e/features/entities.feature
@@ -70,9 +70,7 @@ Feature: Entity management
     When I run `geonic entities list`
     Then the exit code should be 1
 
-  @wip
   Scenario: Replace entity attributes
-    # Server does not support PUT on /entities/{id}/attrs
     Given I am logged in
     And I run `geonic entities create '{"id":"urn:ngsi-ld:Room:050","type":"Room"}'`
     When I run `geonic entities replace urn:ngsi-ld:Room:050 '{"temperature":{"value":30,"type":"Property"}}'`

--- a/tests/e2e/features/entities.feature
+++ b/tests/e2e/features/entities.feature
@@ -70,10 +70,10 @@ Feature: Entity management
     When I run `geonic entities list`
     Then the exit code should be 1
 
-  Scenario: Replace entity attributes
+  Scenario: Replace entity with full Entity Representation
     Given I am logged in
     And I run `geonic entities create '{"id":"urn:ngsi-ld:Room:050","type":"Room"}'`
-    When I run `geonic entities replace urn:ngsi-ld:Room:050 '{"temperature":{"value":30,"type":"Property"}}'`
+    When I run `geonic entities replace urn:ngsi-ld:Room:050 '{"id":"urn:ngsi-ld:Room:050","type":"Room","temperature":{"value":30,"type":"Property"}}'`
     Then the exit code should be 0
     And the output should contain "Entity replaced."
 

--- a/tests/entities.test.ts
+++ b/tests/entities.test.ts
@@ -258,7 +258,7 @@ describe("entities command", () => {
   });
 
   describe("replace", () => {
-    it("parses JSON input and puts entity attrs", async () => {
+    it("parses JSON input and puts to /entities/{id} (NGSI-LD 5.6.4 Replace Entity)", async () => {
       const attrData = { temperature: { value: 30 } };
       vi.mocked(parseJsonInput).mockResolvedValue(attrData);
       mockClient.put.mockResolvedValue(mockResponse(undefined, 204));
@@ -267,7 +267,7 @@ describe("entities command", () => {
 
       expect(parseJsonInput).toHaveBeenCalledWith('{"temperature":{"value":30}}');
       expect(mockClient.put).toHaveBeenCalledWith(
-        `/entities/${encodeURIComponent("urn:ngsi-ld:Sensor:001")}/attrs`,
+        `/entities/${encodeURIComponent("urn:ngsi-ld:Sensor:001")}`,
         attrData,
       );
       expect(printSuccess).toHaveBeenCalledWith("Entity replaced.");


### PR DESCRIPTION
## Summary

- `entities replace` が PUT を `/ngsi-ld/v1/entities/{id}/attrs` に送り、サーバーの `MethodNotAllowed` で常に失敗していた問題を修正
- NGSI-LD 仕様 (ETSI GS CIM 009 clause 5.6.4 Replace Entity) では PUT のエンドポイントは末尾 `/attrs` なしの `/entities/{id}`
- `update` (PATCH) は仕様 5.6.3 で `/entities/{id}/attrs` が正しいため変更なし
- `@wip` でスキップしていた E2E シナリオを有効化

Closes #128

## Changes

- `src/commands/entities.ts` — `replace` の PUT 先から `/attrs` を削除
- `tests/entities.test.ts` — 仕様準拠の expectation に修正 (バグった期待値を更新)
- `tests/e2e/features/entities.feature` — `Replace entity attributes` の `@wip` 解除
- `CHANGELOG.md` — Unreleased セクションに記録

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (Vitest 736 件 passed)
- [x] `npm run test:e2e` (Cucumber 141 件 passed)
- [x] 仕様確認: NGSI-LD ETSI GS CIM 009 clause 5.6.3 (PATCH `/entities/{id}/attrs`) と 5.6.4 (PUT `/entities/{id}`) の差異を確認済み

## Note

E2E の `auth.feature` 内で flaky なシナリオが残っているが、本 PR の変更とは無関係。原因は本体側 `AuthService.logout()` の invalidation 挙動で、geolonia/geonicdb#1202 に切り出し済み。`cucumber.mjs` の `retry: 2` で CI は救済される想定。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * エンティティ置換時の送信先をNGSI‑LD仕様に合わせて修正し、従来のMethodNotAllowedエラーを解消

* **改善**
  * エンティティ置換コマンドの説明と推奨例を「属性のみ」からID/型を含む完全なエンティティ表現に更新

* **テスト**
  * E2Eの置換シナリオを有効化し、関連テストを更新して仕様に準拠することを確認
<!-- end of auto-generated comment: release notes by coderabbit.ai -->