### PR TITLE
release: v0.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## [Unreleased]
 
+## [0.16.2] - 2026-06-09
+
 ### 2026-05-31
 - **Fix**: `entities replace` が PUT を `/ngsi-ld/v1/entities/{id}/attrs` に送ってサーバーの `MethodNotAllowed` で常に失敗していた問題を修正。NGSI-LD 仕様 (ETSI GS CIM 009 clause 5.6.4 Replace Entity) に従い、PUT を `/ngsi-ld/v1/entities/{id}` に送るよう変更。`@wip` でスキップしていた E2E シナリオを有効化 (#128)
 
@@ -246,7 +248,8 @@
 ### 2026-02-26
 - **Docs**: README にインストール手順・使い方・コマンドリファレンスを追加 (#1)
 
-[Unreleased]: https://github.com/geolonia/geonicdb-cli/compare/v0.16.1...HEAD
+[Unreleased]: https://github.com/geolonia/geonicdb-cli/compare/v0.16.2...HEAD
+[0.16.2]: https://github.com/geolonia/geonicdb-cli/compare/v0.16.1...v0.16.2
 [0.16.1]: https://github.com/geolonia/geonicdb-cli/compare/v0.16.0...v0.16.1
 [0.16.0]: https://github.com/geolonia/geonicdb-cli/compare/v0.15.1...v0.16.0
 [0.15.1]: https://github.com/geolonia/geonicdb-cli/compare/v0.15.0...v0.15.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolonia/geonicdb-cli",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolonia/geonicdb-cli",
-      "version": "0.16.1",
+      "version": "0.16.2",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolonia/geonicdb-cli",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "A CLI client for the GeonicDB",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

v0.16.2 リリース。

### Fix
- `entities replace` が PUT を `/ngsi-ld/v1/entities/{id}/attrs` に送ってサーバーの `MethodNotAllowed` で常に失敗していた問題を修正。NGSI-LD 仕様 (ETSI GS CIM 009 clause 5.6.4) に従い `/ngsi-ld/v1/entities/{id}` に送るよう変更 (#128)

詳細は [CHANGELOG.md](./CHANGELOG.md) 参照。

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (736 件 pass)
- [x] `npm run build`
- [ ] マージ後、`v0.16.2` タグを main に push して publish.yml で npm に公開

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * バージョン番号を 0.16.2 に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->