### PR TITLE
fix(auth): テナント名でログインできない問題を修正 + --tenant フラグ追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   - `--tenant-id` フラグはサーバーへの素通しで ID 検索のみ対応していたため、name を渡すと 403 で失敗していた。`-s/--service` と同じく `availableTenants` を引いて name→ID 解決を行うようフラグの挙動を統合
   - 複数テナント検出時に TTY であってもインタラクティブ選択 prompt を出さず即エラー終了していた挙動を改善。TTY 時は番号入力による選択 prompt を表示する (フラグ未指定かつ非 TTY 時は従来通りエラー)
 - **Refactor**: `auth login` の HTTP フローを「テナント未指定の初回ログイン → クライアント側で name→ID 解決 → 必要なら resolved ID で再ログイン」に整理。`--tenant-id <name|id>` のフラグヘルプも実挙動に合わせて更新 (#132)
+- **Feat**: `auth login` に `--tenant <name|id>` を追加 — `--tenant-id` のエイリアス。`profile create --tenant` と表記を揃え、`geonic auth login --tenant miya` のように打てる (#132)
 - **Test**: `promptTenantSelection`、`--tenant-id` の name 解決、インタラクティブ選択フローの単体テストを追加。既存テストの `TenantInfo` フィクスチャを `tenantName` に揃えた (#132)
 
 ## [0.16.2] - 2026-06-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,13 @@
 ## [Unreleased]
 
 ### 2026-06-10
-- **Fix**: `auth login` で複数テナント所属ユーザーがテナント名で指定できなかった問題を修正 (#132)
+- **Fix**: `auth login` で複数テナント所属ユーザーがテナント名で指定できなかった問題を修正 (#133)
   - サーバーが返す `availableTenants[].tenantName` を CLI 側が `name` で読んでおり、一覧表示が常に tenantId にフォールバックし、`-s/--service <name>` のマッチングも常に false になっていた。`TenantInfo.tenantName` に統一
   - 複数テナント検出時に TTY であってもインタラクティブ選択 prompt を出さず即エラー終了していた挙動を改善。TTY 時は番号入力による選択 prompt を表示する (フラグ未指定かつ非 TTY 時は従来通りエラー)
-- **Feat**: `auth login` に `--tenant <name|id>` を追加 — テナント名でも ID でもログインできる新フラグ。`profile create --tenant` と表記を揃えた (`geonic auth login --tenant miya`) (#132)
-- **Refactor**: `auth login` の HTTP フローを「テナント未指定の初回ログイン → クライアント側で name→ID 解決 → 必要なら resolved ID で再ログイン」に整理 (#132)
-- **Refactor**: `--tenant-id` フラグはフラグ名通り **ID 専用**として動作するように整理。ヒントを出すエラーメッセージを追加 (`--tenant-id miya` のように name を渡した場合、`Use --tenant miya (or --tenant-id <id>)` と案内する) (#132)
-- **Test**: `promptTenantSelection`、`--tenant-id` の name 解決、インタラクティブ選択フローの単体テストを追加。既存テストの `TenantInfo` フィクスチャを `tenantName` に揃えた (#132)
+- **Feat**: `auth login` に `--tenant <name|id>` を追加 — テナント名でも ID でもログインできる新フラグ。`profile create --tenant` と表記を揃えた (`geonic auth login --tenant miya`) (#133)
+- **Refactor**: `auth login` の HTTP フローを「テナント未指定の初回ログイン → クライアント側で name→ID 解決 → 必要なら resolved ID で再ログイン」に整理 (#133)
+- **Refactor**: `--tenant-id` フラグはフラグ名通り **ID 専用**として動作するように整理。ヒントを出すエラーメッセージを追加 (`--tenant-id miya` のように name を渡した場合、`Use --tenant miya (or --tenant-id <id>)` と案内する) (#133)
+- **Test**: `promptTenantSelection`、`--tenant-id` の name 解決、インタラクティブ選択フローの単体テストを追加。既存テストの `TenantInfo` フィクスチャを `tenantName` に揃えた (#133)
 
 ## [0.16.2] - 2026-06-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@
 
 ## [Unreleased]
 
+### 2026-06-10
+- **Fix**: `auth login` で複数テナント所属ユーザーがテナント名で指定できなかった問題を 3 点まとめて修正 (#132)
+  - サーバーが返す `availableTenants[].tenantName` を CLI 側が `name` で読んでおり、一覧表示が常に tenantId にフォールバックし、`-s/--service <name>` のマッチングも常に false になっていた。`TenantInfo.tenantName` に統一
+  - `--tenant-id` フラグはサーバーへの素通しで ID 検索のみ対応していたため、name を渡すと 403 で失敗していた。`-s/--service` と同じく `availableTenants` を引いて name→ID 解決を行うようフラグの挙動を統合
+  - 複数テナント検出時に TTY であってもインタラクティブ選択 prompt を出さず即エラー終了していた挙動を改善。TTY 時は番号入力による選択 prompt を表示する (フラグ未指定かつ非 TTY 時は従来通りエラー)
+- **Refactor**: `auth login` の HTTP フローを「テナント未指定の初回ログイン → クライアント側で name→ID 解決 → 必要なら resolved ID で再ログイン」に整理。`--tenant-id <name|id>` のフラグヘルプも実挙動に合わせて更新 (#132)
+- **Test**: `promptTenantSelection`、`--tenant-id` の name 解決、インタラクティブ選択フローの単体テストを追加。既存テストの `TenantInfo` フィクスチャを `tenantName` に揃えた (#132)
+
 ## [0.16.2] - 2026-06-09
 
 ### 2026-05-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,12 @@
 ## [Unreleased]
 
 ### 2026-06-10
-- **Fix**: `auth login` で複数テナント所属ユーザーがテナント名で指定できなかった問題を 3 点まとめて修正 (#132)
+- **Fix**: `auth login` で複数テナント所属ユーザーがテナント名で指定できなかった問題を修正 (#132)
   - サーバーが返す `availableTenants[].tenantName` を CLI 側が `name` で読んでおり、一覧表示が常に tenantId にフォールバックし、`-s/--service <name>` のマッチングも常に false になっていた。`TenantInfo.tenantName` に統一
-  - `--tenant-id` フラグはサーバーへの素通しで ID 検索のみ対応していたため、name を渡すと 403 で失敗していた。`-s/--service` と同じく `availableTenants` を引いて name→ID 解決を行うようフラグの挙動を統合
   - 複数テナント検出時に TTY であってもインタラクティブ選択 prompt を出さず即エラー終了していた挙動を改善。TTY 時は番号入力による選択 prompt を表示する (フラグ未指定かつ非 TTY 時は従来通りエラー)
-- **Refactor**: `auth login` の HTTP フローを「テナント未指定の初回ログイン → クライアント側で name→ID 解決 → 必要なら resolved ID で再ログイン」に整理。`--tenant-id <name|id>` のフラグヘルプも実挙動に合わせて更新 (#132)
-- **Feat**: `auth login` に `--tenant <name|id>` を追加 — `--tenant-id` のエイリアス。`profile create --tenant` と表記を揃え、`geonic auth login --tenant miya` のように打てる (#132)
+- **Feat**: `auth login` に `--tenant <name|id>` を追加 — テナント名でも ID でもログインできる新フラグ。`profile create --tenant` と表記を揃えた (`geonic auth login --tenant miya`) (#132)
+- **Refactor**: `auth login` の HTTP フローを「テナント未指定の初回ログイン → クライアント側で name→ID 解決 → 必要なら resolved ID で再ログイン」に整理 (#132)
+- **Refactor**: `--tenant-id` フラグはフラグ名通り **ID 専用**として動作するように整理。ヒントを出すエラーメッセージを追加 (`--tenant-id miya` のように name を渡した場合、`Use --tenant miya (or --tenant-id <id>)` と案内する) (#132)
 - **Test**: `promptTenantSelection`、`--tenant-id` の name 解決、インタラクティブ選択フローの単体テストを追加。既存テストの `TenantInfo` フィクスチャを `tenantName` に揃えた (#132)
 
 ## [0.16.2] - 2026-06-09

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -26,8 +26,8 @@ function createLoginCommand(): Command {
     .option("--client-id <id>", "OAuth client ID")
     .option("--client-secret <secret>", "OAuth client secret")
     .option("--scope <scopes>", "OAuth scopes (space-separated)")
-    .option("--tenant-id <name|id>", "Tenant to authenticate against (accepts tenant name or ID)")
-    .option("--tenant <name|id>", "Alias of --tenant-id")
+    .option("--tenant-id <id>", "Tenant ID to authenticate against (accepts tenant ID only — use --tenant for name)")
+    .option("--tenant <name|id>", "Tenant to authenticate against (accepts tenant name or ID)")
     .action(
       withErrorHandler(async (...args: unknown[]) => {
         const cmd = args[args.length - 1] as Command;
@@ -99,8 +99,11 @@ function createLoginCommand(): Command {
 
         const client = createClient(cmd);
 
-        // Tenant flag: accept either a tenant name or a tenantId via --tenant-id, --tenant, or -s/--service
-        const tenantFlag = loginOpts.tenantId ?? loginOpts.tenant ?? globalOpts.service;
+        // --tenant-id matches by ID only. --tenant and -s/--service match by name or ID.
+        // --tenant-id wins when both are supplied.
+        const tenantIdFlag = loginOpts.tenantId;
+        const tenantNameOrIdFlag = loginOpts.tenant ?? globalOpts.service;
+        const tenantFlag = tenantIdFlag ?? tenantNameOrIdFlag;
 
         // Step 1: tenantless login. Server returns either a single-tenant token
         // or, for multi-tenant users, a primary-tenant token plus availableTenants.
@@ -125,16 +128,33 @@ function createLoginCommand(): Command {
         if (availableTenants && availableTenants.length > 1) {
           let selected: TenantInfo | undefined;
 
-          if (tenantFlag) {
+          if (tenantIdFlag) {
+            // --tenant-id: match by ID only
+            selected = availableTenants.find((t) => t.tenantId === tenantIdFlag);
+            if (!selected) {
+              const list = availableTenants
+                .map((t) => `  - ${t.tenantName ?? t.tenantId} (${t.tenantId}) [${t.role}]`)
+                .join("\n");
+              const nameMatch = availableTenants.find((t) => t.tenantName === tenantIdFlag);
+              const hint = nameMatch
+                ? `\nHint: "${tenantIdFlag}" looks like a tenant name. Use --tenant ${tenantIdFlag} (or --tenant-id ${nameMatch.tenantId}).`
+                : "";
+              printError(
+                `Tenant ID "${tenantIdFlag}" not found. Available tenants:\n${list}${hint}`,
+              );
+              process.exit(1);
+            }
+          } else if (tenantNameOrIdFlag) {
+            // --tenant / -s / --service: match by name or ID
             selected = availableTenants.find(
-              (t) => t.tenantName === tenantFlag || t.tenantId === tenantFlag,
+              (t) => t.tenantName === tenantNameOrIdFlag || t.tenantId === tenantNameOrIdFlag,
             );
             if (!selected) {
               const list = availableTenants
                 .map((t) => `  - ${t.tenantName ?? t.tenantId} (${t.tenantId}) [${t.role}]`)
                 .join("\n");
               printError(
-                `Tenant "${tenantFlag}" not found. Available tenants:\n${list}`,
+                `Tenant "${tenantNameOrIdFlag}" not found. Available tenants:\n${list}`,
               );
               process.exit(1);
             }
@@ -145,7 +165,7 @@ function createLoginCommand(): Command {
               .map((t) => `  - ${t.tenantName ?? t.tenantId} (${t.tenantId}) [${t.role}]`)
               .join("\n");
             printError(
-              `Multiple tenants are available for this account. Specify one with --tenant-id <name|id> or -s/--service <name|id>:\n${list}`,
+              `Multiple tenants are available for this account. Specify one with --tenant <name|id>, --tenant-id <id>, or -s/--service <name|id>:\n${list}`,
             );
             process.exit(1);
           }
@@ -168,7 +188,10 @@ function createLoginCommand(): Command {
         } else if (tenantFlag && availableTenants && availableTenants.length === 1) {
           // Single-tenant account but flag was provided — validate it matches
           const only = availableTenants[0];
-          if (only.tenantName !== tenantFlag && only.tenantId !== tenantFlag) {
+          const matches = tenantIdFlag
+            ? only.tenantId === tenantIdFlag
+            : only.tenantName === tenantFlag || only.tenantId === tenantFlag;
+          if (!matches) {
             printError(
               `Tenant "${tenantFlag}" not found. The only available tenant is "${only.tenantName ?? only.tenantId}" (${only.tenantId}).`,
             );
@@ -454,11 +477,11 @@ export function registerAuthCommands(program: Command): void {
       command: "geonic auth login --tenant miya",
     },
     {
-      description: "Same as above — --tenant-id is an alias of --tenant",
-      command: "geonic auth login --tenant-id my-tenant",
+      description: "Login by tenant ID only (rejects names — use --tenant for names)",
+      command: "geonic auth login --tenant-id 7f3b1c-abcd-...",
     },
     {
-      description: "Login to a tenant via the --service flag (accepts name or ID)",
+      description: "Login via the --service flag (accepts name or ID, same as --tenant)",
       command: "geonic auth login -s demo_smartcity",
     },
   ]);

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -9,7 +9,7 @@ import {
 } from "../helpers.js";
 import { loadConfig, saveConfig, getCurrentProfile, validateUrl } from "../config.js";
 import { printSuccess, printError, printInfo, printWarning } from "../output.js";
-import { isInteractive, promptEmail, promptPassword } from "../prompt.js";
+import { isInteractive, promptEmail, promptPassword, promptTenantSelection } from "../prompt.js";
 import type { TenantInfo } from "../types.js";
 import { getTokenStatus, formatDuration } from "../token.js";
 import { clientCredentialsGrant } from "../oauth.js";
@@ -26,7 +26,7 @@ function createLoginCommand(): Command {
     .option("--client-id <id>", "OAuth client ID")
     .option("--client-secret <secret>", "OAuth client secret")
     .option("--scope <scopes>", "OAuth scopes (space-separated)")
-    .option("--tenant-id <id>", "Tenant ID for scoped authentication")
+    .option("--tenant-id <name|id>", "Tenant to authenticate against (accepts tenant name or ID)")
     .action(
       withErrorHandler(async (...args: unknown[]) => {
         const cmd = args[args.length - 1] as Command;
@@ -96,18 +96,14 @@ function createLoginCommand(): Command {
         const password = await promptPassword();
 
         const client = createClient(cmd);
-        const body: Record<string, string> = { email, password };
 
-        // --tenant-id takes priority
-        const requestTenantId = loginOpts.tenantId;
-        const serviceFlag = globalOpts.service;
+        // Tenant flag: accept either a tenant name or a tenantId via --tenant-id or -s/--service
+        const tenantFlag = loginOpts.tenantId ?? globalOpts.service;
 
-        if (requestTenantId) {
-          body.tenantId = requestTenantId;
-        }
-
+        // Step 1: tenantless login. Server returns either a single-tenant token
+        // or, for multi-tenant users, a primary-tenant token plus availableTenants.
         const response = await client.rawRequest("POST", "/auth/login", {
-          body,
+          body: { email, password },
           skipTenantHeader: true,
         });
 
@@ -120,39 +116,41 @@ function createLoginCommand(): Command {
           process.exit(1);
         }
 
-        // Multi-tenant: require explicit tenant selection (no interactive prompt)
         const availableTenants = data.availableTenants as TenantInfo[] | undefined;
         let finalTenantId = data.tenantId as string | undefined;
 
-        if (availableTenants && availableTenants.length > 1 && !requestTenantId) {
-          let resolvedTenantId: string | undefined;
-          if (serviceFlag) {
-            const match = availableTenants.find(
-              (t) => t.name === serviceFlag || t.tenantId === serviceFlag,
+        // Multi-tenant: resolve target tenant from flag, interactive prompt, or fall back to primary
+        if (availableTenants && availableTenants.length > 1) {
+          let selected: TenantInfo | undefined;
+
+          if (tenantFlag) {
+            selected = availableTenants.find(
+              (t) => t.tenantName === tenantFlag || t.tenantId === tenantFlag,
             );
-            if (match) {
-              resolvedTenantId = match.tenantId;
-            } else {
+            if (!selected) {
+              const list = availableTenants
+                .map((t) => `  - ${t.tenantName ?? t.tenantId} (${t.tenantId}) [${t.role}]`)
+                .join("\n");
               printError(
-                `Tenant "${serviceFlag}" not found. Available: ${availableTenants.map((t) => t.name ?? t.tenantId).join(", ")}`,
+                `Tenant "${tenantFlag}" not found. Available tenants:\n${list}`,
               );
               process.exit(1);
             }
-          }
-
-          if (!resolvedTenantId) {
+          } else if (isInteractive()) {
+            selected = await promptTenantSelection(availableTenants);
+          } else {
             const list = availableTenants
-              .map((t) => `  - ${t.name ?? t.tenantId} (${t.tenantId}) [${t.role}]`)
+              .map((t) => `  - ${t.tenantName ?? t.tenantId} (${t.tenantId}) [${t.role}]`)
               .join("\n");
             printError(
-              `Multiple tenants are available for this account. Specify one with --tenant-id <id> or -s/--service <name>:\n${list}`,
+              `Multiple tenants are available for this account. Specify one with --tenant-id <name|id> or -s/--service <name|id>:\n${list}`,
             );
             process.exit(1);
           }
 
-          if (resolvedTenantId !== finalTenantId) {
+          if (selected && selected.tenantId !== finalTenantId) {
             const reloginResponse = await client.rawRequest("POST", "/auth/login", {
-              body: { email, password, tenantId: resolvedTenantId },
+              body: { email, password, tenantId: selected.tenantId },
               skipTenantHeader: true,
             });
             const reloginData = reloginResponse.data as Record<string, unknown>;
@@ -163,7 +161,16 @@ function createLoginCommand(): Command {
             }
             token = newToken;
             refreshToken = reloginData.refreshToken as string | undefined;
-            finalTenantId = resolvedTenantId;
+            finalTenantId = selected.tenantId;
+          }
+        } else if (tenantFlag && availableTenants && availableTenants.length === 1) {
+          // Single-tenant account but flag was provided — validate it matches
+          const only = availableTenants[0];
+          if (only.tenantName !== tenantFlag && only.tenantId !== tenantFlag) {
+            printError(
+              `Tenant "${tenantFlag}" not found. The only available tenant is "${only.tenantName ?? only.tenantId}" (${only.tenantId}).`,
+            );
+            process.exit(1);
           }
         }
 
@@ -185,7 +192,7 @@ function createLoginCommand(): Command {
         if (availableTenants && availableTenants.length > 0) {
           config.availableTenants = availableTenants.map((t) => ({
             tenantId: t.tenantId,
-            ...(t.name ? { name: t.name } : {}),
+            ...(t.tenantName ? { tenantName: t.tenantName } : {}),
             role: t.role,
           }));
         } else {
@@ -194,7 +201,7 @@ function createLoginCommand(): Command {
         saveConfig(config, globalOpts.profile);
 
         const tenantLabel = finalTenantId
-          ? ` (tenant: ${availableTenants?.find((t) => t.tenantId === finalTenantId)?.name ?? finalTenantId})`
+          ? ` (tenant: ${availableTenants?.find((t) => t.tenantId === finalTenantId)?.tenantName ?? finalTenantId})`
           : "";
         printSuccess(`Login successful${tenantLabel}. Token saved to config.`);
       }),
@@ -441,11 +448,11 @@ export function registerAuthCommands(program: Command): void {
         "geonic auth login --client-credentials --client-id MY_ID --client-secret MY_SECRET",
     },
     {
-      description: "Login to a specific tenant by ID",
+      description: "Login to a tenant by name or ID (multi-tenant accounts)",
       command: "geonic auth login --tenant-id my-tenant",
     },
     {
-      description: "Login to a tenant by name",
+      description: "Login to a tenant via the --service flag (accepts name or ID)",
       command: "geonic auth login -s demo_smartcity",
     },
   ]);

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -27,6 +27,7 @@ function createLoginCommand(): Command {
     .option("--client-secret <secret>", "OAuth client secret")
     .option("--scope <scopes>", "OAuth scopes (space-separated)")
     .option("--tenant-id <name|id>", "Tenant to authenticate against (accepts tenant name or ID)")
+    .option("--tenant <name|id>", "Alias of --tenant-id")
     .action(
       withErrorHandler(async (...args: unknown[]) => {
         const cmd = args[args.length - 1] as Command;
@@ -36,6 +37,7 @@ function createLoginCommand(): Command {
           clientSecret?: string;
           scope?: string;
           tenantId?: string;
+          tenant?: string;
         };
         const globalOpts = resolveOptions(cmd);
 
@@ -97,8 +99,8 @@ function createLoginCommand(): Command {
 
         const client = createClient(cmd);
 
-        // Tenant flag: accept either a tenant name or a tenantId via --tenant-id or -s/--service
-        const tenantFlag = loginOpts.tenantId ?? globalOpts.service;
+        // Tenant flag: accept either a tenant name or a tenantId via --tenant-id, --tenant, or -s/--service
+        const tenantFlag = loginOpts.tenantId ?? loginOpts.tenant ?? globalOpts.service;
 
         // Step 1: tenantless login. Server returns either a single-tenant token
         // or, for multi-tenant users, a primary-tenant token plus availableTenants.
@@ -449,6 +451,10 @@ export function registerAuthCommands(program: Command): void {
     },
     {
       description: "Login to a tenant by name or ID (multi-tenant accounts)",
+      command: "geonic auth login --tenant miya",
+    },
+    {
+      description: "Same as above — --tenant-id is an alias of --tenant",
       command: "geonic auth login --tenant-id my-tenant",
     },
     {

--- a/src/commands/profile.ts
+++ b/src/commands/profile.ts
@@ -47,7 +47,7 @@ export function registerProfileCommands(program: Command): void {
 
       const config = loadConfig(name);
       const tenantLabel = config.tenantId
-        ? ` (tenant: ${config.availableTenants?.find((t) => t.tenantId === config.tenantId)?.name ?? config.tenantId})`
+        ? ` (tenant: ${config.availableTenants?.find((t) => t.tenantId === config.tenantId)?.tenantName ?? config.tenantId})`
         : "";
 
       // Auto-refresh expired token if refreshToken is available
@@ -174,8 +174,8 @@ export function registerProfileCommands(program: Command): void {
           console.log(`${key}: ***`);
         } else if (key === "availableTenants" && Array.isArray(value)) {
           console.log(`${key}:`);
-          for (const t of value as { tenantId: string; name?: string; role: string }[]) {
-            const label = t.name ? `${t.name} (${t.tenantId})` : t.tenantId;
+          for (const t of value as { tenantId: string; tenantName?: string; role: string }[]) {
+            const label = t.tenantName ? `${t.tenantName} (${t.tenantId})` : t.tenantId;
             const current = t.tenantId === config.tenantId ? " ← current" : "";
             console.log(`  - ${label} [${t.role}]${current}`);
           }

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -1,5 +1,6 @@
 import { createInterface } from "node:readline/promises";
 import { Writable } from "node:stream";
+import type { TenantInfo } from "./types.js";
 
 export function isInteractive(): boolean {
   return process.stdin.isTTY === true && process.stdout.isTTY === true;
@@ -10,6 +11,37 @@ export async function promptEmail(): Promise<string> {
   try {
     const email = await rl.question("Email: ");
     return email.trim();
+  } finally {
+    rl.close();
+  }
+}
+
+export async function promptTenantSelection(
+  tenants: TenantInfo[],
+): Promise<TenantInfo> {
+  if (tenants.length === 0) {
+    throw new Error("No tenants to choose from.");
+  }
+  const stdout = process.stdout;
+  stdout.write("Multiple tenants available. Select one:\n");
+  for (let i = 0; i < tenants.length; i++) {
+    const t = tenants[i];
+    const label = t.tenantName ? `${t.tenantName} (${t.tenantId})` : t.tenantId;
+    stdout.write(`  ${i + 1}) ${label} [${t.role}]\n`);
+  }
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    while (true) {
+      const answer = (await rl.question(`Select [1-${tenants.length}] (default: 1): `)).trim();
+      if (answer === "") {
+        return tenants[0];
+      }
+      const idx = Number.parseInt(answer, 10);
+      if (Number.isInteger(idx) && idx >= 1 && idx <= tenants.length) {
+        return tenants[idx - 1];
+      }
+      stdout.write(`Invalid selection "${answer}". Please enter a number between 1 and ${tenants.length}.\n`);
+    }
   } finally {
     rl.close();
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ export type OutputFormat = "json" | "table" | "geojson";
 
 export interface TenantInfo {
   tenantId: string;
-  name?: string;
+  tenantName?: string;
   role: string;
 }
 

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -49,6 +49,7 @@ vi.mock("../src/prompt.js", () => ({
   isInteractive: vi.fn(),
   promptEmail: vi.fn(),
   promptPassword: vi.fn(),
+  promptTenantSelection: vi.fn(),
 }));
 
 vi.mock("../src/token.js", () => ({
@@ -63,7 +64,7 @@ vi.mock("../src/oauth.js", () => ({
 import { createClient, getFormat, outputResponse, resolveOptions } from "../src/helpers.js";
 import { printSuccess, printError, printInfo, printWarning } from "../src/output.js";
 import { loadConfig, saveConfig, getCurrentProfile, validateUrl } from "../src/config.js";
-import { isInteractive, promptEmail, promptPassword } from "../src/prompt.js";
+import { isInteractive, promptEmail, promptPassword, promptTenantSelection } from "../src/prompt.js";
 import { getTokenStatus, formatDuration } from "../src/token.js";
 import { clientCredentialsGrant } from "../src/oauth.js";
 import { registerAuthCommands } from "../src/commands/auth.js";
@@ -258,17 +259,18 @@ describe("auth commands", () => {
       expect(exitSpy).toHaveBeenCalledWith(1);
     });
 
-    it("includes tenantId in the request body when --tenant-id is provided", async () => {
+    it("first request is tenantless even when --tenant-id is provided", async () => {
+      // New flow: always do tenantless first to receive availableTenants for name->ID resolution.
       vi.mocked(isInteractive).mockReturnValue(true);
       vi.mocked(promptEmail).mockResolvedValue("user@example.com");
       vi.mocked(promptPassword).mockResolvedValue("pass123");
       client.rawRequest.mockResolvedValue(
-        mockResponse({ accessToken: "tenant-token" }),
+        mockResponse({ accessToken: "tenant-token", tenantId: "my-tenant" }),
       );
       const program = makeProgram();
       await runCommand(program, ["auth", "login", "--tenant-id", "my-tenant"]);
-      expect(client.rawRequest).toHaveBeenCalledWith("POST", "/auth/login", {
-        body: { email: "user@example.com", password: "pass123", tenantId: "my-tenant" },
+      expect(client.rawRequest).toHaveBeenNthCalledWith(1, "POST", "/auth/login", {
+        body: { email: "user@example.com", password: "pass123" },
         skipTenantHeader: true,
       });
     });
@@ -423,7 +425,10 @@ describe("auth commands", () => {
       vi.mocked(promptPassword).mockResolvedValue("pass123");
     });
 
-    it("errors out when multiple tenants are available and none is specified", async () => {
+    it("errors out when multi-tenant, non-interactive, and no flag is specified", async () => {
+      // Interactive selection requires a TTY (but auth.login itself already required TTY for
+      // password prompt — this branch is reached when stdin is TTY-faked but isInteractive() is overridden).
+      vi.mocked(isInteractive).mockReturnValueOnce(true).mockReturnValue(false);
       const tenants = [
         { tenantId: "city_a", role: "tenant_admin" },
         { tenantId: "city_b", role: "user" },
@@ -450,7 +455,7 @@ describe("auth commands", () => {
       expect(saveConfig).not.toHaveBeenCalled();
     });
 
-    it("succeeds when --tenant-id is explicitly provided", async () => {
+    it("succeeds when --tenant-id matches the primary tenant (no re-login)", async () => {
       const tenants = [
         { tenantId: "city_a", role: "tenant_admin" },
         { tenantId: "city_b", role: "user" },
@@ -460,12 +465,64 @@ describe("auth commands", () => {
       );
       const program = makeProgram();
       await runCommand(program, ["auth", "login", "--tenant-id", "city_a"]);
+      // Primary tenant already matches the flag — only the initial tenantless call is made.
+      expect(client.rawRequest).toHaveBeenCalledTimes(1);
       expect(client.rawRequest).toHaveBeenCalledWith("POST", "/auth/login", {
-        body: { email: "user@example.com", password: "pass123", tenantId: "city_a" },
+        body: { email: "user@example.com", password: "pass123" },
         skipTenantHeader: true,
       });
       expect(saveConfig).toHaveBeenCalledWith(
         expect.objectContaining({ token: "tok", service: "city_a" }),
+        "default",
+      );
+    });
+
+    it("resolves --tenant-id by tenant name and re-logins", async () => {
+      const tenants = [
+        { tenantId: "tid-aaa", tenantName: "demo_smartcity", role: "tenant_admin" },
+        { tenantId: "tid-bbb", tenantName: "demo_bousai", role: "user" },
+      ];
+      client.rawRequest
+        .mockResolvedValueOnce(
+          mockResponse({ accessToken: "tok-a", tenantId: "tid-aaa", availableTenants: tenants }),
+        )
+        .mockResolvedValueOnce(
+          mockResponse({ accessToken: "tok-b", tenantId: "tid-bbb" }),
+        );
+      const program = makeProgram();
+      await runCommand(program, ["auth", "login", "--tenant-id", "demo_bousai"]);
+      expect(client.rawRequest).toHaveBeenLastCalledWith("POST", "/auth/login", {
+        body: { email: "user@example.com", password: "pass123", tenantId: "tid-bbb" },
+        skipTenantHeader: true,
+      });
+      expect(saveConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ token: "tok-b", service: "tid-bbb", tenantId: "tid-bbb" }),
+        "default",
+      );
+    });
+
+    it("prompts interactively when multi-tenant and no flag is provided (TTY)", async () => {
+      const tenants = [
+        { tenantId: "tid-aaa", tenantName: "demo_smartcity", role: "tenant_admin" },
+        { tenantId: "tid-bbb", tenantName: "demo_bousai", role: "user" },
+      ];
+      vi.mocked(promptTenantSelection).mockResolvedValue(tenants[1]);
+      client.rawRequest
+        .mockResolvedValueOnce(
+          mockResponse({ accessToken: "tok-a", tenantId: "tid-aaa", availableTenants: tenants }),
+        )
+        .mockResolvedValueOnce(
+          mockResponse({ accessToken: "tok-b", tenantId: "tid-bbb" }),
+        );
+      const program = makeProgram();
+      await runCommand(program, ["auth", "login"]);
+      expect(promptTenantSelection).toHaveBeenCalledWith(tenants);
+      expect(client.rawRequest).toHaveBeenLastCalledWith("POST", "/auth/login", {
+        body: { email: "user@example.com", password: "pass123", tenantId: "tid-bbb" },
+        skipTenantHeader: true,
+      });
+      expect(saveConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ token: "tok-b", tenantId: "tid-bbb" }),
         "default",
       );
     });
@@ -485,7 +542,7 @@ describe("auth commands", () => {
 
     it("saves availableTenants list when login succeeds with one tenant", async () => {
       const tenants = [
-        { tenantId: "city_a", name: "Smart City A", role: "tenant_admin" },
+        { tenantId: "city_a", tenantName: "Smart City A", role: "tenant_admin" },
       ];
       client.rawRequest.mockResolvedValue(
         mockResponse({ accessToken: "tok", tenantId: "city_a", availableTenants: tenants }),
@@ -496,7 +553,7 @@ describe("auth commands", () => {
         expect.objectContaining({
           tenantId: "city_a",
           availableTenants: [
-            { tenantId: "city_a", name: "Smart City A", role: "tenant_admin" },
+            { tenantId: "city_a", tenantName: "Smart City A", role: "tenant_admin" },
           ],
         }),
         "default",
@@ -505,8 +562,8 @@ describe("auth commands", () => {
 
     it("resolves tenant by name via --service flag and re-logins", async () => {
       const tenants = [
-        { tenantId: "tid-aaa", name: "demo_smartcity", role: "tenant_admin" },
-        { tenantId: "tid-bbb", name: "demo_bousai", role: "user" },
+        { tenantId: "tid-aaa", tenantName: "demo_smartcity", role: "tenant_admin" },
+        { tenantId: "tid-bbb", tenantName: "demo_bousai", role: "user" },
       ];
       vi.mocked(resolveOptions).mockReturnValue({
         url: "http://localhost:3000",
@@ -563,7 +620,7 @@ describe("auth commands", () => {
 
     it("prints error when --service tenant name not found", async () => {
       const tenants = [
-        { tenantId: "city_a", name: "Smart City A", role: "tenant_admin" },
+        { tenantId: "city_a", tenantName: "Smart City A", role: "tenant_admin" },
         { tenantId: "city_b", role: "user" },
       ];
       vi.mocked(resolveOptions).mockReturnValue({
@@ -614,7 +671,7 @@ describe("auth commands", () => {
 
     it("includes tenant label in success message", async () => {
       const tenants = [
-        { tenantId: "city_a", name: "Smart City A", role: "tenant_admin" },
+        { tenantId: "city_a", tenantName: "Smart City A", role: "tenant_admin" },
       ];
       client.rawRequest.mockResolvedValue(
         mockResponse({ accessToken: "tok", tenantId: "city_a", availableTenants: tenants }),

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -477,7 +477,7 @@ describe("auth commands", () => {
       );
     });
 
-    it("resolves --tenant-id by tenant name and re-logins", async () => {
+    it("--tenant-id resolves by tenant ID and re-logins", async () => {
       const tenants = [
         { tenantId: "tid-aaa", tenantName: "demo_smartcity", role: "tenant_admin" },
         { tenantId: "tid-bbb", tenantName: "demo_bousai", role: "user" },
@@ -490,18 +490,39 @@ describe("auth commands", () => {
           mockResponse({ accessToken: "tok-b", tenantId: "tid-bbb" }),
         );
       const program = makeProgram();
-      await runCommand(program, ["auth", "login", "--tenant-id", "demo_bousai"]);
+      await runCommand(program, ["auth", "login", "--tenant-id", "tid-bbb"]);
       expect(client.rawRequest).toHaveBeenLastCalledWith("POST", "/auth/login", {
         body: { email: "user@example.com", password: "pass123", tenantId: "tid-bbb" },
         skipTenantHeader: true,
       });
       expect(saveConfig).toHaveBeenCalledWith(
-        expect.objectContaining({ token: "tok-b", service: "tid-bbb", tenantId: "tid-bbb" }),
+        expect.objectContaining({ token: "tok-b", tenantId: "tid-bbb" }),
         "default",
       );
     });
 
-    it("accepts --tenant as an alias of --tenant-id", async () => {
+    it("--tenant-id rejects a tenant name (hints to use --tenant)", async () => {
+      const tenants = [
+        { tenantId: "tid-aaa", tenantName: "demo_smartcity", role: "tenant_admin" },
+        { tenantId: "tid-bbb", tenantName: "demo_bousai", role: "user" },
+      ];
+      client.rawRequest.mockResolvedValueOnce(
+        mockResponse({ accessToken: "tok-a", tenantId: "tid-aaa", availableTenants: tenants }),
+      );
+      const program = makeProgram();
+      await expect(
+        runCommand(program, ["auth", "login", "--tenant-id", "demo_bousai"]),
+      ).rejects.toThrow("process.exit");
+      expect(printError).toHaveBeenCalledWith(
+        expect.stringContaining('Tenant ID "demo_bousai" not found'),
+      );
+      expect(printError).toHaveBeenCalledWith(
+        expect.stringContaining("Use --tenant demo_bousai"),
+      );
+      expect(saveConfig).not.toHaveBeenCalled();
+    });
+
+    it("--tenant resolves by tenant name and re-logins", async () => {
       const tenants = [
         { tenantId: "tid-aaa", tenantName: "demo_smartcity", role: "tenant_admin" },
         { tenantId: "tid-bbb", tenantName: "demo_bousai", role: "user" },
@@ -519,6 +540,26 @@ describe("auth commands", () => {
         body: { email: "user@example.com", password: "pass123", tenantId: "tid-bbb" },
         skipTenantHeader: true,
       });
+      expect(saveConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ tenantId: "tid-bbb" }),
+        "default",
+      );
+    });
+
+    it("--tenant also accepts a tenant ID", async () => {
+      const tenants = [
+        { tenantId: "tid-aaa", tenantName: "demo_smartcity", role: "tenant_admin" },
+        { tenantId: "tid-bbb", tenantName: "demo_bousai", role: "user" },
+      ];
+      client.rawRequest
+        .mockResolvedValueOnce(
+          mockResponse({ accessToken: "tok-a", tenantId: "tid-aaa", availableTenants: tenants }),
+        )
+        .mockResolvedValueOnce(
+          mockResponse({ accessToken: "tok-b", tenantId: "tid-bbb" }),
+        );
+      const program = makeProgram();
+      await runCommand(program, ["auth", "login", "--tenant", "tid-bbb"]);
       expect(saveConfig).toHaveBeenCalledWith(
         expect.objectContaining({ tenantId: "tid-bbb" }),
         "default",

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -501,6 +501,30 @@ describe("auth commands", () => {
       );
     });
 
+    it("accepts --tenant as an alias of --tenant-id", async () => {
+      const tenants = [
+        { tenantId: "tid-aaa", tenantName: "demo_smartcity", role: "tenant_admin" },
+        { tenantId: "tid-bbb", tenantName: "demo_bousai", role: "user" },
+      ];
+      client.rawRequest
+        .mockResolvedValueOnce(
+          mockResponse({ accessToken: "tok-a", tenantId: "tid-aaa", availableTenants: tenants }),
+        )
+        .mockResolvedValueOnce(
+          mockResponse({ accessToken: "tok-b", tenantId: "tid-bbb" }),
+        );
+      const program = makeProgram();
+      await runCommand(program, ["auth", "login", "--tenant", "demo_bousai"]);
+      expect(client.rawRequest).toHaveBeenLastCalledWith("POST", "/auth/login", {
+        body: { email: "user@example.com", password: "pass123", tenantId: "tid-bbb" },
+        skipTenantHeader: true,
+      });
+      expect(saveConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ tenantId: "tid-bbb" }),
+        "default",
+      );
+    });
+
     it("prompts interactively when multi-tenant and no flag is provided (TTY)", async () => {
       const tenants = [
         { tenantId: "tid-aaa", tenantName: "demo_smartcity", role: "tenant_admin" },

--- a/tests/commands-profile.test.ts
+++ b/tests/commands-profile.test.ts
@@ -96,7 +96,7 @@ describe("profile commands", () => {
       vi.mocked(loadConfig).mockReturnValue({
         tenantId: "city_a",
         availableTenants: [
-          { tenantId: "city_a", name: "Smart City A", role: "tenant_admin" },
+          { tenantId: "city_a", tenantName: "Smart City A", role: "tenant_admin" },
         ],
       } as never);
       const program = makeProgram();
@@ -367,7 +367,7 @@ describe("profile commands", () => {
         url: "http://example.com",
         tenantId: "city_a",
         availableTenants: [
-          { tenantId: "city_a", name: "Smart City A", role: "tenant_admin" },
+          { tenantId: "city_a", tenantName: "Smart City A", role: "tenant_admin" },
           { tenantId: "city_b", role: "user" },
         ],
       } as never);

--- a/tests/prompt.test.ts
+++ b/tests/prompt.test.ts
@@ -11,7 +11,7 @@ vi.mock("node:readline/promises", () => ({
   })),
 }));
 
-import { isInteractive, promptEmail, promptPassword } from "../src/prompt.js";
+import { isInteractive, promptEmail, promptPassword, promptTenantSelection } from "../src/prompt.js";
 
 describe("prompt", () => {
   const originalStdinIsTTY = process.stdin.isTTY;
@@ -274,6 +274,78 @@ describe("prompt", () => {
         stdinListeners["error"]?.forEach((cb) => cb(error));
         await expect(promise).rejects.toThrow("pipe error");
       });
+    });
+  });
+
+  describe("promptTenantSelection", () => {
+    let stdoutWriteSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      stdoutWriteSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    });
+
+    afterEach(() => {
+      stdoutWriteSpy.mockRestore();
+    });
+
+    it("returns the selected tenant by index", async () => {
+      mockQuestion.mockResolvedValueOnce("2");
+      const tenants = [
+        { tenantId: "tid-a", tenantName: "alpha", role: "tenant_admin" },
+        { tenantId: "tid-b", tenantName: "beta", role: "user" },
+      ];
+      const result = await promptTenantSelection(tenants);
+      expect(result).toEqual(tenants[1]);
+      expect(stdoutWriteSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Multiple tenants available"),
+      );
+      expect(stdoutWriteSpy).toHaveBeenCalledWith(
+        expect.stringContaining("alpha (tid-a)"),
+      );
+      expect(stdoutWriteSpy).toHaveBeenCalledWith(
+        expect.stringContaining("beta (tid-b)"),
+      );
+    });
+
+    it("defaults to the first tenant on empty input", async () => {
+      mockQuestion.mockResolvedValueOnce("");
+      const tenants = [
+        { tenantId: "tid-a", tenantName: "alpha", role: "tenant_admin" },
+        { tenantId: "tid-b", role: "user" },
+      ];
+      const result = await promptTenantSelection(tenants);
+      expect(result).toEqual(tenants[0]);
+    });
+
+    it("re-prompts on invalid input until a valid index is given", async () => {
+      mockQuestion
+        .mockResolvedValueOnce("xyz")
+        .mockResolvedValueOnce("99")
+        .mockResolvedValueOnce("1");
+      const tenants = [
+        { tenantId: "tid-a", role: "tenant_admin" },
+        { tenantId: "tid-b", role: "user" },
+      ];
+      const result = await promptTenantSelection(tenants);
+      expect(result).toEqual(tenants[0]);
+      expect(mockQuestion).toHaveBeenCalledTimes(3);
+      expect(stdoutWriteSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Invalid selection "xyz"'),
+      );
+    });
+
+    it("falls back to tenantId in the label when tenantName is missing", async () => {
+      mockQuestion.mockResolvedValueOnce("1");
+      const tenants = [{ tenantId: "tid-only", role: "user" }];
+      const result = await promptTenantSelection(tenants);
+      expect(result).toEqual(tenants[0]);
+      expect(stdoutWriteSpy).toHaveBeenCalledWith(
+        expect.stringContaining("tid-only [user]"),
+      );
+    });
+
+    it("throws when no tenants are provided", async () => {
+      await expect(promptTenantSelection([])).rejects.toThrow(/No tenants/);
     });
   });
 


### PR DESCRIPTION
## Summary

`miya@geolonia.com` のように複数テナント所属のユーザーが、テナント名ではどう指定してもログインできなかった問題を修正。Closes #132

- **Fix**: `availableTenants[].tenantName` を CLI 側が `name` で読んでいたため、`-s/--service <name>` のマッチングが常に false で、一覧表示も全部 tenantId にフォールバックしていた。`TenantInfo` のフィールドを `tenantName` に統一
- **Feat**: `auth login --tenant <name|id>` を新設 — テナント名でも ID でも通る。`profile create --tenant` と表記を揃えた。`--tenant-id <id>` は名前通り ID 専用に整理 (name を渡すと "Use --tenant <input>" のヒントを出して拒否)
- **Feat**: 複数テナント検出時かつ TTY なら番号入力による選択 prompt を表示。v0.16.0 (#123) で廃止された対話選択を復活。非 TTY 時は従来通りエラー

## フラグの整理

| フラグ | 受け付ける値 | 用途 |
|---|---|---|
| `--tenant <name\|id>` | テナント名 または ID | 推奨。`profile create --tenant` と表記統一 |
| `--tenant-id <id>` | **テナント ID のみ** | フラグ名通り厳密。name を渡すと拒否 + ヒント |
| `-s/--service <name\|id>` | テナント名 または ID | グローバルフラグ |

## Test plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm test` — 746 tests / 35 files all passing
- [x] `npm run build` clean
- [x] 新規テスト: `promptTenantSelection` (5 件)、`--tenant` 名前/ID 解決、`--tenant-id` の ID 限定挙動・ヒント、インタラクティブ選択フロー
- [ ] ステージング (https://geonicdb.geolonia.com) で `miya@geolonia.com` (miya / geolonia 二テナント所属) を使った手動検証 — マージ前にレビュアーが実施推奨

## 影響範囲

- `src/types.ts`、`src/commands/auth.ts`、`src/commands/profile.ts`、`src/prompt.ts`
- `tests/auth.test.ts`、`tests/commands-profile.test.ts`、`tests/prompt.test.ts`

## 後方互換

- `--tenant-id <id>` を ID で使うスクリプトは引き続き動作
- v0.16.0 (#123) で廃止された対話選択を復活させているが、非 TTY 環境 (CI 等) では従来通りエラー終了するためヘッドレス運用は影響なし
- `config.availableTenants` の name フィールドはサーバーレスポンスとの不整合により実際には未保存だったため、移行不要

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * `--tenant` を追加し、テナント名またはIDでのログインをサポート。`--tenant-id` はID専用。
  * 対話式のテナント選択プロンプトを改善し、番号入力で選べるように。

* **バグ修正**
  * 表示されるテナント名フィールド表記を統一し、TTYでの誤終了を防止。
  * 名前指定時の誤用に対する案内メッセージを追加。

* **テスト**
  * テナント選択・ログインフローの単体テストを追加/更新。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->