### PR TITLE
test: models.feature の @wip 解除と一意制約 E2E シナリオ追加 (geonicdb#1268 追従)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ## [Unreleased]
 
 ### 2026-07-15
-- **Test**: `models.feature` の @wip を解除し、一意制約（geonicdb#1268）の E2E シナリオを追加 (#147)
+- **Test**: `models.feature` の @wip を解除し、一意制約（geonicdb#1268）の E2E シナリオを追加 (#148)
   - @wip の理由だった「モデル作成に tenantId が必要」は、e2e hooks の `e2e_test` テナント + tenant_admin 整備（#143）で解消済みだったため既存 6 シナリオをそのまま有効化
   - 新規シナリオ: 制約宣言 → `models get --format table` の可読表示確認 → 重複エンティティの exit 1 + 違反制約名 + ヒント表示 → `uniqueConstraints: []` での全削除後に重複作成可
   - 既存の get/delete シナリオが Mongo の `id` を渡していたのを type 指定に修正（API はモデルを type でキーする: `GET/DELETE /custom-data-models/{type}`）

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@
 
 ## [Unreleased]
 
+### 2026-07-15
+- **Test**: `models.feature` の @wip を解除し、一意制約（geonicdb#1268）の E2E シナリオを追加 (#147)
+  - @wip の理由だった「モデル作成に tenantId が必要」は、e2e hooks の `e2e_test` テナント + tenant_admin 整備（#143）で解消済みだったため既存 6 シナリオをそのまま有効化
+  - 新規シナリオ: 制約宣言 → `models get --format table` の可読表示確認 → 重複エンティティの exit 1 + 違反制約名 + ヒント表示 → `uniqueConstraints: []` での全削除後に重複作成可
+  - 既存の get/delete シナリオが Mongo の `id` を渡していたのを type 指定に修正（API はモデルを type でキーする: `GET/DELETE /custom-data-models/{type}`）
+  - devDependency の geonicdb を一意制約実装済みの main (`913ceecf`) に更新
+
 ## [0.18.0] - 2026-07-15
 
 ### 2026-07-15

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@types/node": "^22.13.0",
         "@vitest/coverage-v8": "^4.1.8",
         "eslint": "^9.19.0",
-        "geonicdb": "github:geolonia/geonicdb#53e276825754ee7718218dde4a5abc4c6d8b76b5",
+        "geonicdb": "github:geolonia/geonicdb#913ceecf31285ef2cf7d7a0c04370f869de0480b",
         "mongodb": "^7.1.0",
         "mongodb-memory-server": "^11.0.1",
         "prettier": "^3.4.2",
@@ -6636,8 +6636,8 @@
     },
     "node_modules/geonicdb": {
       "version": "0.14.0",
-      "resolved": "git+ssh://git@github.com/geolonia/geonicdb.git#53e276825754ee7718218dde4a5abc4c6d8b76b5",
-      "integrity": "sha512-gBUOV6/4ANjWvGeqxR0+EPROXTCoyWkkAtBhPPIgKyS9VP6hD9zENNZ4y6/449eQjGoQ5Azhn0EZ/FAk3RPBrw==",
+      "resolved": "git+ssh://git@github.com/geolonia/geonicdb.git#913ceecf31285ef2cf7d7a0c04370f869de0480b",
+      "integrity": "sha512-qgAPXatASvID6XkqOTL/9RGZhEx0JrHCfVDM9J0eUHIiTU0YnLdJeU8h8D1s4Oj3Si8PNaRvruq1yA6Xf0XCmg==",
       "dev": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@types/node": "^22.13.0",
     "@vitest/coverage-v8": "^4.1.8",
     "eslint": "^9.19.0",
-    "geonicdb": "github:geolonia/geonicdb#53e276825754ee7718218dde4a5abc4c6d8b76b5",
+    "geonicdb": "github:geolonia/geonicdb#913ceecf31285ef2cf7d7a0c04370f869de0480b",
     "mongodb": "^7.1.0",
     "mongodb-memory-server": "^11.0.1",
     "prettier": "^3.4.2",

--- a/tests/e2e/features/models.feature
+++ b/tests/e2e/features/models.feature
@@ -1,6 +1,7 @@
-@extended-api @wip
+@extended-api
 Feature: Custom data model management
-  # Server requires tenantId for model creation; skipping until multi-tenant test support
+  # Model creation requires a tenant-scoped actor; the e2e hooks provision the
+  # "e2e_test" tenant and a tenant_admin, and "I am logged in" uses that admin.
   As a CLI user
   I want to manage custom data models
   So that I can define entity schemas
@@ -24,24 +25,58 @@ Feature: Custom data model management
     And the output should contain "TestModel02"
 
   Scenario: Get a model by ID
+    # モデルの ID はエンティティタイプ (API: GET /custom-data-models/{type})
     Given I am logged in
     And I run `geonic models create '{"type":"TestModel03","domain":"test","description":"Model TestModel03","propertyDetails":{"temperature":{"ngsiType":"Property","valueType":"Number","example":25},"humidity":{"ngsiType":"Property","valueType":"Number","example":60}}}'`
-    And I run `geonic models list --format json`
-    And I save the ID from the JSON output
-    When I run `geonic models get $ID` replacing ID
+    When I run `geonic models get TestModel03`
     Then the exit code should be 0
     And stdout should be valid JSON
+    And the output should contain "TestModel03"
 
   Scenario: Delete a model
+    # モデルの ID はエンティティタイプ (API: DELETE /custom-data-models/{type})
     Given I am logged in
     And I run `geonic models create '{"type":"TestModel04","domain":"test","description":"Model TestModel04","propertyDetails":{"temperature":{"ngsiType":"Property","valueType":"Number","example":25},"humidity":{"ngsiType":"Property","valueType":"Number","example":60}}}'`
-    And I run `geonic models list --format json`
-    And I save the ID from the JSON output
-    When I run `geonic models delete $ID` replacing ID
+    When I run `geonic models delete TestModel04`
     Then the exit code should be 0
     And the output should contain "Model deleted."
 
   Scenario: custom-data-models alias works
     Given I am logged in
     When I run `geonic custom-data-models list`
+    Then the exit code should be 0
+
+  Scenario: Declare unique constraints and enforce duplicates (geonicdb#1268)
+    Given I am logged in
+    When I run `geonic models create '{"type":"UcReservation","domain":"test","description":"Reservation with unique constraint","propertyDetails":{"room":{"ngsiType":"Property","valueType":"string","example":"R1"},"date":{"ngsiType":"Property","valueType":"string","example":"2026-07-15"}},"uniqueConstraints":[{"name":"no-double-booking","fields":["room","date"]}]}' --service e2e_test`
+    Then the exit code should be 0
+    And the output should contain "Model created."
+    # models get shows the constraint (readable form in table format)
+    When I run `geonic models get UcReservation --format table --service e2e_test`
+    Then the exit code should be 0
+    And the output should contain "no-double-booking(room, date)"
+    # first entity is accepted
+    When I run `geonic entities create '{"id":"urn:ngsi-ld:UcReservation:001","type":"UcReservation","room":{"type":"Property","value":"R1"},"date":{"type":"Property","value":"2026-07-15"}}' --service e2e_test`
+    Then the exit code should be 0
+    # duplicate combination is rejected with the violated constraint name and a hint
+    When I run `geonic entities create '{"id":"urn:ngsi-ld:UcReservation:002","type":"UcReservation","room":{"type":"Property","value":"R1"},"date":{"type":"Property","value":"2026-07-15"}}' --service e2e_test`
+    Then the exit code should be 1
+    And the output should contain "violates unique constraint 'no-double-booking'"
+    And stderr should contain "geonic models get"
+    # a different combination is accepted
+    When I run `geonic entities create '{"id":"urn:ngsi-ld:UcReservation:003","type":"UcReservation","room":{"type":"Property","value":"R2"},"date":{"type":"Property","value":"2026-07-15"}}' --service e2e_test`
+    Then the exit code should be 0
+
+  Scenario: Remove unique constraints via update (geonicdb#1268)
+    Given I am logged in
+    And I run `geonic models create '{"type":"UcSlot","domain":"test","description":"Slot with removable constraint","propertyDetails":{"code":{"ngsiType":"Property","valueType":"string","example":"A1"}},"uniqueConstraints":[{"name":"unique-code","fields":["code"]}]}' --service e2e_test`
+    And I run `geonic entities create '{"id":"urn:ngsi-ld:UcSlot:001","type":"UcSlot","code":{"type":"Property","value":"A1"}}' --service e2e_test`
+    When I run `geonic entities create '{"id":"urn:ngsi-ld:UcSlot:002","type":"UcSlot","code":{"type":"Property","value":"A1"}}' --service e2e_test`
+    Then the exit code should be 1
+    And the output should contain "unique-code"
+    # replacing the list with [] removes all constraints
+    When I run `geonic models update UcSlot '{"uniqueConstraints":[]}' --service e2e_test`
+    Then the exit code should be 0
+    And the output should contain "Model updated."
+    When I run `geonic entities create '{"id":"urn:ngsi-ld:UcSlot:002","type":"UcSlot","code":{"type":"Property","value":"A1"}}' --service e2e_test`
     Then the exit code should be 0


### PR DESCRIPTION
## 概要

geolonia/geonicdb#1268（一意制約）の本体マージ（`913ceecf`）を受けた CLI 側の残タスク対応。

## 変更内容

- **devDependency 更新**: `geonicdb` を一意制約実装済みの main (`913ceecf`) に更新（package-lock の解決ハッシュも明示 install で更新）
- **`models.feature` の @wip 解除**: skip 理由だった「Server requires tenantId for model creation」は、e2e hooks の `e2e_test` テナント + tenant_admin 整備で解消済みだったため、既存シナリオを有効化
- **既存シナリオの修正**: get/delete が `models list` の JSON から Mongo の `id` を拾って渡していたが、API はモデルを **type** でキーする（`GET/DELETE /custom-data-models/{type}`）ため type 直指定に修正
- **一意制約シナリオを追加**（PR #145 の機能を実サーバーで検証）:
  - `uniqueConstraints` 宣言付き `models create` → `models get --format table` で `no-double-booking(room, date)` の可読表示
  - 重複エンティティ作成 → exit 1 + 違反制約名 + `geonic models get` ヒント（stderr）
  - `uniqueConstraints: []` の全置換で制約削除 → 重複作成可

## テスト

- lint / typecheck / unit 763 全通過
- E2E 149 シナリオ（models.feature 8 本含む）全通過

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * モデルに一意制約を設定できるようになり、重複するエンティティの作成時に制約名とヒントを含むエラーを表示します。
  * 一意制約を削除すると、重複するエンティティを作成できるようになります。
  * モデル詳細のテーブル表示で、一意制約を確認できます。

* **改善**
  * モデルの取得・削除をタイプ指定で実行できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->