### PR TITLE
release: v0.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## [Unreleased]
 
+## [0.18.1] - 2026-07-15
+
 ### 2026-07-15
 - **Test**: `models.feature` の @wip を解除し、一意制約（geonicdb#1268）の E2E シナリオを追加 (#148)
   - @wip の理由だった「モデル作成に tenantId が必要」は、e2e hooks の `e2e_test` テナント + tenant_admin 整備（#143）で解消済みだったため既存 6 シナリオをそのまま有効化
@@ -291,7 +293,8 @@
 ### 2026-02-26
 - **Docs**: README にインストール手順・使い方・コマンドリファレンスを追加 (#1)
 
-[Unreleased]: https://github.com/geolonia/geonicdb-cli/compare/v0.18.0...HEAD
+[Unreleased]: https://github.com/geolonia/geonicdb-cli/compare/v0.18.1...HEAD
+[0.18.1]: https://github.com/geolonia/geonicdb-cli/compare/v0.18.0...v0.18.1
 [0.18.0]: https://github.com/geolonia/geonicdb-cli/compare/v0.17.0...v0.18.0
 [0.17.0]: https://github.com/geolonia/geonicdb-cli/compare/v0.16.2...v0.17.0
 [0.16.2]: https://github.com/geolonia/geonicdb-cli/compare/v0.16.1...v0.16.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolonia/geonicdb-cli",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolonia/geonicdb-cli",
-      "version": "0.18.0",
+      "version": "0.18.1",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolonia/geonicdb-cli",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "A CLI client for the GeonicDB",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## v0.18.1 リリース

パッチリリース。含まれる変更:

- **Fix**: 存在しないサブコマンドへの `--help` がヘルプ表示 + exit 0 になっていた問題を修正 — エラー + exit 1 に (#147)
- **Test**: `models.feature` の @wip 解除と一意制約（geonicdb#1268）E2E シナリオ追加、devDependency geonicdb を `913ceecf` に更新 (#148)

## 変更内容

- `package.json` / `package-lock.json`: 0.18.0 → 0.18.1
- `CHANGELOG.md`: [Unreleased] を [0.18.1] セクションに移動、比較リンク更新

マージ後に `v0.18.1` タグを push し、publish workflow で npm 公開する。