### PR TITLE
release: v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-06-12
+
 ### 2026-06-10
 - **Fix**: `auth login` で複数テナント所属ユーザーがテナント名で指定できなかった問題を修正 (#133)
   - サーバーが返す `availableTenants[].tenantName` を CLI 側が `name` で読んでおり、一覧表示が常に tenantId にフォールバックし、`-s/--service <name>` のマッチングも常に false になっていた。`TenantInfo.tenantName` に統一
@@ -257,7 +259,8 @@
 ### 2026-02-26
 - **Docs**: README にインストール手順・使い方・コマンドリファレンスを追加 (#1)
 
-[Unreleased]: https://github.com/geolonia/geonicdb-cli/compare/v0.16.2...HEAD
+[Unreleased]: https://github.com/geolonia/geonicdb-cli/compare/v0.17.0...HEAD
+[0.17.0]: https://github.com/geolonia/geonicdb-cli/compare/v0.16.2...v0.17.0
 [0.16.2]: https://github.com/geolonia/geonicdb-cli/compare/v0.16.1...v0.16.2
 [0.16.1]: https://github.com/geolonia/geonicdb-cli/compare/v0.16.0...v0.16.1
 [0.16.0]: https://github.com/geolonia/geonicdb-cli/compare/v0.15.1...v0.16.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolonia/geonicdb-cli",
-  "version": "0.16.2",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolonia/geonicdb-cli",
-      "version": "0.16.2",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolonia/geonicdb-cli",
-  "version": "0.16.2",
+  "version": "0.17.0",
   "description": "A CLI client for the GeonicDB",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

v0.17.0 リリース。

### Feat
- `auth login` に `--tenant <name|id>` を追加 — テナント名でも ID でもログインできる新フラグ。`profile create --tenant` と表記を揃えた (#133)
- 複数テナント検出時に TTY なら番号入力による選択 prompt を表示する挙動を復活 (v0.16.0 #123 で廃止していた)、非 TTY 時は従来通りエラー (#133)

### Fix
- `auth login` で複数テナント所属ユーザーがテナント名で指定できなかった問題を修正。サーバーが返す `availableTenants[].tenantName` を CLI が `name` で読んでおり、name による検索が常に false、一覧表示も tenantId にフォールバックしていた (#133)

### Refactor
- `auth login` の HTTP フローを「テナント未指定の初回ログイン → クライアント側で name→ID 解決 → 必要なら再ログイン」に整理 (#133)
- `--tenant-id` フラグは名前通り **ID 専用**に整理。name を渡した場合は `Use --tenant <input>` のヒントを出して拒否 (#133)

### Chore
- 依存関係を更新 (vitest 3→4 等 13 パッケージ、#130)

詳細は [CHANGELOG.md](./CHANGELOG.md) 参照。

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (746 件 pass、vitest 4.1.8)
- [x] `npm run build`
- [ ] マージ後、`v0.17.0` タグを main に push して publish.yml で npm に公開


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * バージョンを 0.17.0 にアップデートしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->