### PR TITLE
fix: list 系コマンドの silent truncate を解消 — 全ページ自動取得と打ち切り警告 (closes #139)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 ## [Unreleased]
 
 ### 2026-07-14
+- **Fix**: list 系コマンドがサーバーのデフォルトページサイズ (20件) で結果を暗黙に切り捨てていた問題を修正 (#141)
+  - `--limit`/`--offset` 未指定時は `X-Total-Count` に従って全ページを自動取得するように変更。対象: `admin users/tenants/policies/api-keys/oauth-clients list`, `me api-keys/oauth-clients/policies list`, `rules list`, `custom-data-models list`, `catalog datasets list`
+  - `--limit`/`--offset` 明示時は従来通り単一リクエストとし、結果が全体の一部である場合は stderr に `Showing N of M results...` の警告を表示する
+  - `types list` / `entities list` は NGSI データプレーンのページネーション (NGSILD-Results-Count) を使うため対象外
+- **Test**: `fetchPaginatedList` のページ巡回・打ち切り警告・非配列応答パススルーの単体テストを追加 (#141)
 - **CI**: 週次 geonicdb 互換性チェックが実際には最新版をテストしていなかった問題を修正 — package.json の spec を `github:geolonia/geonicdb` に書き換えるだけでは package-lock.json の旧解決 (pinned hash) が優先され更新されないため、`git ls-remote` で HEAD ハッシュを取得して明示的に `npm install` するように変更 (#144)
 - **CI**: geonicdb 本体をローカル起動するジョブ (compat check / e2e) の Node.js を 20 → 24 に更新 — 本体の `engines` (>= 24.13) に追従 (#144)
 - **CI**: devDependency の geonicdb を最新 main (`53e27682`) に更新。E2E 全シナリオのパスを確認済み (#144)

--- a/src/commands/admin/api-keys.ts
+++ b/src/commands/admin/api-keys.ts
@@ -1,5 +1,5 @@
 import type { Command } from "commander";
-import { withErrorHandler, createClient, resolveOptions, getFormat, outputResponse, parseNonNegativeInt, buildPaginationParams } from "../../helpers.js";
+import { withErrorHandler, createClient, resolveOptions, getFormat, outputResponse, parseNonNegativeInt, fetchPaginatedList } from "../../helpers.js";
 import { loadConfig, saveConfig, validateUrl } from "../../config.js";
 import { parseJsonInput } from "../../input.js";
 import { printApiKeyBox, printError } from "../../output.js";
@@ -117,11 +117,9 @@ export function registerApiKeysCommand(parent: Command): void {
         const opts = cmd.opts() as { tenantId?: string; limit?: number; offset?: number };
         const client = createClient(cmd);
         const format = getFormat(cmd);
-        const params: Record<string, string> = buildPaginationParams(opts);
-        if (opts.tenantId) params.tenantId = opts.tenantId;
-        const response = await client.rawRequest("GET", "/admin/api-keys", {
-          params,
-        });
+        const extraParams: Record<string, string> = {};
+        if (opts.tenantId) extraParams.tenantId = opts.tenantId;
+        const response = await fetchPaginatedList(client, "/admin/api-keys", opts, extraParams);
         response.data = cleanApiKeyData(response.data);
         outputResponse(response, format);
         console.error("※ API キー値は作成時 (create) またはリフレッシュ時 (refresh) にのみ表示されます。");

--- a/src/commands/admin/oauth-clients.ts
+++ b/src/commands/admin/oauth-clients.ts
@@ -1,5 +1,5 @@
 import type { Command } from "commander";
-import { withErrorHandler, createClient, getFormat, outputResponse, parseNonNegativeInt, buildPaginationParams } from "../../helpers.js";
+import { withErrorHandler, createClient, getFormat, outputResponse, parseNonNegativeInt, fetchPaginatedList } from "../../helpers.js";
 import { parseJsonInput } from "../../input.js";
 import { printSuccess } from "../../output.js";
 import { addExamples } from "../help.js";
@@ -19,9 +19,7 @@ export function registerOAuthClientsCommand(parent: Command): void {
       withErrorHandler(async (_opts: unknown, cmd: Command) => {
         const client = createClient(cmd);
         const format = getFormat(cmd);
-        const params = buildPaginationParams(cmd.opts());
-
-        const response = await client.rawRequest("GET", "/admin/oauth-clients", { params });
+        const response = await fetchPaginatedList(client, "/admin/oauth-clients", cmd.opts());
         outputResponse(response, format);
       }),
     );

--- a/src/commands/admin/policies.ts
+++ b/src/commands/admin/policies.ts
@@ -1,5 +1,5 @@
 import type { Command } from "commander";
-import { withErrorHandler, createClient, getFormat, outputResponse, parseNonNegativeInt, buildPaginationParams } from "../../helpers.js";
+import { withErrorHandler, createClient, getFormat, outputResponse, parseNonNegativeInt, fetchPaginatedList } from "../../helpers.js";
 import { parseJsonInput } from "../../input.js";
 import { printSuccess } from "../../output.js";
 import { addExamples } from "../help.js";
@@ -19,9 +19,7 @@ export function registerPoliciesCommand(parent: Command): void {
       withErrorHandler(async (_opts: unknown, cmd: Command) => {
         const client = createClient(cmd);
         const format = getFormat(cmd);
-        const params = buildPaginationParams(cmd.opts());
-
-        const response = await client.rawRequest("GET", "/admin/policies", { params });
+        const response = await fetchPaginatedList(client, "/admin/policies", cmd.opts());
         outputResponse(response, format);
       }),
     );

--- a/src/commands/admin/tenants.ts
+++ b/src/commands/admin/tenants.ts
@@ -1,5 +1,5 @@
 import type { Command } from "commander";
-import { withErrorHandler, createClient, getFormat, outputResponse, parseNonNegativeInt, buildPaginationParams } from "../../helpers.js";
+import { withErrorHandler, createClient, getFormat, outputResponse, parseNonNegativeInt, fetchPaginatedList } from "../../helpers.js";
 import { parseJsonInput } from "../../input.js";
 import { printSuccess } from "../../output.js";
 import { addExamples, addNotes } from "../help.js";
@@ -41,9 +41,7 @@ export function registerTenantsCommand(parent: Command): void {
       withErrorHandler(async (_opts: unknown, cmd: Command) => {
         const client = createClient(cmd);
         const format = getFormat(cmd);
-        const params = buildPaginationParams(cmd.opts());
-
-        const response = await client.rawRequest("GET", "/admin/tenants", { params });
+        const response = await fetchPaginatedList(client, "/admin/tenants", cmd.opts());
         outputResponse(response, format);
       }),
     );

--- a/src/commands/admin/users.ts
+++ b/src/commands/admin/users.ts
@@ -1,5 +1,5 @@
 import type { Command } from "commander";
-import { withErrorHandler, createClient, getFormat, outputResponse, parseNonNegativeInt, buildPaginationParams } from "../../helpers.js";
+import { withErrorHandler, createClient, getFormat, outputResponse, parseNonNegativeInt, fetchPaginatedList } from "../../helpers.js";
 import { parseJsonInput } from "../../input.js";
 import { printSuccess } from "../../output.js";
 import { addExamples } from "../help.js";
@@ -19,9 +19,8 @@ export function registerUsersCommand(parent: Command): void {
       withErrorHandler(async (_opts: unknown, cmd: Command) => {
         const client = createClient(cmd);
         const format = getFormat(cmd);
-        const params = buildPaginationParams(cmd.opts());
 
-        const response = await client.rawRequest("GET", "/admin/users", { params });
+        const response = await fetchPaginatedList(client, "/admin/users", cmd.opts());
         outputResponse(response, format);
       }),
     );

--- a/src/commands/catalog.ts
+++ b/src/commands/catalog.ts
@@ -1,5 +1,5 @@
 import type { Command } from "commander";
-import { withErrorHandler, createClient, getFormat, outputResponse, parseNonNegativeInt, buildPaginationParams } from "../helpers.js";
+import { withErrorHandler, createClient, getFormat, outputResponse, parseNonNegativeInt, fetchPaginatedList } from "../helpers.js";
 import { addExamples } from "./help.js";
 
 export function registerCatalogCommand(program: Command): void {
@@ -46,9 +46,7 @@ export function registerCatalogCommand(program: Command): void {
       withErrorHandler(async (_opts: unknown, cmd: Command) => {
         const client = createClient(cmd);
         const format = getFormat(cmd);
-        const params = buildPaginationParams(cmd.opts());
-
-        const response = await client.rawRequest("GET", "/catalog/datasets", { params });
+        const response = await fetchPaginatedList(client, "/catalog/datasets", cmd.opts());
         outputResponse(response, format);
       }),
     );

--- a/src/commands/me-api-keys.ts
+++ b/src/commands/me-api-keys.ts
@@ -1,5 +1,5 @@
 import type { Command } from "commander";
-import { withErrorHandler, createClient, resolveOptions, getFormat, outputResponse, parseNonNegativeInt, buildPaginationParams } from "../helpers.js";
+import { withErrorHandler, createClient, resolveOptions, getFormat, outputResponse, parseNonNegativeInt, fetchPaginatedList } from "../helpers.js";
 import { loadConfig, saveConfig, validateUrl } from "../config.js";
 import { parseJsonInput } from "../input.js";
 import { printApiKeyBox, printError } from "../output.js";
@@ -73,9 +73,7 @@ export function addMeApiKeysSubcommand(me: Command): void {
       withErrorHandler(async (_opts: unknown, cmd: Command) => {
         const client = createClient(cmd);
         const format = getFormat(cmd);
-        const params = buildPaginationParams(cmd.opts());
-
-        const response = await client.rawRequest("GET", "/me/api-keys", { params });
+        const response = await fetchPaginatedList(client, "/me/api-keys", cmd.opts());
         response.data = cleanApiKeyData(response.data);
         outputResponse(response, format);
         console.error("※ API キー値は作成時 (create) またはリフレッシュ時 (refresh) にのみ表示されます。");

--- a/src/commands/me-oauth-clients.ts
+++ b/src/commands/me-oauth-clients.ts
@@ -1,5 +1,5 @@
 import type { Command } from "commander";
-import { withErrorHandler, createClient, resolveOptions, getFormat, outputResponse, parseNonNegativeInt, buildPaginationParams } from "../helpers.js";
+import { withErrorHandler, createClient, resolveOptions, getFormat, outputResponse, parseNonNegativeInt, fetchPaginatedList } from "../helpers.js";
 import { loadConfig, saveConfig, validateUrl } from "../config.js";
 import { parseJsonInput } from "../input.js";
 import { printSuccess, printError, printInfo, printWarning } from "../output.js";
@@ -21,9 +21,7 @@ export function addMeOAuthClientsSubcommand(me: Command): void {
       withErrorHandler(async (_opts: unknown, cmd: Command) => {
         const client = createClient(cmd);
         const format = getFormat(cmd);
-        const params = buildPaginationParams(cmd.opts());
-
-        const response = await client.rawRequest("GET", "/me/oauth-clients", { params });
+        const response = await fetchPaginatedList(client, "/me/oauth-clients", cmd.opts());
         outputResponse(response, format);
       }),
     );

--- a/src/commands/me-policies.ts
+++ b/src/commands/me-policies.ts
@@ -1,5 +1,5 @@
 import type { Command } from "commander";
-import { withErrorHandler, createClient, getFormat, outputResponse, parseNonNegativeInt, buildPaginationParams } from "../helpers.js";
+import { withErrorHandler, createClient, getFormat, outputResponse, parseNonNegativeInt, fetchPaginatedList } from "../helpers.js";
 import { parseJsonInput } from "../input.js";
 import { printSuccess } from "../output.js";
 import { addExamples, addNotes } from "./help.js";
@@ -19,9 +19,7 @@ export function addMePoliciesSubcommand(me: Command): void {
       withErrorHandler(async (_opts: unknown, cmd: Command) => {
         const client = createClient(cmd);
         const format = getFormat(cmd);
-        const params = buildPaginationParams(cmd.opts());
-
-        const response = await client.rawRequest("GET", "/me/policies", { params });
+        const response = await fetchPaginatedList(client, "/me/policies", cmd.opts());
         outputResponse(response, format);
       }),
     );

--- a/src/commands/models.ts
+++ b/src/commands/models.ts
@@ -1,5 +1,5 @@
 import type { Command } from "commander";
-import { withErrorHandler, createClient, getFormat, outputResponse, parseNonNegativeInt, buildPaginationParams } from "../helpers.js";
+import { withErrorHandler, createClient, getFormat, outputResponse, parseNonNegativeInt, fetchPaginatedList } from "../helpers.js";
 import { parseJsonInput } from "../input.js";
 import { printSuccess } from "../output.js";
 import { addExamples } from "./help.js";
@@ -20,9 +20,7 @@ export function registerModelsCommand(program: Command): void {
       withErrorHandler(async (_opts: unknown, cmd: Command) => {
         const client = createClient(cmd);
         const format = getFormat(cmd);
-        const params = buildPaginationParams(cmd.opts());
-
-        const response = await client.rawRequest("GET", "/custom-data-models", { params });
+        const response = await fetchPaginatedList(client, "/custom-data-models", cmd.opts());
         outputResponse(response, format);
       }),
     );

--- a/src/commands/rules.ts
+++ b/src/commands/rules.ts
@@ -1,5 +1,5 @@
 import type { Command } from "commander";
-import { withErrorHandler, createClient, getFormat, outputResponse, parseNonNegativeInt, buildPaginationParams } from "../helpers.js";
+import { withErrorHandler, createClient, getFormat, outputResponse, parseNonNegativeInt, fetchPaginatedList } from "../helpers.js";
 import { parseJsonInput } from "../input.js";
 import { printSuccess } from "../output.js";
 import { addExamples } from "./help.js";
@@ -19,9 +19,7 @@ export function registerRulesCommand(program: Command): void {
       withErrorHandler(async (_opts: unknown, cmd: Command) => {
         const client = createClient(cmd);
         const format = getFormat(cmd);
-        const params = buildPaginationParams(cmd.opts());
-
-        const response = await client.rawRequest("GET", "/rules", { params });
+        const response = await fetchPaginatedList(client, "/rules", cmd.opts());
         outputResponse(response, format);
       }),
     );

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,7 +1,7 @@
 import { Command, InvalidArgumentError } from "commander";
 import { loadConfig, saveConfig, validateUrl } from "./config.js";
 import { DryRunSignal, GdbClient, GdbClientError } from "./client.js";
-import { printError, printOutput, printCount } from "./output.js";
+import { printError, printOutput, printCount, printWarning } from "./output.js";
 import type { ClientResponse, GlobalOptions, OutputFormat } from "./types.js";
 
 /**
@@ -111,6 +111,72 @@ export function buildPaginationParams(opts: {
   if (opts.limit !== undefined) params["limit"] = String(opts.limit);
   if (opts.offset !== undefined) params["offset"] = String(opts.offset);
   return params;
+}
+
+/** Server-side maximum page size for admin/me list endpoints (ADMIN_MAX_LIMIT). */
+const LIST_PAGE_SIZE = 100;
+
+function parseTotalCount(headers: Headers): number | undefined {
+  const raw = headers.get("X-Total-Count");
+  if (raw === null) return undefined;
+  const total = Number(raw);
+  return Number.isInteger(total) && total >= 0 ? total : undefined;
+}
+
+/**
+ * Fetch a paginated list endpoint (admin/me APIs).
+ *
+ * Without explicit --limit/--offset the server returns only its default page
+ * (20 items) with no indication that more exist, so "list" commands would
+ * silently truncate. Instead, follow X-Total-Count and aggregate every page.
+ * With explicit flags, issue a single request as-is and warn on stderr when
+ * the result is only a slice of the total.
+ */
+export async function fetchPaginatedList(
+  client: GdbClient,
+  path: string,
+  opts: { limit?: number; offset?: number },
+  extraParams: Record<string, string> = {},
+): Promise<ClientResponse> {
+  if (opts.limit !== undefined || opts.offset !== undefined) {
+    const response = await client.rawRequest("GET", path, {
+      params: { ...extraParams, ...buildPaginationParams(opts) },
+    });
+    const total = parseTotalCount(response.headers);
+    if (total !== undefined && Array.isArray(response.data)) {
+      const offset = opts.offset ?? 0;
+      const remaining = total - offset - response.data.length;
+      if (remaining > 0) {
+        printWarning(
+          `Showing ${response.data.length} of ${total} results. ${remaining} more available (use --offset ${offset + response.data.length}).`,
+        );
+      }
+    }
+    return response;
+  }
+
+  const items: unknown[] = [];
+  let firstResponse: ClientResponse | undefined;
+  let offset = 0;
+  for (;;) {
+    const response = await client.rawRequest("GET", path, {
+      params: { ...extraParams, limit: String(LIST_PAGE_SIZE), offset: String(offset) },
+    });
+    // Endpoint doesn't return a collection — pass the response through untouched.
+    if (!Array.isArray(response.data)) return response;
+    firstResponse ??= response;
+    items.push(...response.data);
+    offset += response.data.length;
+    const total = parseTotalCount(response.headers);
+    if (
+      response.data.length === 0 ||
+      response.data.length < LIST_PAGE_SIZE ||
+      (total !== undefined && offset >= total)
+    ) {
+      break;
+    }
+  }
+  return { ...firstResponse!, data: items };
 }
 
 /**

--- a/tests/admin-api-keys.test.ts
+++ b/tests/admin-api-keys.test.ts
@@ -18,6 +18,19 @@ vi.mock("../src/helpers.js", () => ({
     if (opts.offset !== undefined) params["offset"] = String(opts.offset);
     return params;
   },
+  // Single-request passthrough; the real page-following logic is unit-tested
+  // in tests/helpers.test.ts against the unmocked implementation.
+  fetchPaginatedList: async (
+    client: { rawRequest: (method: string, path: string, options?: unknown) => Promise<unknown> },
+    path: string,
+    opts: { limit?: number; offset?: number },
+    extraParams: Record<string, string> = {},
+  ): Promise<unknown> => {
+    const params: Record<string, string> = { ...extraParams };
+    if (opts.limit !== undefined) params["limit"] = String(opts.limit);
+    if (opts.offset !== undefined) params["offset"] = String(opts.offset);
+    return client.rawRequest("GET", path, { params });
+  },
 }));
 
 vi.mock("../src/input.js", () => ({

--- a/tests/admin-oauth-clients.test.ts
+++ b/tests/admin-oauth-clients.test.ts
@@ -18,6 +18,19 @@ vi.mock("../src/helpers.js", () => ({
     if (opts.offset !== undefined) params["offset"] = String(opts.offset);
     return params;
   },
+  // Single-request passthrough; the real page-following logic is unit-tested
+  // in tests/helpers.test.ts against the unmocked implementation.
+  fetchPaginatedList: async (
+    client: { rawRequest: (method: string, path: string, options?: unknown) => Promise<unknown> },
+    path: string,
+    opts: { limit?: number; offset?: number },
+    extraParams: Record<string, string> = {},
+  ): Promise<unknown> => {
+    const params: Record<string, string> = { ...extraParams };
+    if (opts.limit !== undefined) params["limit"] = String(opts.limit);
+    if (opts.offset !== undefined) params["offset"] = String(opts.offset);
+    return client.rawRequest("GET", path, { params });
+  },
 }));
 
 vi.mock("../src/input.js", () => ({

--- a/tests/admin-policies.test.ts
+++ b/tests/admin-policies.test.ts
@@ -18,6 +18,19 @@ vi.mock("../src/helpers.js", () => ({
     if (opts.offset !== undefined) params["offset"] = String(opts.offset);
     return params;
   },
+  // Single-request passthrough; the real page-following logic is unit-tested
+  // in tests/helpers.test.ts against the unmocked implementation.
+  fetchPaginatedList: async (
+    client: { rawRequest: (method: string, path: string, options?: unknown) => Promise<unknown> },
+    path: string,
+    opts: { limit?: number; offset?: number },
+    extraParams: Record<string, string> = {},
+  ): Promise<unknown> => {
+    const params: Record<string, string> = { ...extraParams };
+    if (opts.limit !== undefined) params["limit"] = String(opts.limit);
+    if (opts.offset !== undefined) params["offset"] = String(opts.offset);
+    return client.rawRequest("GET", path, { params });
+  },
 }));
 
 vi.mock("../src/input.js", () => ({

--- a/tests/admin-tenants.test.ts
+++ b/tests/admin-tenants.test.ts
@@ -18,6 +18,19 @@ vi.mock("../src/helpers.js", () => ({
     if (opts.offset !== undefined) params["offset"] = String(opts.offset);
     return params;
   },
+  // Single-request passthrough; the real page-following logic is unit-tested
+  // in tests/helpers.test.ts against the unmocked implementation.
+  fetchPaginatedList: async (
+    client: { rawRequest: (method: string, path: string, options?: unknown) => Promise<unknown> },
+    path: string,
+    opts: { limit?: number; offset?: number },
+    extraParams: Record<string, string> = {},
+  ): Promise<unknown> => {
+    const params: Record<string, string> = { ...extraParams };
+    if (opts.limit !== undefined) params["limit"] = String(opts.limit);
+    if (opts.offset !== undefined) params["offset"] = String(opts.offset);
+    return client.rawRequest("GET", path, { params });
+  },
 }));
 
 vi.mock("../src/input.js", () => ({

--- a/tests/admin-users.test.ts
+++ b/tests/admin-users.test.ts
@@ -18,6 +18,19 @@ vi.mock("../src/helpers.js", () => ({
     if (opts.offset !== undefined) params["offset"] = String(opts.offset);
     return params;
   },
+  // Single-request passthrough; the real page-following logic is unit-tested
+  // in tests/helpers.test.ts against the unmocked implementation.
+  fetchPaginatedList: async (
+    client: { rawRequest: (method: string, path: string, options?: unknown) => Promise<unknown> },
+    path: string,
+    opts: { limit?: number; offset?: number },
+    extraParams: Record<string, string> = {},
+  ): Promise<unknown> => {
+    const params: Record<string, string> = { ...extraParams };
+    if (opts.limit !== undefined) params["limit"] = String(opts.limit);
+    if (opts.offset !== undefined) params["offset"] = String(opts.offset);
+    return client.rawRequest("GET", path, { params });
+  },
 }));
 
 vi.mock("../src/input.js", () => ({

--- a/tests/helpers.test.ts
+++ b/tests/helpers.test.ts
@@ -9,9 +9,10 @@ vi.mock("../src/output.js", () => ({
   printError: vi.fn(),
   printOutput: vi.fn(),
   printCount: vi.fn(),
+  printWarning: vi.fn(),
 }));
 
-import { printError, printOutput, printCount } from "../src/output.js";
+import { printError, printOutput, printCount, printWarning } from "../src/output.js";
 import { saveConfig } from "../src/config.js";
 import { DryRunSignal, GdbClientError, GdbClient } from "../src/client.js";
 import {
@@ -20,6 +21,7 @@ import {
   getFormat,
   outputResponse,
   withErrorHandler,
+  fetchPaginatedList,
 } from "../src/helpers.js";
 
 function fakeCmd(cliOpts: Partial<GlobalOptions> = {}): Command {
@@ -369,6 +371,112 @@ describe("helpers", () => {
       const wrapped = withErrorHandler(fn);
       await expect(wrapped()).rejects.toThrow("process.exit");
       expect(printError).toHaveBeenCalledWith("Forbidden");
+    });
+  });
+  describe("fetchPaginatedList", () => {
+    function pageResponse(items: unknown[], total?: number): ClientResponse {
+      const headers = new Headers();
+      if (total !== undefined) headers.set("X-Total-Count", String(total));
+      return { status: 200, headers, data: items };
+    }
+
+    function clientWithPages(...responses: ClientResponse[]): GdbClient {
+      const rawRequest = vi.fn();
+      for (const r of responses) rawRequest.mockResolvedValueOnce(r);
+      return { rawRequest } as unknown as GdbClient;
+    }
+
+    it("follows pages until X-Total-Count is reached when no flags are given", async () => {
+      const page1 = Array.from({ length: 100 }, (_, i) => ({ id: i }));
+      const page2 = Array.from({ length: 100 }, (_, i) => ({ id: 100 + i }));
+      const page3 = Array.from({ length: 50 }, (_, i) => ({ id: 200 + i }));
+      const client = clientWithPages(
+        pageResponse(page1, 250),
+        pageResponse(page2, 250),
+        pageResponse(page3, 250),
+      );
+
+      const response = await fetchPaginatedList(client, "/admin/users", {});
+
+      expect(client.rawRequest).toHaveBeenCalledTimes(3);
+      expect(client.rawRequest).toHaveBeenNthCalledWith(1, "GET", "/admin/users", {
+        params: { limit: "100", offset: "0" },
+      });
+      expect(client.rawRequest).toHaveBeenNthCalledWith(2, "GET", "/admin/users", {
+        params: { limit: "100", offset: "100" },
+      });
+      expect(client.rawRequest).toHaveBeenNthCalledWith(3, "GET", "/admin/users", {
+        params: { limit: "100", offset: "200" },
+      });
+      expect((response.data as unknown[]).length).toBe(250);
+    });
+
+    it("stops after a single short page", async () => {
+      const client = clientWithPages(pageResponse([{ id: 1 }, { id: 2 }], 2));
+      const response = await fetchPaginatedList(client, "/admin/users", {});
+      expect(client.rawRequest).toHaveBeenCalledTimes(1);
+      expect(response.data).toEqual([{ id: 1 }, { id: 2 }]);
+    });
+
+    it("stops on a short page even without X-Total-Count", async () => {
+      const client = clientWithPages(pageResponse(Array.from({ length: 7 }, (_, i) => ({ id: i }))));
+      const response = await fetchPaginatedList(client, "/rules", {});
+      expect(client.rawRequest).toHaveBeenCalledTimes(1);
+      expect((response.data as unknown[]).length).toBe(7);
+    });
+
+    it("returns an empty list for an empty first page", async () => {
+      const client = clientWithPages(pageResponse([], 0));
+      const response = await fetchPaginatedList(client, "/admin/users", {});
+      expect(response.data).toEqual([]);
+    });
+
+    it("passes non-array responses through untouched", async () => {
+      const data = { message: "not a collection" };
+      const client = clientWithPages({ status: 200, headers: new Headers(), data });
+      const response = await fetchPaginatedList(client, "/admin/users", {});
+      expect(response.data).toBe(data);
+    });
+
+    it("merges extra params into every page request", async () => {
+      const client = clientWithPages(pageResponse([{ id: 1 }], 1));
+      await fetchPaginatedList(client, "/admin/api-keys", {}, { tenantId: "t-1" });
+      expect(client.rawRequest).toHaveBeenCalledWith("GET", "/admin/api-keys", {
+        params: { tenantId: "t-1", limit: "100", offset: "0" },
+      });
+    });
+
+    it("issues a single request when --limit is given and warns about the remainder", async () => {
+      const client = clientWithPages(pageResponse(Array.from({ length: 20 }, (_, i) => ({ id: i })), 56));
+      const response = await fetchPaginatedList(client, "/admin/users", { limit: 20 });
+      expect(client.rawRequest).toHaveBeenCalledTimes(1);
+      expect(client.rawRequest).toHaveBeenCalledWith("GET", "/admin/users", {
+        params: { limit: "20" },
+      });
+      expect((response.data as unknown[]).length).toBe(20);
+      expect(printWarning).toHaveBeenCalledWith(
+        "Showing 20 of 56 results. 36 more available (use --offset 20).",
+      );
+    });
+
+    it("accounts for --offset in the truncation warning", async () => {
+      const client = clientWithPages(pageResponse(Array.from({ length: 10 }, (_, i) => ({ id: i })), 56));
+      await fetchPaginatedList(client, "/admin/users", { limit: 10, offset: 40 });
+      expect(printWarning).toHaveBeenCalledWith(
+        "Showing 10 of 56 results. 6 more available (use --offset 50).",
+      );
+    });
+
+    it("does not warn when an explicit request returns the full set", async () => {
+      const client = clientWithPages(pageResponse(Array.from({ length: 56 }, (_, i) => ({ id: i })), 56));
+      await fetchPaginatedList(client, "/admin/users", { limit: 100 });
+      expect(printWarning).not.toHaveBeenCalled();
+    });
+
+    it("does not warn on explicit requests when X-Total-Count is absent", async () => {
+      const client = clientWithPages(pageResponse(Array.from({ length: 20 }, (_, i) => ({ id: i }))));
+      await fetchPaginatedList(client, "/admin/users", { limit: 20 });
+      expect(printWarning).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/me-api-keys.test.ts
+++ b/tests/me-api-keys.test.ts
@@ -18,6 +18,19 @@ vi.mock("../src/helpers.js", () => ({
     if (opts.offset !== undefined) params["offset"] = String(opts.offset);
     return params;
   },
+  // Single-request passthrough; the real page-following logic is unit-tested
+  // in tests/helpers.test.ts against the unmocked implementation.
+  fetchPaginatedList: async (
+    client: { rawRequest: (method: string, path: string, options?: unknown) => Promise<unknown> },
+    path: string,
+    opts: { limit?: number; offset?: number },
+    extraParams: Record<string, string> = {},
+  ): Promise<unknown> => {
+    const params: Record<string, string> = { ...extraParams };
+    if (opts.limit !== undefined) params["limit"] = String(opts.limit);
+    if (opts.offset !== undefined) params["offset"] = String(opts.offset);
+    return client.rawRequest("GET", path, { params });
+  },
 }));
 
 vi.mock("../src/input.js", () => ({

--- a/tests/me-oauth-clients.test.ts
+++ b/tests/me-oauth-clients.test.ts
@@ -18,6 +18,19 @@ vi.mock("../src/helpers.js", () => ({
     if (opts.offset !== undefined) params["offset"] = String(opts.offset);
     return params;
   },
+  // Single-request passthrough; the real page-following logic is unit-tested
+  // in tests/helpers.test.ts against the unmocked implementation.
+  fetchPaginatedList: async (
+    client: { rawRequest: (method: string, path: string, options?: unknown) => Promise<unknown> },
+    path: string,
+    opts: { limit?: number; offset?: number },
+    extraParams: Record<string, string> = {},
+  ): Promise<unknown> => {
+    const params: Record<string, string> = { ...extraParams };
+    if (opts.limit !== undefined) params["limit"] = String(opts.limit);
+    if (opts.offset !== undefined) params["offset"] = String(opts.offset);
+    return client.rawRequest("GET", path, { params });
+  },
 }));
 
 vi.mock("../src/input.js", () => ({

--- a/tests/me-policies.test.ts
+++ b/tests/me-policies.test.ts
@@ -18,6 +18,19 @@ vi.mock("../src/helpers.js", () => ({
     if (opts.offset !== undefined) params["offset"] = String(opts.offset);
     return params;
   },
+  // Single-request passthrough; the real page-following logic is unit-tested
+  // in tests/helpers.test.ts against the unmocked implementation.
+  fetchPaginatedList: async (
+    client: { rawRequest: (method: string, path: string, options?: unknown) => Promise<unknown> },
+    path: string,
+    opts: { limit?: number; offset?: number },
+    extraParams: Record<string, string> = {},
+  ): Promise<unknown> => {
+    const params: Record<string, string> = { ...extraParams };
+    if (opts.limit !== undefined) params["limit"] = String(opts.limit);
+    if (opts.offset !== undefined) params["offset"] = String(opts.offset);
+    return client.rawRequest("GET", path, { params });
+  },
 }));
 
 vi.mock("../src/input.js", () => ({

--- a/tests/setup-command-mocks.ts
+++ b/tests/setup-command-mocks.ts
@@ -25,6 +25,20 @@ vi.mock("../src/helpers.js", () => ({
     if (opts.offset !== undefined) params["offset"] = String(opts.offset);
     return params;
   },
+  // Single-request passthrough so command tests keep asserting on
+  // client.rawRequest; the real page-following logic is unit-tested in
+  // tests/helpers.test.ts against the unmocked implementation.
+  fetchPaginatedList: async (
+    client: { rawRequest: (method: string, path: string, options?: unknown) => Promise<unknown> },
+    path: string,
+    opts: { limit?: number; offset?: number },
+    extraParams: Record<string, string> = {},
+  ): Promise<unknown> => {
+    const params: Record<string, string> = { ...extraParams };
+    if (opts.limit !== undefined) params["limit"] = String(opts.limit);
+    if (opts.offset !== undefined) params["offset"] = String(opts.offset);
+    return client.rawRequest("GET", path, { params });
+  },
 }));
 
 vi.mock("../src/input.js", () => ({


### PR DESCRIPTION
## 概要

Closes #139

list 系コマンドがサーバーのデフォルトページサイズ (20件) で結果を暗黙に切り捨てていた問題を修正する。

**Note: #140 の上に積んだ stacked PR** (base: `feature/issue-138-geonicdb-0.2.1-compat`)。#140 マージ後に base が main に自動で切り替わる。

## 問題

`admin users list` は「List **all** users」と説明されているが、サーバー (`GET /admin/users` 等) はデフォルトで 20 件しか返さず、CLI は続きの存在を一切表示しなかった。実際にステージングで 21 件目以降の登録済みユーザーを「未登録」と誤判断する実害が発生した (#139 参照)。同じ問題が pagination 対応の list 系コマンド全部にあった。

## 変更内容

`src/helpers.ts` に `fetchPaginatedList()` を追加し、以下の 11 コマンドを配線:

`admin users/tenants/policies/api-keys/oauth-clients list`, `me api-keys/oauth-clients/policies list`, `rules list`, `custom-data-models list`, `catalog datasets list`

- **`--limit`/`--offset` 未指定 (デフォルト)**: サーバーの `X-Total-Count` に従い、ページサイズ 100 (`ADMIN_MAX_LIMIT`) で全ページを自動取得して集約
- **`--limit`/`--offset` 明示**: 従来通り単一リクエスト。結果が全体の一部なら stderr に `Showing N of M results. K more available (use --offset X).` を警告表示 (stdout の JSON 出力は汚さない)
- 非配列レスポンスはそのままパススルー (将来のエンドポイント形状変更に対する保険)
- `types list` / `entities list` は NGSI データプレーンのページネーション (`NGSILD-Results-Count`, `options=count`) を使う別機構のため対象外

対象エンドポイントは全て `maxLimit: ADMIN_MAX_LIMIT (100)` + `X-Total-Count` 対応であることを本体側コードで確認済み (`parsePaginationParams` は超過 limit を 400 で弾くため、仕様が変わっても silent truncate には戻らない)。

## テスト

- `fetchPaginatedList` の単体テスト 10 本を追加 (ページ巡回・X-Total-Count なしの停止・空ページ・非配列パススルー・extraParams 伝播・打ち切り警告・警告なし条件)
- 既存のコマンドテストは共有モックにパススルー実装を追加して維持 (rawRequest への引数アサーションは従来通り機能)
- `npm run lint` / `npm run typecheck` / `npm test` (756 tests) ✅
- `npm run test:e2e`: **既存の flaky (auth.feature の whoami / auto-refresh が間欠的に 401)** に当たる場合がある。本変更と無関係であることは、変更を含まない base ブランチ (`feature/issue-138-...`) で同一の失敗が再現することで確認済み。同一コミットで全 141 シナリオがパスする実行も複数回確認している。flake 自体は別 issue として起票する


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 各種一覧コマンドで、ページ指定がない場合も複数ページを自動取得し、結果を正しく統合するよう改善しました。
  * `--limit` や `--offset` 指定時に、取得結果が一部である場合の警告表示を追加しました。
  * APIキー、ユーザー、ポリシー、テナント、モデルなどの一覧取得でページング挙動を統一しました。

* **テスト**
  * ページング、空の結果、追加パラメータ、警告表示などの検証を拡充しました。

* **ドキュメント**
  * 未リリース変更履歴を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->