### PR TITLE
fix: 存在しないサブコマンドへの --help をエラー扱いにして exit 1 を返す

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 
 ## [Unreleased]
 
+### 2026-07-15
+- **Fix**: 存在しないサブコマンドへの `--help` (`geonic hello --help` 等) がヘルプ表示 + exit 0 で成功扱いになっていた問題を修正 — `geonic help <unknown>` と同じエラーを stderr に出力し exit 1 を返す (#147)
+  - エラーメッセージはユーザーが入力したエイリアス表記をそのまま echo する（`models badsub` を `custom-data-models badsub` に置換しない）
+  - 未知オプションの値はサブコマンド名と誤認しない（`geonic entities --bogus json --help` は従来通りヘルプ表示）
+
 ## [0.18.0] - 2026-07-15
 
 ### 2026-07-15

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,7 +15,7 @@ import { registerRulesCommand } from "./commands/rules.js";
 import { registerModelsCommand } from "./commands/models.js";
 import { registerCatalogCommand } from "./commands/catalog.js";
 import { registerHealthCommand, registerVersionCommand } from "./commands/health.js";
-import { registerHelpCommand } from "./commands/help.js";
+import { enforceKnownCommandHelp, registerHelpCommand } from "./commands/help.js";
 import { registerCliCommand } from "./commands/cli.js";
 import { addAttrsSubcommands } from "./commands/attrs.js";
 
@@ -61,6 +61,8 @@ export function createProgram(): Command {
     .description("Manage entity attributes");
   addAttrsSubcommands(hiddenAttrs);
   program.addCommand(hiddenAttrs, { hidden: true });
+
+  enforceKnownCommandHelp(program);
 
   return program;
 }

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -1,5 +1,5 @@
 import chalk from "chalk";
-import type { Command, Help, Option } from "commander";
+import type { Command, Help, HelpContext, Option } from "commander";
 
 interface Example {
   description: string;
@@ -247,6 +247,42 @@ function showHelp(program: Command, args: string[]): void {
   const path = [program.name(), ...resolved.map((c) => c.name())].join(" ");
 
   console.log(formatCommandDetails(program, target, path));
+}
+
+function reportUnknownCommand(cmd: Command, operand: string): never {
+  // getCommandPath() starts with the program name ("geonic"); drop it
+  const prefix = getCommandPath(cmd).split(" ").slice(1);
+  const attempted = [...prefix, operand].join(" ");
+  console.error(chalk.red(`Error: '${attempted}' is not a geonic command.`));
+  console.error(`\nSee 'geonic help' for available commands.`);
+  process.exit(1);
+}
+
+export function enforceKnownCommandHelp(program: Command): void {
+  // Commander prints help and exits 0 when --help/-h is present, even if the
+  // remaining operand is not a known subcommand (e.g. `geonic hello --help`).
+  // Wrap outputHelp() on every command group so that case errors with exit 1,
+  // matching `geonic help <unknown>`. Call after all commands are registered.
+  const visit = (cmd: Command): void => {
+    if (cmd.commands.length > 0) {
+      const originalOutputHelp = cmd.outputHelp.bind(cmd);
+      // Same parameter type as Command.outputHelp (including deprecated overload)
+      cmd.outputHelp = (
+        contextOptions?: HelpContext | ((str: string) => string),
+      ): void => {
+        // cmd.args is operands followed by unparsed options such as --help
+        const operand = cmd.args.find((arg) => !arg.startsWith("-"));
+        if (operand !== undefined && !findCommand(cmd, operand)) {
+          reportUnknownCommand(cmd, operand);
+        }
+        originalOutputHelp(contextOptions as HelpContext | undefined);
+      };
+    }
+    for (const sub of cmd.commands) {
+      visit(sub);
+    }
+  };
+  visit(program);
 }
 
 export function registerHelpCommand(program: Command): void {

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -220,6 +220,12 @@ export function formatCommandDetails(
   return lines.join("\n");
 }
 
+function unknownCommandError(attempted: string): never {
+  console.error(chalk.red(`Error: '${attempted}' is not a geonic command.`));
+  console.error(`\nSee 'geonic help' for available commands.`);
+  process.exit(1);
+}
+
 function showHelp(program: Command, args: string[]): void {
   if (args.length === 0) {
     console.log(formatTopLevelHelp(program));
@@ -232,12 +238,7 @@ function showHelp(program: Command, args: string[]): void {
   for (let i = 0; i < args.length; i++) {
     const found = findCommand(current, args[i]);
     if (!found) {
-      const attempted = args.slice(0, i + 1).join(" ");
-      console.error(
-        chalk.red(`Error: '${attempted}' is not a geonic command.`),
-      );
-      console.error(`\nSee 'geonic help' for available commands.`);
-      process.exit(1);
+      unknownCommandError(args.slice(0, i + 1).join(" "));
     }
     resolved.push(found);
     current = found;
@@ -249,13 +250,31 @@ function showHelp(program: Command, args: string[]): void {
   console.log(formatCommandDetails(program, target, path));
 }
 
-function reportUnknownCommand(cmd: Command, operand: string): never {
-  // getCommandPath() starts with the program name ("geonic"); drop it
-  const prefix = getCommandPath(cmd).split(" ").slice(1);
-  const attempted = [...prefix, operand].join(" ");
-  console.error(chalk.red(`Error: '${attempted}' is not a geonic command.`));
-  console.error(`\nSee 'geonic help' for available commands.`);
-  process.exit(1);
+// Resolve the chain from the program down to cmd back to the tokens the user
+// actually typed (rawArgs), so aliases are echoed as typed (e.g. "models"),
+// not as their canonical name ("custom-data-models").
+function typedCommandPath(cmd: Command): string[] {
+  const chain: Command[] = [];
+  let current: Command | null = cmd;
+  while (current && current.parent) {
+    chain.unshift(current);
+    current = current.parent;
+  }
+
+  // rawArgs exists at runtime but is missing from commander's typings
+  const root = getRootProgram(cmd) as Command & { rawArgs: string[] };
+  const rawArgs = root.rawArgs.slice(2); // drop node + script
+
+  const typed: string[] = [];
+  let i = 0;
+  for (const c of chain) {
+    const names = [c.name(), ...c.aliases()];
+    while (i < rawArgs.length && !names.includes(rawArgs[i])) {
+      i++;
+    }
+    typed.push(i < rawArgs.length ? rawArgs[i] : c.name());
+  }
+  return typed;
 }
 
 export function enforceKnownCommandHelp(program: Command): void {
@@ -270,10 +289,16 @@ export function enforceKnownCommandHelp(program: Command): void {
       cmd.outputHelp = (
         contextOptions?: HelpContext | ((str: string) => string),
       ): void => {
-        // cmd.args is operands followed by unparsed options such as --help
-        const operand = cmd.args.find((arg) => !arg.startsWith("-"));
-        if (operand !== undefined && !findCommand(cmd, operand)) {
-          reportUnknownCommand(cmd, operand);
+        // cmd.args lists operands first, then unparsed options such as --help.
+        // Only a leading non-dash token is a genuine operand — a non-dash token
+        // found later may be the value of an unrecognized option.
+        const operand = cmd.args[0];
+        if (
+          operand !== undefined &&
+          !operand.startsWith("-") &&
+          !findCommand(cmd, operand)
+        ) {
+          unknownCommandError([...typedCommandPath(cmd), operand].join(" "));
         }
         originalOutputHelp(contextOptions as HelpContext | undefined);
       };

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -250,54 +250,50 @@ function showHelp(program: Command, args: string[]): void {
   console.log(formatCommandDetails(program, target, path));
 }
 
-// Resolve the chain from the program down to cmd back to the tokens the user
-// actually typed (rawArgs), so aliases are echoed as typed (e.g. "models"),
-// not as their canonical name ("custom-data-models").
-function typedCommandPath(cmd: Command): string[] {
-  const chain: Command[] = [];
-  let current: Command | null = cmd;
-  while (current && current.parent) {
-    chain.unshift(current);
-    current = current.parent;
-  }
-
-  // rawArgs exists at runtime but is missing from commander's typings
-  const root = getRootProgram(cmd) as Command & { rawArgs: string[] };
-  const rawArgs = root.rawArgs.slice(2); // drop node + script
-
-  const typed: string[] = [];
-  let i = 0;
-  for (const c of chain) {
-    const names = [c.name(), ...c.aliases()];
-    while (i < rawArgs.length && !names.includes(rawArgs[i])) {
-      i++;
-    }
-    typed.push(i < rawArgs.length ? rawArgs[i] : c.name());
-  }
-  return typed;
-}
-
 export function enforceKnownCommandHelp(program: Command): void {
   // Commander prints help and exits 0 when --help/-h is present, even if the
   // remaining operand is not a known subcommand (e.g. `geonic hello --help`).
   // Wrap outputHelp() on every command group so that case errors with exit 1,
   // matching `geonic help <unknown>`. Call after all commands are registered.
+
+  // Token the user actually typed to invoke each command (name or alias),
+  // recorded at dispatch time so error messages echo e.g. "models" as typed,
+  // not the canonical name "custom-data-models".
+  const typedNames = new WeakMap<Command, string>();
+
+  // Path from the program down to cmd, using the recorded typed tokens.
+  const typedCommandPath = (cmd: Command): string[] => {
+    const path: string[] = [];
+    let current: Command | null = cmd;
+    while (current && current.parent) {
+      path.unshift(typedNames.get(current) ?? current.name());
+      current = current.parent;
+    }
+    return path;
+  };
+
   const visit = (cmd: Command): void => {
     if (cmd.commands.length > 0) {
+      // preSubcommand fires on dispatch, before commander's --help
+      // short-circuit; parent.args[0] is the operand commander resolved the
+      // subcommand from. Hooks are not inherited, so attach per group.
+      cmd.hook("preSubcommand", (parent, subCommand) => {
+        const token = parent.args[0];
+        if (token !== undefined) {
+          typedNames.set(subCommand, token);
+        }
+      });
+
       const originalOutputHelp = cmd.outputHelp.bind(cmd);
       // Same parameter type as Command.outputHelp (including deprecated overload)
       cmd.outputHelp = (
         contextOptions?: HelpContext | ((str: string) => string),
       ): void => {
         // cmd.args lists operands first, then unparsed options such as --help.
-        // Only a leading non-dash token is a genuine operand — a non-dash token
-        // found later may be the value of an unrecognized option.
+        // Only a leading non-empty, non-dash token is a genuine operand — a
+        // non-dash token found later may be the value of an unrecognized option.
         const operand = cmd.args[0];
-        if (
-          operand !== undefined &&
-          !operand.startsWith("-") &&
-          !findCommand(cmd, operand)
-        ) {
+        if (operand && !operand.startsWith("-") && !findCommand(cmd, operand)) {
           unknownCommandError([...typedCommandPath(cmd), operand].join(" "));
         }
         originalOutputHelp(contextOptions as HelpContext | undefined);

--- a/tests/help.test.ts
+++ b/tests/help.test.ts
@@ -683,6 +683,60 @@ describe("help", () => {
     });
   });
 
+  describe("unknown subcommand with --help", () => {
+    async function runExpectingError(argv: string[]): Promise<string> {
+      const prog = createProgram();
+      prog.exitOverride();
+      const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+        throw new Error("process.exit");
+      });
+      try {
+        await prog.parseAsync(["node", "geonic", ...argv]);
+      } catch {
+        // expected
+      }
+      const output = stripAnsi(errSpy.mock.calls.map((c) => c[0]).join("\n"));
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      errSpy.mockRestore();
+      exitSpy.mockRestore();
+      return output;
+    }
+
+    it("errors for unknown top-level command with --help", async () => {
+      const output = await runExpectingError(["hello", "--help"]);
+      expect(output).toContain("'hello' is not a geonic command");
+      expect(output).toContain("geonic help");
+    });
+
+    it("errors for unknown top-level command with -h", async () => {
+      const output = await runExpectingError(["hello", "-h"]);
+      expect(output).toContain("'hello' is not a geonic command");
+    });
+
+    it("errors for unknown nested subcommand with --help", async () => {
+      const output = await runExpectingError(["entities", "hello", "--help"]);
+      expect(output).toContain("'entities hello' is not a geonic command");
+    });
+
+    it("still shows help for a leaf command with an argument and --help", async () => {
+      const prog = createProgram();
+      prog.exitOverride();
+      const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+      const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      try {
+        await prog.parseAsync(["node", "geonic", "entities", "get", "urn:x", "--help"]);
+      } catch {
+        // exitOverride throws on help
+      }
+      const output = stripAnsi(writeSpy.mock.calls.map((c) => c[0]).join(""));
+      expect(output).toContain("geonic entities get");
+      expect(errSpy).not.toHaveBeenCalled();
+      writeSpy.mockRestore();
+      errSpy.mockRestore();
+    });
+  });
+
   describe("no-args handler", () => {
     it("shows help when geonic is run with no arguments", async () => {
       const prog = createProgram();

--- a/tests/help.test.ts
+++ b/tests/help.test.ts
@@ -26,15 +26,18 @@ async function runExpectingError(argv: string[]): Promise<string> {
     throw new Error("process.exit");
   });
   try {
-    await prog.parseAsync(["node", "geonic", ...argv]);
-  } catch {
-    // expected
+    try {
+      await prog.parseAsync(["node", "geonic", ...argv]);
+    } catch {
+      // expected
+    }
+    const output = stripAnsi(errSpy.mock.calls.map((c) => c[0]).join("\n"));
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    return output;
+  } finally {
+    errSpy.mockRestore();
+    exitSpy.mockRestore();
   }
-  const output = stripAnsi(errSpy.mock.calls.map((c) => c[0]).join("\n"));
-  expect(exitSpy).toHaveBeenCalledWith(1);
-  errSpy.mockRestore();
-  exitSpy.mockRestore();
-  return output;
 }
 
 describe("help", () => {
@@ -700,15 +703,18 @@ describe("help", () => {
       const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
       const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
       try {
-        await prog.parseAsync(["node", "geonic", ...argv]);
-      } catch {
-        // exitOverride throws on help
+        try {
+          await prog.parseAsync(["node", "geonic", ...argv]);
+        } catch {
+          // exitOverride throws on help
+        }
+        const output = stripAnsi(writeSpy.mock.calls.map((c) => c[0]).join(""));
+        expect(errSpy).not.toHaveBeenCalled();
+        return output;
+      } finally {
+        writeSpy.mockRestore();
+        errSpy.mockRestore();
       }
-      const output = stripAnsi(writeSpy.mock.calls.map((c) => c[0]).join(""));
-      expect(errSpy).not.toHaveBeenCalled();
-      writeSpy.mockRestore();
-      errSpy.mockRestore();
-      return output;
     }
 
     it("errors for unknown top-level command with --help", async () => {

--- a/tests/help.test.ts
+++ b/tests/help.test.ts
@@ -16,6 +16,27 @@ function findCommand(program: ReturnType<typeof createProgram>, ...names: string
   return current;
 }
 
+// Parses argv expecting the unknown-command error path: captures stderr,
+// asserts process.exit(1), and returns the stripped stderr output.
+async function runExpectingError(argv: string[]): Promise<string> {
+  const prog = createProgram();
+  prog.exitOverride();
+  const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+    throw new Error("process.exit");
+  });
+  try {
+    await prog.parseAsync(["node", "geonic", ...argv]);
+  } catch {
+    // expected
+  }
+  const output = stripAnsi(errSpy.mock.calls.map((c) => c[0]).join("\n"));
+  expect(exitSpy).toHaveBeenCalledWith(1);
+  errSpy.mockRestore();
+  exitSpy.mockRestore();
+  return output;
+}
+
 describe("help", () => {
   const program = createProgram();
 
@@ -609,21 +630,8 @@ describe("help", () => {
     });
 
     it("shows error for invalid command name in help", async () => {
-      const prog = createProgram();
-      prog.exitOverride();
-      const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-      const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
-        throw new Error("process.exit");
-      });
-      try {
-        await prog.parseAsync(["node", "geonic", "help", "nonexistent"]);
-      } catch {
-        // expected
-      }
-      const output = errSpy.mock.calls.map((c) => c[0]).join("\n");
-      expect(stripAnsi(output)).toContain("'nonexistent' is not a geonic command");
-      errSpy.mockRestore();
-      exitSpy.mockRestore();
+      const output = await runExpectingError(["help", "nonexistent"]);
+      expect(output).toContain("'nonexistent' is not a geonic command");
     });
 
     it("shows top-level help when help is called with no args", async () => {
@@ -684,22 +692,22 @@ describe("help", () => {
   });
 
   describe("unknown subcommand with --help", () => {
-    async function runExpectingError(argv: string[]): Promise<string> {
+    // Parses argv expecting help to be shown: captures stdout and returns it,
+    // asserting no error was printed.
+    async function runExpectingHelp(argv: string[]): Promise<string> {
       const prog = createProgram();
       prog.exitOverride();
+      const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
       const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-      const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
-        throw new Error("process.exit");
-      });
       try {
         await prog.parseAsync(["node", "geonic", ...argv]);
       } catch {
-        // expected
+        // exitOverride throws on help
       }
-      const output = stripAnsi(errSpy.mock.calls.map((c) => c[0]).join("\n"));
-      expect(exitSpy).toHaveBeenCalledWith(1);
+      const output = stripAnsi(writeSpy.mock.calls.map((c) => c[0]).join(""));
+      expect(errSpy).not.toHaveBeenCalled();
+      writeSpy.mockRestore();
       errSpy.mockRestore();
-      exitSpy.mockRestore();
       return output;
     }
 
@@ -720,20 +728,25 @@ describe("help", () => {
     });
 
     it("still shows help for a leaf command with an argument and --help", async () => {
-      const prog = createProgram();
-      prog.exitOverride();
-      const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-      const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-      try {
-        await prog.parseAsync(["node", "geonic", "entities", "get", "urn:x", "--help"]);
-      } catch {
-        // exitOverride throws on help
-      }
-      const output = stripAnsi(writeSpy.mock.calls.map((c) => c[0]).join(""));
+      const output = await runExpectingHelp(["entities", "get", "urn:x", "--help"]);
       expect(output).toContain("geonic entities get");
-      expect(errSpy).not.toHaveBeenCalled();
-      writeSpy.mockRestore();
-      errSpy.mockRestore();
+    });
+
+    it("echoes the alias the user typed, not the canonical command name", async () => {
+      const output = await runExpectingError(["models", "badsub", "--help"]);
+      expect(output).toContain("'models badsub' is not a geonic command");
+      expect(output).not.toContain("custom-data-models");
+    });
+
+    it("does not mistake an unknown option's value for a subcommand", async () => {
+      // "--bogus json" must not be reported as `geonic entities json`
+      const output = await runExpectingHelp(["entities", "--bogus", "json", "--help"]);
+      expect(output).toContain("geonic entities");
+    });
+
+    it("shows top-level help when --help precedes a non-command token", async () => {
+      const output = await runExpectingHelp(["--help", "hello"]);
+      expect(output).toContain("AVAILABLE COMMANDS");
     });
   });
 

--- a/tests/help.test.ts
+++ b/tests/help.test.ts
@@ -738,6 +738,15 @@ describe("help", () => {
       expect(output).not.toContain("custom-data-models");
     });
 
+    it("echoes the typed alias even when an option value collides with a command name", async () => {
+      // The --service value must not be mistaken for the typed command token
+      const output = await runExpectingError([
+        "--service", "custom-data-models", "models", "badsub", "--help",
+      ]);
+      expect(output).toContain("'models badsub' is not a geonic command");
+      expect(output).not.toContain("custom-data-models badsub");
+    });
+
     it("does not mistake an unknown option's value for a subcommand", async () => {
       // "--bogus json" must not be reported as `geonic entities json`
       const output = await runExpectingHelp(["entities", "--bogus", "json", "--help"]);
@@ -747,6 +756,16 @@ describe("help", () => {
     it("shows top-level help when --help precedes a non-command token", async () => {
       const output = await runExpectingHelp(["--help", "hello"]);
       expect(output).toContain("AVAILABLE COMMANDS");
+    });
+
+    it("shows group help when --help precedes a non-command token in a subgroup", async () => {
+      const output = await runExpectingHelp(["entities", "--help", "badsub"]);
+      expect(output).toContain("geonic entities");
+    });
+
+    it("does not report an empty-string operand as an unknown command", async () => {
+      const output = await runExpectingHelp(["entities", "", "--help"]);
+      expect(output).toContain("geonic entities");
     });
   });
 


### PR DESCRIPTION
## 概要

`geonic hello --help` のような存在しないサブコマンドに対するヘルプ実行が、トップレベルのヘルプを表示して exit 0 で成功扱いになっていた。エラーメッセージを stderr に出力し、exit 1 を返すようにする。

## 原因

Commander は `--help`/`-h` を検出すると、残りの operand が既知のサブコマンドか検証する前に `_outputHelpIfRequested` でヘルプを表示して exit 0 する。ルート・グループ配下（`geonic entities hello --help`）の両方で発生していた。

## 実装

- `enforceKnownCommandHelp()` を追加し、サブコマンドを持つ全コマンドの `outputHelp` をラップ。未知のサブコマンド名が operand に残っている場合は `geonic help <unknown>` と同じエラー形式で exit 1
- operand 判定は `cmd.args` の**先頭トークンのみ**（commander は operands を unknown オプションより前に並べるため、未知オプションの値を誤ってサブコマンド名と判定しない）
- エラーメッセージはユーザーが入力したエイリアスをそのまま echo（`models badsub` → `'models badsub'`。正規名 `custom-data-models` に置換しない）
- unknown-command エラー出力を `unknownCommandError()` に統合し showHelp と共有

## 挙動

| コマンド | Before | After |
|---|---|---|
| `geonic hello --help` | トップレベルヘルプ / exit 0 | `Error: 'hello' is not a geonic command.` / exit 1 |
| `geonic entities hello --help` | entities ヘルプ / exit 0 | `Error: 'entities hello' ...` / exit 1 |
| `geonic models badsub --help` | models ヘルプ / exit 0 | `Error: 'models badsub' ...` / exit 1 |
| `geonic entities --bogus json --help` | entities ヘルプ / exit 0 | 変更なし（値 "json" をコマンド名と誤認しない） |
| `geonic --help` / `entities --help` 等の正常系 | ヘルプ / exit 0 | 変更なし |

## テスト

- 単体テスト 7 件追加（--help/-h/ネスト/エイリアス echo/オプション値誤認防止/正常系リーフ/--help 先行）
- lint / typecheck / unit 770 件パス

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * 存在しないサブコマンドで `--help` または `-h` を指定した場合、ヘルプ表示のみで成功終了していた挙動を修正し、エラーメッセージ出力のうえ終了コード 1 に変更。
  * 入力したコマンド名やエイリアスをエラーメッセージに適切に反映。
* **テスト**
  * ヘルプ表示時の未知コマンド挙動を検証するテストを整理・追加。
* **ドキュメント**
  * 未リリースの変更履歴に更新内容を記載。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->