### PR TITLE
feat(import): クライアント駆動バルクローダー `geonic import` (closes #151)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@
 
 ## [Unreleased]
 
+### 2026-07-20
+- **Feat**: `geonic import` — 巨大データセット向けのクライアント駆動バルクローダーを追加 (geonicdb#1409, #151)
+  - NDJSON をストリーミングで読み、件数 + バイトの両基準でチャンク分割して batch upsert に投入。API Gateway の 29 秒制限を回避
+  - 429(Retry-After 尊重・プロセス全体クールダウン)/5xx/タイムアウトを指数バックオフ + jitter でリトライ
+  - `--resume` によるチェックポイント再開（入力ファイル同一性 + mode/format 一致を検証、atomic write、upsert + ファイル入力限定）
+  - 失敗の 2 系統出力: `--errors-out`(再投入可能な NDJSON) と `--errors-log`(理由/ステータス/行番号)
+  - 400 chunk 失敗時の `--bisect` による不正エンティティの二分探索特定
+  - 既定はエラーで停止、`--continue-on-error` で継続。`--dry-run` で送信せず計画を表示
+  - `--mode replace` は再送で最新を上書きするため resume 非対応 + 警告表示（at-least-once の副作用を明記）
+  - `client.ts`: リクエストの `AbortSignal` タイムアウトと 429 応答の `Retry-After` パースに対応
+
 ## [0.18.1] - 2026-07-15
 
 ### 2026-07-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ## [Unreleased]
 
 ### 2026-07-20
-- **Feat**: `geonic import` — 巨大データセット向けのクライアント駆動バルクローダーを追加 (geonicdb#1409, #151)
+- **Feat**: `geonic import` — 巨大データセット向けのクライアント駆動バルクローダーを追加 (#152, closes #151, geonicdb#1409)
   - NDJSON をストリーミングで読み、件数 + バイトの両基準でチャンク分割して batch upsert に投入。API Gateway の 29 秒制限を回避
   - 429(Retry-After 尊重・プロセス全体クールダウン)/5xx/タイムアウトを指数バックオフ + jitter でリトライ
   - `--resume` によるチェックポイント再開（入力ファイル同一性 + mode/format 一致を検証、atomic write、upsert + ファイル入力限定）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,8 +49,10 @@ src/
 ├── client.ts             # HTTP client for GeonicDB API
 ├── config.ts             # Configuration management (~/.config/geonic/config.json)
 ├── helpers.ts            # Shared utility functions
-├── input.ts              # Input parsing (JSON5, stdin auto-detect, interactive mode)
+├── input.ts              # Input parsing (JSON5, stdin auto-detect, interactive mode, NDJSON streaming)
 ├── output.ts             # Output formatting (json, table, geojson)
+├── loader.ts             # Bulk-import orchestrator (chunking, retry, resume, error sinks)
+├── retry.ts              # Exponential-backoff retry helper (429 Retry-After / 5xx / timeout)
 ├── types.ts              # Shared TypeScript types
 ├── oauth.ts              # OAuth token requests
 ├── token.ts              # Token management & refresh
@@ -60,6 +62,7 @@ src/
     ├── entities.ts       # Entity CRUD + attrs subcommand
     ├── attrs.ts          # Attribute operations (entities attrs subcommand)
     ├── batch.ts          # entityOperations (alias: batch) — batch entity operations
+    ├── import.ts         # Bulk-load entities from a file (chunked, retry, resume)
     ├── subscriptions.ts  # Subscription management
     ├── registrations.ts  # Registration management
     ├── types.ts          # Entity type queries

--- a/README.md
+++ b/README.md
@@ -358,6 +358,54 @@ geonic me oauth-clients update <client-id> --policy-id my-readonly
 
 `batch` is available as an alias for `entityOperations`.
 
+### import — Bulk-load entities (large datasets)
+
+`entityOperations upsert` sends the whole payload in a single request, so it is bounded by the
+server's batch size and the API Gateway 29-second timeout. For nationwide-scale loads
+(hundreds of thousands to millions of entities), use `import`, which streams the input, splits it
+into batch-upsert requests (by entity count **and** byte size), retries transient failures, and
+can resume after an interruption.
+
+```bash
+# Load an NDJSON file (one entity per line)
+geonic import entities.ndjson
+
+# Resumable load with error capture
+geonic import entities.ndjson \
+  --resume .import.ckpt \
+  --errors-out failed.ndjson \
+  --errors-log errors.log
+
+# Re-submit only the entities that failed
+geonic import failed.ndjson
+
+# Preview the plan without sending anything
+geonic import entities.ndjson --dry-run
+```
+
+| Option | Description |
+|---|---|
+| `--input-format <fmt>` | `ndjson` (default, streamed) or `json` (a JSON array, loaded into memory) |
+| `--mode <mode>` | `upsert` (merge, default) or `replace` |
+| `--batch-size <n>` | Entities per request (default 100; must not exceed your plan's max batch size) |
+| `--max-bytes <n>` | Max request body bytes per chunk (default 1,000,000) |
+| `--concurrency <n>` | Concurrent requests (default 1 = sequential; a shared cooldown honors 429s) |
+| `--retries <n>` | Max retries per chunk on 429/5xx/timeout (default 5) |
+| `--timeout <ms>` | Per-request timeout (default 60,000) |
+| `--continue-on-error` | Keep going after failures (default: stop at the first failure) |
+| `--resume <checkpoint>` | Resume from a checkpoint file (upsert + file input only) |
+| `--errors-out <file>` | Write failed entities as re-submittable NDJSON |
+| `--errors-log <file>` | Write failure details (reason/status/line) as NDJSON |
+| `--bisect` / `--bisect-max <n>` | On a `400`/`413` chunk, binary-split to isolate the offending entity |
+
+Notes:
+- Input is read from a file path or, with `-` / a pipe, from stdin. **Resume is only available for
+  file input** (stdin cannot be replayed) and **only with `--mode upsert`** (replaying a `replace`
+  would overwrite newer state).
+- Retries and resume are **at-least-once**: a re-sent chunk re-runs the upsert (and its change
+  events / notifications). Upserts are idempotent in value but not in side effects — see the
+  warning printed for `--mode replace`.
+
 ### subscriptions (sub) — Manage context subscriptions
 
 | Subcommand | Description |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import { registerAuthCommands } from "./commands/auth.js";
 import { registerProfileCommands } from "./commands/profile.js";
 import { registerEntitiesCommand } from "./commands/entities.js";
 import { registerBatchCommand } from "./commands/batch.js";
+import { registerImportCommand } from "./commands/import.js";
 import { registerSubscriptionsCommand } from "./commands/subscriptions.js";
 import { registerRegistrationsCommand } from "./commands/registrations.js";
 import { registerTypesCommand } from "./commands/types.js";
@@ -43,6 +44,7 @@ export function createProgram(): Command {
   registerProfileCommands(program);
   registerEntitiesCommand(program);
   registerBatchCommand(program);
+  registerImportCommand(program);
   registerSubscriptionsCommand(program);
   registerRegistrationsCommand(program);
   registerTypesCommand(program);

--- a/src/client.ts
+++ b/src/client.ts
@@ -269,6 +269,7 @@ export class GdbClient {
       body?: unknown;
       params?: Record<string, string>;
       headers?: Record<string, string>;
+      signal?: AbortSignal;
     },
   ): Promise<ClientResponse<T>> {
     const url = this.buildUrl(`${this.getBasePath()}${path}`, options?.params);
@@ -277,7 +278,7 @@ export class GdbClient {
 
     this.logRequest(method, url, headers, body);
     this.handleDryRun(method, url, headers, body);
-    const response = await fetch(url, { method, headers, body });
+    const response = await fetch(url, { method, headers, body, signal: options?.signal });
     this.logResponse(response);
 
     const countHeader = response.headers.get("NGSILD-Results-Count");
@@ -297,7 +298,12 @@ export class GdbClient {
       const err = data as unknown as NgsiError;
       const message =
         err?.description || err?.detail || err?.error || err?.title || `HTTP ${response.status}`;
-      throw new GdbClientError(message, response.status, err);
+      throw new GdbClientError(
+        message,
+        response.status,
+        err,
+        parseRetryAfter(response.headers.get("retry-after")),
+      );
     }
 
     return { status: response.status, headers: response.headers, data, count };
@@ -311,6 +317,7 @@ export class GdbClient {
       params?: Record<string, string>;
       headers?: Record<string, string>;
       skipTenantHeader?: boolean;
+      signal?: AbortSignal;
     },
   ): Promise<ClientResponse<T>> {
     const url = this.buildUrl(path, options?.params);
@@ -322,7 +329,7 @@ export class GdbClient {
 
     this.logRequest(method, url, headers, body);
     this.handleDryRun(method, url, headers, body);
-    const response = await fetch(url, { method, headers, body });
+    const response = await fetch(url, { method, headers, body, signal: options?.signal });
     this.logResponse(response);
 
     let data: T;
@@ -339,7 +346,12 @@ export class GdbClient {
       const err = data as unknown as NgsiError;
       const message =
         err?.description || err?.detail || err?.error || err?.title || `HTTP ${response.status}`;
-      throw new GdbClientError(message, response.status, err);
+      throw new GdbClientError(
+        message,
+        response.status,
+        err,
+        parseRetryAfter(response.headers.get("retry-after")),
+      );
     }
 
     return { status: response.status, headers: response.headers, data };
@@ -352,6 +364,7 @@ export class GdbClient {
       body?: unknown;
       params?: Record<string, string>;
       headers?: Record<string, string>;
+      signal?: AbortSignal;
     },
   ): Promise<ClientResponse<T>> {
     await this.proactiveRefresh();
@@ -380,8 +393,9 @@ export class GdbClient {
     path: string,
     body?: unknown,
     params?: Record<string, string>,
+    options?: { signal?: AbortSignal },
   ): Promise<ClientResponse<T>> {
-    return this.request<T>("POST", path, { body, params });
+    return this.request<T>("POST", path, { body, params, signal: options?.signal });
   }
 
   async patch<T = unknown>(
@@ -416,6 +430,7 @@ export class GdbClient {
       params?: Record<string, string>;
       headers?: Record<string, string>;
       skipTenantHeader?: boolean;
+      signal?: AbortSignal;
     },
   ): Promise<ClientResponse<T>> {
     await this.proactiveRefresh();
@@ -438,8 +453,28 @@ export class GdbClientError extends Error {
     message: string,
     public readonly status: number,
     public readonly ngsiError?: NgsiError,
+    /** Parsed Retry-After (ms) from a 429/503 response, if present. */
+    public readonly retryAfterMs?: number,
   ) {
     super(message);
     this.name = "GdbClientError";
   }
+}
+
+/**
+ * Parse an HTTP `Retry-After` header into milliseconds.
+ * Supports both delta-seconds (e.g. "120") and an HTTP-date. Returns undefined
+ * when the header is absent or unparseable.
+ */
+export function parseRetryAfter(value: string | null): number | undefined {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  if (/^\d+$/.test(trimmed)) {
+    return Number(trimmed) * 1000;
+  }
+  const dateMs = Date.parse(trimmed);
+  if (!Number.isNaN(dateMs)) {
+    return Math.max(0, dateMs - Date.now());
+  }
+  return undefined;
 }

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -1,0 +1,238 @@
+import { Command, InvalidArgumentError } from "commander";
+import { createClient, resolveOptions, withErrorHandler } from "../helpers.js";
+import {
+  fileFingerprint,
+  parseJsonInput,
+  recordsFromArray,
+  streamNdjsonFile,
+  streamNdjsonFrom,
+} from "../input.js";
+import type { EntityRecord, FileFingerprint } from "../input.js";
+import { BulkImporter } from "../loader.js";
+import type { ImportMode, ImporterOptions, InputFormat } from "../loader.js";
+import { printError, printInfo, printSuccess, printWarning } from "../output.js";
+import { addExamples } from "./help.js";
+
+interface ImportCliOptions {
+  inputFormat: InputFormat;
+  mode: ImportMode;
+  batchSize: number;
+  maxBytes: number;
+  concurrency: number;
+  retries: number;
+  timeout: number;
+  continueOnError?: boolean;
+  resume?: string;
+  errorsOut?: string;
+  errorsLog?: string;
+  bisect?: boolean;
+  bisectMax: number;
+}
+
+function parsePositiveInt(value: string): number {
+  if (!/^\d+$/.test(value) || Number(value) < 1) {
+    throw new InvalidArgumentError("Must be a positive integer.");
+  }
+  return Number(value);
+}
+
+function parseMode(value: string): ImportMode {
+  if (value !== "upsert" && value !== "replace") {
+    throw new InvalidArgumentError("Must be 'upsert' or 'replace'.");
+  }
+  return value;
+}
+
+function parseInputFormat(value: string): InputFormat {
+  if (value !== "ndjson" && value !== "json") {
+    throw new InvalidArgumentError("Must be 'ndjson' or 'json'.");
+  }
+  return value;
+}
+
+async function* fromArray(records: EntityRecord[]): AsyncGenerator<EntityRecord> {
+  for (const record of records) yield record;
+}
+
+/**
+ * Resolve the input into a record stream. File paths are resume-capable (they
+ * carry a fingerprint); stdin is not.
+ */
+async function buildSource(
+  fileArg: string | undefined,
+  inputFormat: InputFormat,
+): Promise<{ source: AsyncIterable<EntityRecord>; fingerprint?: FileFingerprint }> {
+  const isStdin = fileArg === undefined || fileArg === "-";
+  const path = fileArg?.startsWith("@") ? fileArg.slice(1) : fileArg;
+
+  if (inputFormat === "ndjson") {
+    if (isStdin) return { source: streamNdjsonFrom(process.stdin) };
+    return { source: streamNdjsonFile(path!), fingerprint: fileFingerprint(path!) };
+  }
+
+  // JSON array format — parsed fully into memory (not streaming).
+  const data = await parseJsonInput(isStdin ? "-" : `@${path}`);
+  const records = recordsFromArray(data);
+  return {
+    source: fromArray(records),
+    fingerprint: isStdin ? undefined : fileFingerprint(path!),
+  };
+}
+
+export function registerImportCommand(program: Command): void {
+  const cmd = program
+    .command("import [file]")
+    .summary("Bulk-load entities from a file, chunked with retry/resume")
+    .description(
+      "Bulk-load NGSI-LD entities past the 29s API Gateway limit by chunking the input\n" +
+        "into batch-upsert requests with retry, resume, and per-entity error reporting.\n\n" +
+        "Input: an NDJSON file (one entity per line, default) or a JSON array (--input-format json).\n" +
+        "Use '-' or a pipe for stdin (resume is not available for stdin).",
+    )
+    .option("--input-format <fmt>", "Input format: ndjson (default) or json", parseInputFormat, "ndjson")
+    .option("--mode <mode>", "upsert (merge, default) or replace", parseMode, "upsert")
+    .option("--batch-size <n>", "Entities per request (default 100; must not exceed your plan's max batch size)", parsePositiveInt, 100)
+    .option("--max-bytes <n>", "Max request body bytes per chunk", parsePositiveInt, 1_000_000)
+    .option("--concurrency <n>", "Concurrent requests (default 1 = sequential)", parsePositiveInt, 1)
+    .option("--retries <n>", "Max retries per chunk on 429/5xx/timeout", parsePositiveInt, 5)
+    .option("--timeout <ms>", "Per-request timeout in ms", parsePositiveInt, 60_000)
+    .option("--continue-on-error", "Keep going after failures (default: stop)")
+    .option("--resume <checkpoint>", "Checkpoint file for resumable loads (upsert + file input only)")
+    .option("--errors-out <file>", "Write failed entities as re-submittable NDJSON")
+    .option("--errors-log <file>", "Write failure details (reason/status/line) as NDJSON")
+    .option("--bisect", "On a 400/413 chunk, binary-split to isolate the offending entity")
+    .option("--bisect-max <n>", "Max bisect depth", parsePositiveInt, 8)
+    .action(
+      withErrorHandler(async (file: string | undefined, _opts: unknown, command: Command) => {
+        const cli = command.optsWithGlobals() as ImportCliOptions;
+        const resolved = resolveOptions(command);
+        const isStdin = file === undefined || file === "-";
+
+        // Validate resume constraints up front, before consuming any input.
+        if (cli.resume && cli.mode === "replace") {
+          printError("--resume is only supported with --mode upsert (replace re-sends overwrite latest state).");
+          process.exit(1);
+        }
+        if (cli.resume && isStdin) {
+          printError("--resume requires a file input; stdin cannot be resumed.");
+          process.exit(1);
+        }
+
+        const { source, fingerprint } = await buildSource(file, cli.inputFormat);
+
+        if (cli.mode === "replace") {
+          printWarning(
+            "replace mode: re-sent chunks overwrite the latest server state, and retries/resume are at-least-once. Proceed with care.",
+          );
+        }
+        if (cli.continueOnError && !cli.errorsOut) {
+          printWarning(
+            "--continue-on-error without --errors-out: failed entities won't be captured for re-submission.",
+          );
+        }
+
+        // A dry-run only plans chunks — no client (and no configured URL) required.
+        const client = resolved.dryRun ? undefined : createClient(command);
+        const importerOpts: ImporterOptions = {
+          mode: cli.mode,
+          format: cli.inputFormat,
+          batchSize: cli.batchSize,
+          maxBytes: cli.maxBytes,
+          concurrency: cli.concurrency,
+          retries: cli.retries,
+          timeoutMs: cli.timeout,
+          continueOnError: cli.continueOnError ?? false,
+          bisect: cli.bisect ?? false,
+          bisectMax: cli.bisectMax,
+          dryRun: resolved.dryRun,
+          resumePath: cli.resume,
+          errorsOutPath: cli.errorsOut,
+          errorsLogPath: cli.errorsLog,
+          fingerprint,
+          onProgress: makeProgressReporter(resolved.verbose ?? false),
+          onRetry: resolved.verbose
+            ? (info) =>
+                process.stderr.write(
+                  `retry #${info.attempt} in ${Math.round(info.delayMs)}ms${info.status ? ` (status ${info.status})` : ""}\n`,
+                )
+            : undefined,
+        };
+
+        const importer = new BulkImporter(client, importerOpts);
+        const result = await importer.run(source);
+
+        if (resolved.dryRun) {
+          printInfo(
+            `dry-run: would send ${result.planned ?? 0} entities in ${result.chunks} chunk(s) ` +
+              `(batch-size=${cli.batchSize}, max-bytes=${cli.maxBytes}, mode=${cli.mode}).`,
+          );
+          return;
+        }
+
+        finishProgressLine();
+        printSummary(result, importerOpts);
+
+        if (result.aborted) {
+          printWarning("Stopped at the first failure. Use --continue-on-error to process the rest.");
+        }
+        if (result.failed > 0 || result.aborted) {
+          process.exitCode = 1;
+        }
+      }),
+    );
+
+  addExamples(cmd, [
+    {
+      description: "Load an NDJSON file",
+      command: "geonic import entities.ndjson",
+    },
+    {
+      description: "Resumable load with error capture",
+      command:
+        "geonic import entities.ndjson --resume .import.ckpt --errors-out failed.ndjson --errors-log errors.log",
+    },
+    {
+      description: "Re-submit only the failed entities",
+      command: "geonic import failed.ndjson",
+    },
+    {
+      description: "Preview the plan without sending",
+      command: "geonic import entities.ndjson --dry-run",
+    },
+  ]);
+}
+
+function makeProgressReporter(verbose: boolean): ImporterOptions["onProgress"] {
+  const isTty = process.stderr.isTTY ?? false;
+  return (p) => {
+    if (isTty) {
+      process.stderr.write(
+        `\rprocessed=${p.processed} ok=${p.succeeded} failed=${p.failed} skipped=${p.skipped} chunks=${p.chunks}`,
+      );
+    } else if (verbose) {
+      process.stderr.write(
+        `processed=${p.processed} ok=${p.succeeded} failed=${p.failed} chunks=${p.chunks}\n`,
+      );
+    }
+  };
+}
+
+function finishProgressLine(): void {
+  if (process.stderr.isTTY) process.stderr.write("\n");
+}
+
+function printSummary(
+  result: { processed: number; succeeded: number; failed: number; skipped: number; chunks: number },
+  opts: ImporterOptions,
+): void {
+  const line =
+    `Imported: ${result.succeeded} succeeded, ${result.failed} failed, ` +
+    `${result.skipped} skipped across ${result.chunks} chunk(s).`;
+  if (result.failed === 0 && result.skipped === 0) {
+    printSuccess(line);
+  } else {
+    printWarning(line);
+    if (opts.errorsOutPath) printInfo(`Failed entities written to ${opts.errorsOutPath} (re-run to retry).`);
+    if (opts.errorsLogPath) printInfo(`Failure details written to ${opts.errorsLogPath}.`);
+  }
+}

--- a/src/input.ts
+++ b/src/input.ts
@@ -1,6 +1,8 @@
 import JSON5 from "json5";
-import { readFileSync } from "node:fs";
+import { closeSync, createReadStream, openSync, readFileSync, readSync, statSync } from "node:fs";
+import { createHash } from "node:crypto";
 import { createInterface } from "node:readline";
+import type { Readable } from "node:stream";
 
 /**
  * Parse JSON input from a string, file (@path), stdin (-), pipe, or interactive mode.
@@ -31,6 +33,100 @@ export async function parseJsonInput(input?: string): Promise<unknown> {
 
 function parseData(text: string): unknown {
   return JSON5.parse(text.trim());
+}
+
+/**
+ * One record produced by the streaming input readers used for bulk import.
+ * `value` holds the parsed entity; `parseError` is set instead when the line
+ * could not be parsed (the raw text is preserved either way).
+ */
+export interface EntityRecord {
+  /** 1-based position: file line number for NDJSON, array index+1 for JSON arrays. */
+  lineNumber: number;
+  raw: string;
+  value?: unknown;
+  parseError?: string;
+}
+
+/** Guard against a single pathologically long line (e.g. a file with no newlines). */
+const MAX_LINE_BYTES = 16 * 1024 * 1024;
+
+/** Stream NDJSON records from a readable stream (one JSON value per line). */
+export async function* streamNdjsonFrom(input: Readable): AsyncGenerator<EntityRecord> {
+  const rl = createInterface({ input, crlfDelay: Infinity });
+  let lineNumber = 0;
+  for await (const line of rl) {
+    lineNumber++;
+    const trimmed = line.trim();
+    if (trimmed === "") continue; // skip blank lines silently
+    if (Buffer.byteLength(line) > MAX_LINE_BYTES) {
+      yield { lineNumber, raw: "", parseError: `line exceeds max size (${MAX_LINE_BYTES} bytes)` };
+      continue;
+    }
+    try {
+      yield { lineNumber, raw: line, value: JSON.parse(trimmed) };
+    } catch (err) {
+      yield { lineNumber, raw: line, parseError: err instanceof Error ? err.message : String(err) };
+    }
+  }
+}
+
+/** Stream NDJSON records from a file path. */
+export function streamNdjsonFile(filePath: string): AsyncGenerator<EntityRecord> {
+  return streamNdjsonFrom(createReadStream(filePath, { encoding: "utf-8" }));
+}
+
+/**
+ * Turn an already-parsed JSON array into EntityRecords (for `--format json`
+ * inputs and small inline payloads). Not streaming: the whole array is in memory.
+ */
+export function recordsFromArray(data: unknown): EntityRecord[] {
+  if (!Array.isArray(data)) {
+    throw new Error("Expected a JSON array of entities.");
+  }
+  return data.map((value, i) => ({
+    lineNumber: i + 1,
+    raw: JSON.stringify(value),
+    value,
+  }));
+}
+
+/** Cheap fingerprint to detect that a resumed input file is the same file. */
+export interface FileFingerprint {
+  size: number;
+  mtimeMs: number;
+  /** sha256 of the first 64KiB — avoids a full re-read of huge files. */
+  headHash: string;
+}
+
+const FINGERPRINT_HEAD_BYTES = 65536;
+
+export function fileFingerprint(filePath: string): FileFingerprint {
+  const st = statSync(filePath);
+  const len = Math.min(FINGERPRINT_HEAD_BYTES, st.size);
+  const buf = Buffer.alloc(len);
+  const fd = openSync(filePath, "r");
+  let read = 0;
+  try {
+    // readSync may return a short read; loop until the head is fully read so the
+    // hash is deterministic (a short read would otherwise fold in zero padding).
+    while (read < len) {
+      const n = readSync(fd, buf, read, len - read, read);
+      if (n === 0) break; // unexpected EOF
+      read += n;
+    }
+  } finally {
+    closeSync(fd);
+  }
+  return {
+    size: st.size,
+    mtimeMs: st.mtimeMs,
+    headHash: createHash("sha256").update(buf.subarray(0, read)).digest("hex"),
+  };
+}
+
+export function fingerprintsMatch(a: FileFingerprint, b: FileFingerprint): boolean {
+  return a.size === b.size && a.mtimeMs === b.mtimeMs && a.headHash === b.headHash;
 }
 
 /**

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -1,0 +1,476 @@
+import { createWriteStream, existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import type { WriteStream } from "node:fs";
+import type { GdbClient } from "./client.js";
+import { GdbClientError } from "./client.js";
+import { withRetry } from "./retry.js";
+import { fingerprintsMatch } from "./input.js";
+import type { EntityRecord, FileFingerprint } from "./input.js";
+
+export type ImportMode = "upsert" | "replace";
+export type InputFormat = "ndjson" | "json";
+
+export interface ImporterOptions {
+  mode: ImportMode;
+  format: InputFormat;
+  batchSize: number;
+  maxBytes: number;
+  concurrency: number;
+  retries: number;
+  timeoutMs: number;
+  continueOnError: boolean;
+  bisect: boolean;
+  bisectMax: number;
+  dryRun?: boolean;
+  /** Checkpoint file for resume; requires a file input (fingerprint) and upsert mode. */
+  resumePath?: string;
+  errorsOutPath?: string;
+  errorsLogPath?: string;
+  /** Present only for file input — enables resume and same-file verification. */
+  fingerprint?: FileFingerprint;
+  sleep?: (ms: number) => Promise<void>;
+  random?: () => number;
+  onProgress?: (p: ImportProgress) => void;
+  onRetry?: (info: { attempt: number; delayMs: number; status?: number }) => void;
+}
+
+export interface ImportProgress {
+  processed: number;
+  succeeded: number;
+  failed: number;
+  skipped: number;
+  chunks: number;
+}
+
+export interface ImportResult extends ImportProgress {
+  aborted: boolean;
+  /** For dry-run: number of entities that would be sent (no request made). */
+  planned?: number;
+}
+
+interface Chunk {
+  index: number;
+  records: EntityRecord[];
+  startLine: number;
+  endLine: number;
+}
+
+interface Checkpoint {
+  version: 1;
+  fingerprint: FileFingerprint;
+  mode: ImportMode;
+  format: InputFormat;
+  batchSize: number;
+  committedLines: number;
+}
+
+/** Server 207 Multi-Status body shape for batch upsert. */
+interface MultiStatusBody {
+  created?: string[];
+  updated?: string[];
+  errors?: { entityId: string; error?: unknown }[];
+}
+
+/** Upper bound for a single shared cooldown, so a hostile Retry-After can't stall for hours. */
+const MAX_COOLDOWN_MS = 60_000;
+
+/**
+ * Process-wide rate-limit cooldown. When any request is 429/503'd, all workers pause
+ * until the shared deadline so we don't keep hammering the server (429 storm).
+ */
+class SharedCooldown {
+  private until = 0;
+  note(ms: number): void {
+    this.until = Math.max(this.until, Date.now() + Math.min(ms, MAX_COOLDOWN_MS));
+  }
+  async wait(sleep: (ms: number) => Promise<void>): Promise<void> {
+    // Loop: another worker may extend `until` while we sleep.
+    for (let remaining = this.until - Date.now(); remaining > 0; remaining = this.until - Date.now()) {
+      await sleep(remaining);
+    }
+  }
+}
+
+const defaultSleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+function entityId(value: unknown): string | undefined {
+  if (value && typeof value === "object" && typeof (value as Record<string, unknown>).id === "string") {
+    return (value as Record<string, unknown>).id as string;
+  }
+  return undefined;
+}
+
+/**
+ * Client-driven bulk loader. Streams records, chunks them (by count AND bytes),
+ * sends each chunk to the batch upsert endpoint with retry/backoff, classifies
+ * 204/207/400 outcomes, writes failures to re-submittable NDJSON + a detail log,
+ * and checkpoints progress for resume.
+ */
+export class BulkImporter {
+  private counts: ImportProgress = { processed: 0, succeeded: 0, failed: 0, skipped: 0, chunks: 0 };
+  private aborted = false;
+  private cooldown = new SharedCooldown();
+  private sleep: (ms: number) => Promise<void>;
+  private random: () => number;
+  private errorsOut?: WriteStream;
+  private errorsLog?: WriteStream;
+  private sinkError?: Error;
+  // Contiguous checkpoint tracking (chunks may complete out of order under concurrency).
+  private committedLines = 0;
+  private nextExpected = 0;
+  private pendingEnds = new Map<number, number>();
+
+  constructor(
+    // Optional: a dry-run never sends, so no client is required.
+    private readonly client: GdbClient | undefined,
+    private readonly opts: ImporterOptions,
+  ) {
+    this.sleep = opts.sleep ?? defaultSleep;
+    this.random = opts.random ?? Math.random;
+  }
+
+  async run(source: AsyncIterable<EntityRecord>): Promise<ImportResult> {
+    const skipUntilLine = this.initCheckpoint();
+
+    if (this.opts.dryRun) {
+      return this.planDryRun(source, skipUntilLine);
+    }
+
+    const appendErrors = skipUntilLine > 0;
+    this.openErrorSinks(appendErrors);
+    try {
+      const chunks = chunkRecords(source, {
+        batchSize: this.opts.batchSize,
+        maxBytes: this.opts.maxBytes,
+        skipUntilLine,
+        isAborted: () => this.aborted,
+        onParseError: (r) => this.handleParseError(r),
+      });
+      await this.runPool(chunks);
+    } finally {
+      await this.closeErrorSinks();
+    }
+
+    if (this.sinkError) throw this.sinkError; // a failed error-file write must not pass silently
+    return { ...this.counts, aborted: this.aborted };
+  }
+
+  // ---- checkpoint ----------------------------------------------------------
+
+  private initCheckpoint(): number {
+    if (!this.opts.resumePath) return 0;
+    if (!existsSync(this.opts.resumePath)) return 0;
+    const cp = JSON.parse(readFileSync(this.opts.resumePath, "utf-8")) as Checkpoint;
+    if (!this.opts.fingerprint || !fingerprintsMatch(cp.fingerprint, this.opts.fingerprint)) {
+      throw new Error(
+        "Resume aborted: the input file differs from the one recorded in the checkpoint.",
+      );
+    }
+    if (cp.mode !== this.opts.mode || cp.format !== this.opts.format) {
+      throw new Error(
+        `Resume aborted: checkpoint mode/format (${cp.mode}/${cp.format}) does not match current (${this.opts.mode}/${this.opts.format}).`,
+      );
+    }
+    this.committedLines = cp.committedLines;
+    return cp.committedLines;
+  }
+
+  private writeCheckpoint(): void {
+    if (!this.opts.resumePath || !this.opts.fingerprint) return;
+    const cp: Checkpoint = {
+      version: 1,
+      fingerprint: this.opts.fingerprint,
+      mode: this.opts.mode,
+      format: this.opts.format,
+      batchSize: this.opts.batchSize,
+      committedLines: this.committedLines,
+    };
+    const tmp = `${this.opts.resumePath}.tmp`;
+    writeFileSync(tmp, JSON.stringify(cp));
+    renameSync(tmp, this.opts.resumePath); // atomic replace
+  }
+
+  // ---- dry run -------------------------------------------------------------
+
+  private async planDryRun(source: AsyncIterable<EntityRecord>, skipUntilLine: number): Promise<ImportResult> {
+    let planned = 0;
+    let chunks = 0;
+    for await (const chunk of chunkRecords(source, {
+      batchSize: this.opts.batchSize,
+      maxBytes: this.opts.maxBytes,
+      skipUntilLine,
+      isAborted: () => false,
+      onParseError: () => {
+        this.counts.skipped++;
+      },
+    })) {
+      planned += chunk.records.length;
+      chunks++;
+    }
+    this.counts.chunks = chunks;
+    return { ...this.counts, aborted: false, planned };
+  }
+
+  // ---- concurrency pool ----------------------------------------------------
+
+  private async runPool(chunks: AsyncIterable<Chunk>): Promise<void> {
+    const concurrency = Math.max(1, this.opts.concurrency);
+    const inFlight = new Set<Promise<void>>();
+    for await (const chunk of chunks) {
+      if (this.aborted) break;
+      const p = this.processChunk(chunk).finally(() => inFlight.delete(p));
+      inFlight.add(p);
+      if (inFlight.size >= concurrency) await Promise.race(inFlight);
+    }
+    await Promise.all(inFlight);
+  }
+
+  private async processChunk(chunk: Chunk): Promise<void> {
+    const failedBefore = this.counts.failed;
+    await this.processGroup(chunk.records, 0);
+    // Only the chunk that actually failed is left uncommitted (resume retries it).
+    // A chunk that itself succeeded is committed even if another concurrent chunk
+    // aborted — otherwise resume would needlessly re-send it.
+    const thisChunkFailed = this.counts.failed > failedBefore;
+    if (thisChunkFailed && !this.opts.continueOnError) {
+      this.aborted = true;
+      return;
+    }
+    // A chunk skipped because an abort was already in flight isn't a real commit.
+    if (chunk.records.length === 0) return;
+    this.counts.chunks++;
+    this.pendingEnds.set(chunk.index, chunk.endLine);
+    while (this.pendingEnds.has(this.nextExpected)) {
+      this.committedLines = this.pendingEnds.get(this.nextExpected)!;
+      this.pendingEnds.delete(this.nextExpected);
+      this.nextExpected++;
+    }
+    this.writeCheckpoint();
+    this.reportProgress();
+  }
+
+  // ---- send + classify -----------------------------------------------------
+
+  private async processGroup(records: EntityRecord[], depth: number): Promise<void> {
+    if (this.aborted || records.length === 0) return;
+    await this.cooldown.wait(this.sleep);
+    // Another (concurrent) chunk may have aborted while we waited on the cooldown.
+    if (this.aborted) return;
+
+    let response;
+    try {
+      response = await withRetry(() => this.send(records), {
+        retries: this.opts.retries,
+        sleep: this.sleep,
+        random: this.random,
+        onRetry: (info) => {
+          // A rate-limit signal (429/503) pauses ALL workers via the shared cooldown,
+          // honoring Retry-After when present and falling back to the computed backoff
+          // otherwise — so a header-less 429 storm is still throttled process-wide.
+          if (info.error instanceof GdbClientError && (info.error.status === 429 || info.error.status === 503)) {
+            this.cooldown.note(info.error.retryAfterMs ?? info.delayMs);
+          }
+          const status = info.error instanceof GdbClientError ? info.error.status : undefined;
+          this.opts.onRetry?.({ attempt: info.attempt, delayMs: info.delayMs, status });
+        },
+      });
+    } catch (err) {
+      await this.handleSendFailure(records, err, depth);
+      return;
+    }
+    this.handleResponse(records, response);
+  }
+
+  private async send(records: EntityRecord[]) {
+    /* istanbul ignore next -- guarded: send() is never reached in dry-run */
+    if (!this.client) throw new Error("No client configured for sending.");
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.opts.timeoutMs);
+    try {
+      return await this.client.post(
+        "/entityOperations/upsert",
+        records.map((r) => r.value),
+        this.opts.mode === "replace" ? { options: "replace" } : undefined,
+        { signal: controller.signal },
+      );
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  private handleResponse(records: EntityRecord[], response: { status: number; data: unknown }): void {
+    this.counts.processed += records.length;
+
+    if (response.status === 207) {
+      this.handleMultiStatus(records, (response.data ?? {}) as MultiStatusBody);
+      return;
+    }
+
+    // 201/204/200 — whole chunk succeeded.
+    this.counts.succeeded += records.length;
+  }
+
+  /**
+   * Reconcile a 207 against the chunk *by record*, not by trusting the server's error
+   * list alone. Anything not confirmed created/updated is treated as failed and written
+   * to the re-submittable errors file — so id normalization or an under-reporting server
+   * can never silently drop an entity.
+   */
+  private handleMultiStatus(records: EntityRecord[], body: MultiStatusBody): void {
+    const succeededIds = new Set<string>([...(body.created ?? []), ...(body.updated ?? [])]);
+    const errorById = new Map((body.errors ?? []).map((e) => [e.entityId, e] as const));
+
+    for (const record of records) {
+      const id = entityId(record.value);
+      if (id !== undefined && succeededIds.has(id)) {
+        this.counts.succeeded++;
+        continue;
+      }
+      // Not confirmed as succeeded → failed. Prefer the server's reason when it maps.
+      this.counts.failed++;
+      const matched = id !== undefined ? errorById.get(id) : undefined;
+      const reason = matched ? describeError(matched.error) : "not confirmed in 207 response";
+      this.writeError(record, 207, reason);
+    }
+    // Surface any server error whose id matched no input record (never silently dropped).
+    for (const e of body.errors ?? []) {
+      if (!records.some((r) => entityId(r.value) === e.entityId)) {
+        this.writeErrorLogOnly(
+          { lineNumber: -1, raw: "", value: { id: e.entityId } },
+          207,
+          `unmatched server error: ${describeError(e.error)}`,
+        );
+      }
+    }
+    // Abort decision is owned by processChunk (based on the per-chunk failure delta).
+  }
+
+  private async handleSendFailure(records: EntityRecord[], err: unknown, depth: number): Promise<void> {
+    const status = err instanceof GdbClientError ? err.status : undefined;
+    const splittable = status === 400 || status === 413;
+    if (this.opts.bisect && splittable && records.length > 1 && depth < this.opts.bisectMax) {
+      const mid = Math.floor(records.length / 2);
+      await this.processGroup(records.slice(0, mid), depth + 1);
+      await this.processGroup(records.slice(mid), depth + 1);
+      return;
+    }
+    // Leaf failure: the whole group failed. (Abort decision is owned by processChunk.)
+    this.counts.processed += records.length;
+    this.counts.failed += records.length;
+    const reason = err instanceof Error ? err.message : String(err);
+    for (const r of records) this.writeError(r, status, reason);
+  }
+
+  private handleParseError(record: EntityRecord): void {
+    this.counts.processed++;
+    this.counts.failed++;
+    this.writeErrorLogOnly(record, undefined, `parse error: ${record.parseError}`);
+    if (!this.opts.continueOnError) this.aborted = true;
+  }
+
+  // ---- error sinks ---------------------------------------------------------
+
+  private openErrorSinks(append: boolean): void {
+    const flags = append ? "a" : "w";
+    const capture = (stream: WriteStream): WriteStream => {
+      // Attach an error listener immediately so a mid-run write failure (disk full,
+      // permissions) is captured instead of crashing the process as an uncaught error.
+      stream.on("error", (err) => {
+        this.sinkError ??= err instanceof Error ? err : new Error(String(err));
+      });
+      return stream;
+    };
+    if (this.opts.errorsOutPath) this.errorsOut = capture(createWriteStream(this.opts.errorsOutPath, { flags }));
+    if (this.opts.errorsLogPath) this.errorsLog = capture(createWriteStream(this.opts.errorsLogPath, { flags }));
+  }
+
+  private writeError(record: EntityRecord, status: number | undefined, reason: string): void {
+    if (this.errorsOut && record.value !== undefined) {
+      this.errorsOut.write(JSON.stringify(record.value) + "\n");
+    }
+    this.writeErrorLogOnly(record, status, reason);
+  }
+
+  private writeErrorLogOnly(record: EntityRecord, status: number | undefined, reason: string): void {
+    if (!this.errorsLog) return;
+    this.errorsLog.write(
+      JSON.stringify({
+        lineNumber: record.lineNumber,
+        entityId: entityId(record.value),
+        status,
+        reason,
+      }) + "\n",
+    );
+  }
+
+  private async closeErrorSinks(): Promise<void> {
+    await Promise.all([closeStream(this.errorsOut), closeStream(this.errorsLog)]);
+  }
+
+  private reportProgress(): void {
+    this.opts.onProgress?.({ ...this.counts });
+  }
+}
+
+function describeError(error: unknown): string {
+  if (error && typeof error === "object") {
+    const e = error as Record<string, unknown>;
+    const detail = e.detail ?? e.title ?? e.description;
+    if (typeof detail === "string") return detail;
+    return JSON.stringify(error);
+  }
+  return String(error);
+}
+
+function closeStream(stream?: WriteStream): Promise<void> {
+  if (!stream) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    stream.on("error", reject);
+    stream.end(resolve);
+  });
+}
+
+/**
+ * Chunk a record stream by BOTH entity count and serialized byte size. A single
+ * record larger than maxBytes becomes its own (over-size) chunk. Parse-error
+ * records are diverted to onParseError and never enter a chunk.
+ */
+export async function* chunkRecords(
+  source: AsyncIterable<EntityRecord>,
+  opts: {
+    batchSize: number;
+    maxBytes: number;
+    skipUntilLine: number;
+    isAborted: () => boolean;
+    onParseError: (record: EntityRecord) => void;
+  },
+): AsyncGenerator<Chunk> {
+  let buf: EntityRecord[] = [];
+  const BRACKET_OVERHEAD = 2; // the enclosing "[" and "]" of the JSON array body
+  let bytes = BRACKET_OVERHEAD;
+  let index = 0;
+
+  const makeChunk = (): Chunk => ({
+    index: index++,
+    records: buf,
+    startLine: buf[0].lineNumber,
+    endLine: buf[buf.length - 1].lineNumber,
+  });
+
+  for await (const rec of source) {
+    if (opts.isAborted()) return;
+    if (rec.lineNumber <= opts.skipUntilLine) continue;
+    if (rec.parseError !== undefined) {
+      opts.onParseError(rec);
+      continue;
+    }
+    const size = Buffer.byteLength(JSON.stringify(rec.value)) + 1; // +1 for the "," separator
+    if (buf.length > 0 && (buf.length >= opts.batchSize || bytes + size > opts.maxBytes)) {
+      yield makeChunk();
+      buf = [];
+      bytes = BRACKET_OVERHEAD;
+    }
+    buf.push(rec);
+    bytes += size;
+  }
+  if (buf.length > 0) yield makeChunk();
+}

--- a/src/retry.ts
+++ b/src/retry.ts
@@ -1,0 +1,82 @@
+import { GdbClientError } from "./client.js";
+
+export interface RetryInfo {
+  /** 1-based attempt number that just failed (i.e. the retry we are about to perform). */
+  attempt: number;
+  delayMs: number;
+  error: unknown;
+}
+
+export interface RetryOptions {
+  /** Maximum number of retries after the initial attempt. */
+  retries: number;
+  baseDelayMs?: number;
+  maxDelayMs?: number;
+  onRetry?: (info: RetryInfo) => void;
+  /** Injectable sleep for tests. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Injectable jitter [0,1) for deterministic tests. */
+  random?: () => number;
+}
+
+const DEFAULT_BASE_DELAY_MS = 500;
+const DEFAULT_MAX_DELAY_MS = 30_000;
+
+/**
+ * Determine whether an error is worth retrying: server-side transient failures
+ * (429 / 5xx), network errors, and request timeouts (AbortError). Client input
+ * errors (4xx other than 429) are NOT retryable — retrying won't help.
+ */
+export function isRetryableError(err: unknown): boolean {
+  if (err instanceof GdbClientError) {
+    return err.status === 429 || err.status >= 500;
+  }
+  if (err instanceof Error) {
+    // AbortError = our timeout; TypeError = fetch network failure (e.g. "fetch failed").
+    return err.name === "AbortError" || err.name === "TypeError";
+  }
+  return false;
+}
+
+const defaultSleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Run `fn`, retrying transient failures with exponential backoff + jitter.
+ * For 429 responses that carry a Retry-After, honor that delay instead of backoff.
+ */
+export async function withRetry<T>(fn: () => Promise<T>, opts: RetryOptions): Promise<T> {
+  const base = opts.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
+  const max = opts.maxDelayMs ?? DEFAULT_MAX_DELAY_MS;
+  const sleep = opts.sleep ?? defaultSleep;
+  const random = opts.random ?? Math.random;
+
+  let attempt = 0;
+  for (;;) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (attempt >= opts.retries || !isRetryableError(err)) throw err;
+      attempt++;
+      const delay = computeDelay(err, attempt, base, max, random);
+      opts.onRetry?.({ attempt, delayMs: delay, error: err });
+      await sleep(delay);
+    }
+  }
+}
+
+function computeDelay(
+  err: unknown,
+  attempt: number,
+  base: number,
+  max: number,
+  random: () => number,
+): number {
+  // Honor a server-provided Retry-After (429 or 503), always clamped to max so a
+  // hostile/buggy header can't stall the client for hours.
+  if (err instanceof GdbClientError && err.retryAfterMs !== undefined) {
+    return Math.min(max, err.retryAfterMs);
+  }
+  // Exponential backoff with full-range jitter on the upper half.
+  const exp = Math.min(max, base * 2 ** (attempt - 1));
+  return exp / 2 + random() * (exp / 2);
+}

--- a/tests/client-retry-after.test.ts
+++ b/tests/client-retry-after.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { GdbClient, GdbClientError, parseRetryAfter } from "../src/client.js";
+
+describe("parseRetryAfter", () => {
+  it("parses delta-seconds", () => {
+    expect(parseRetryAfter("120")).toBe(120_000);
+    expect(parseRetryAfter("0")).toBe(0);
+  });
+
+  it("parses an HTTP-date relative to now", () => {
+    const future = new Date(Date.now() + 5000).toUTCString();
+    const ms = parseRetryAfter(future);
+    expect(ms).toBeGreaterThan(0);
+    expect(ms).toBeLessThanOrEqual(5000);
+  });
+
+  it("returns undefined for missing or unparseable values", () => {
+    expect(parseRetryAfter(null)).toBeUndefined();
+    expect(parseRetryAfter("not-a-date")).toBeUndefined();
+  });
+});
+
+describe("GdbClient error/abort handling", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("attaches retryAfterMs to a 429 error", async () => {
+    const client = new GdbClient({ baseUrl: "http://localhost:3000" });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ title: "Too Many Requests" }), {
+        status: 429,
+        headers: { "Content-Type": "application/json", "Retry-After": "7" },
+      }),
+    );
+    await expect(client.post("/entityOperations/upsert", [])).rejects.toMatchObject({
+      status: 429,
+      retryAfterMs: 7000,
+    });
+  });
+
+  it("forwards an AbortSignal to fetch", async () => {
+    const client = new GdbClient({ baseUrl: "http://localhost:3000" });
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(null, { status: 204 }));
+    const controller = new AbortController();
+    await client.post("/entityOperations/upsert", [], undefined, { signal: controller.signal });
+    expect(spy).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ signal: controller.signal }),
+    );
+  });
+
+  it("attaches retryAfterMs on rawRequest errors too", async () => {
+    const client = new GdbClient({ baseUrl: "http://localhost:3000" });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ title: "Service Unavailable" }), {
+        status: 503,
+        headers: { "Content-Type": "application/json", "Retry-After": "3" },
+      }),
+    );
+    await expect(client.rawRequest("GET", "/health")).rejects.toMatchObject({
+      status: 503,
+      retryAfterMs: 3000,
+    });
+  });
+
+  it("still throws GdbClientError with no retryAfterMs when header absent", async () => {
+    const client = new GdbClient({ baseUrl: "http://localhost:3000" });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ detail: "bad" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const err = await client.post("/entityOperations/upsert", []).catch((e) => e as GdbClientError);
+    expect(err).toBeInstanceOf(GdbClientError);
+    expect(err.retryAfterMs).toBeUndefined();
+  });
+});

--- a/tests/import.test.ts
+++ b/tests/import.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const ctorSpy = vi.fn();
+const runMock = vi.fn();
+vi.mock("../src/loader.js", () => ({
+  BulkImporter: class {
+    run = runMock;
+    constructor(client: unknown, opts: unknown) {
+      ctorSpy(client, opts);
+    }
+  },
+}));
+
+vi.mock("../src/input.js", () => ({
+  streamNdjsonFile: vi.fn(() => "FILE_SRC"),
+  streamNdjsonFrom: vi.fn(() => "STDIN_SRC"),
+  fileFingerprint: vi.fn(() => ({ size: 1, mtimeMs: 2, headHash: "h" })),
+  parseJsonInput: vi.fn(async () => [{ id: "a" }]),
+  recordsFromArray: vi.fn(() => [{ lineNumber: 1, raw: "{}", value: { id: "a" } }]),
+}));
+
+const resolveOptionsMock = vi.fn();
+vi.mock("../src/helpers.js", () => ({
+  createClient: vi.fn(() => ({})),
+  resolveOptions: (...args: unknown[]) => resolveOptionsMock(...args),
+  withErrorHandler: (fn: (...a: unknown[]) => unknown) => fn,
+}));
+
+vi.mock("../src/output.js", () => ({
+  printError: vi.fn(),
+  printInfo: vi.fn(),
+  printSuccess: vi.fn(),
+  printWarning: vi.fn(),
+}));
+
+vi.mock("../src/commands/help.js", () => ({ addExamples: vi.fn() }));
+
+import { registerImportCommand } from "../src/commands/import.js";
+import { createTestProgram, runCommand } from "./test-helpers.js";
+import * as output from "../src/output.js";
+import { createClient } from "../src/helpers.js";
+
+const okResult = { processed: 1, succeeded: 1, failed: 0, skipped: 0, chunks: 1, aborted: false };
+
+describe("import command", () => {
+  let program: ReturnType<typeof createTestProgram>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  const originalExitCode = process.exitCode;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resolveOptionsMock.mockReturnValue({ dryRun: false, verbose: false });
+    runMock.mockResolvedValue(okResult);
+    program = createTestProgram(registerImportCommand);
+    exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`exit:${code}`);
+    }) as never);
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    process.exitCode = originalExitCode;
+  });
+
+  it("imports an NDJSON file and passes parsed flags to the loader", async () => {
+    await runCommand(program, ["import", "data.ndjson", "--batch-size", "50", "--concurrency", "2"]);
+    expect(ctorSpy).toHaveBeenCalledTimes(1);
+    const opts = ctorSpy.mock.calls[0][1] as Record<string, unknown>;
+    expect(opts).toMatchObject({
+      mode: "upsert",
+      format: "ndjson",
+      batchSize: 50,
+      concurrency: 2,
+      fingerprint: { size: 1, mtimeMs: 2, headHash: "h" },
+    });
+    expect(runMock).toHaveBeenCalledWith("FILE_SRC");
+    expect(output.printSuccess).toHaveBeenCalled();
+  });
+
+  it("uses stdin (no fingerprint) for '-'", async () => {
+    await runCommand(program, ["import", "-"]);
+    const opts = ctorSpy.mock.calls[0][1] as Record<string, unknown>;
+    expect(opts.fingerprint).toBeUndefined();
+    expect(runMock).toHaveBeenCalledWith("STDIN_SRC");
+  });
+
+  it("parses a JSON array with --input-format json", async () => {
+    await runCommand(program, ["import", "data.json", "--input-format", "json"]);
+    const opts = ctorSpy.mock.calls[0][1] as Record<string, unknown>;
+    expect(opts.format).toBe("json");
+  });
+
+  it("rejects --resume with --mode replace", async () => {
+    await expect(
+      runCommand(program, ["import", "data.ndjson", "--resume", "ck", "--mode", "replace"]),
+    ).rejects.toThrow("exit:1");
+    expect(output.printError).toHaveBeenCalledWith(expect.stringContaining("upsert"));
+    expect(ctorSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects --resume with stdin input", async () => {
+    await expect(runCommand(program, ["import", "-", "--resume", "ck"])).rejects.toThrow("exit:1");
+    expect(output.printError).toHaveBeenCalledWith(expect.stringContaining("stdin"));
+  });
+
+  it("warns in replace mode", async () => {
+    await runCommand(program, ["import", "data.ndjson", "--mode", "replace"]);
+    expect(output.printWarning).toHaveBeenCalledWith(expect.stringContaining("replace mode"));
+  });
+
+  it("warns when --continue-on-error is used without --errors-out", async () => {
+    await runCommand(program, ["import", "data.ndjson", "--continue-on-error"]);
+    expect(output.printWarning).toHaveBeenCalledWith(expect.stringContaining("won't be captured"));
+  });
+
+  it("prints a dry-run plan and does not set a failing exit code", async () => {
+    resolveOptionsMock.mockReturnValue({ dryRun: true, verbose: false });
+    runMock.mockResolvedValue({ ...okResult, planned: 5, chunks: 2, succeeded: 0 });
+    await runCommand(program, ["import", "data.ndjson"]);
+    expect(output.printInfo).toHaveBeenCalledWith(expect.stringContaining("would send 5 entities"));
+    expect(process.exitCode).toBeUndefined();
+    // Dry-run must not require a configured client/URL.
+    expect(createClient).not.toHaveBeenCalled();
+  });
+
+  it("sets a failing exit code when entities fail", async () => {
+    runMock.mockResolvedValue({ processed: 3, succeeded: 1, failed: 2, skipped: 0, chunks: 1, aborted: false });
+    await runCommand(program, ["import", "data.ndjson", "--continue-on-error"]);
+    expect(process.exitCode).toBe(1);
+    expect(output.printWarning).toHaveBeenCalled();
+  });
+
+  it("warns and fails when the run was aborted", async () => {
+    runMock.mockResolvedValue({ processed: 2, succeeded: 1, failed: 1, skipped: 0, chunks: 1, aborted: true });
+    await runCommand(program, ["import", "data.ndjson"]);
+    expect(process.exitCode).toBe(1);
+    expect(output.printWarning).toHaveBeenCalledWith(expect.stringContaining("first failure"));
+  });
+});

--- a/tests/input-bulk.test.ts
+++ b/tests/input-bulk.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Readable } from "node:stream";
+import {
+  fileFingerprint,
+  fingerprintsMatch,
+  recordsFromArray,
+  streamNdjsonFile,
+  streamNdjsonFrom,
+} from "../src/input.js";
+import type { EntityRecord } from "../src/input.js";
+
+let tmp: string;
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), "geonic-input-"));
+});
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+async function drain(gen: AsyncGenerator<EntityRecord>): Promise<EntityRecord[]> {
+  const out: EntityRecord[] = [];
+  for await (const r of gen) out.push(r);
+  return out;
+}
+
+describe("streamNdjsonFrom", () => {
+  it("yields one record per non-blank line with 1-based line numbers", async () => {
+    const input = Readable.from(['{"id":"a"}\n', "\n", '{"id":"b"}\n']);
+    const recs = await drain(streamNdjsonFrom(input));
+    expect(recs).toHaveLength(2);
+    expect(recs[0]).toMatchObject({ lineNumber: 1, value: { id: "a" } });
+    // Blank line is skipped but still counted, so the second record is line 3.
+    expect(recs[1]).toMatchObject({ lineNumber: 3, value: { id: "b" } });
+  });
+
+  it("diverts an oversize line to a parse error instead of buffering it as an entity", async () => {
+    const huge = "x".repeat(16 * 1024 * 1024 + 1);
+    const input = Readable.from([`${huge}\n`, '{"id":"ok"}\n']);
+    const recs = await drain(streamNdjsonFrom(input));
+    expect(recs[0].parseError).toMatch(/exceeds max size/);
+    expect(recs[0].value).toBeUndefined();
+    expect(recs[1].value).toEqual({ id: "ok" });
+  });
+
+  it("captures a parse error instead of throwing", async () => {
+    const input = Readable.from(["{not json\n", '{"id":"ok"}\n']);
+    const recs = await drain(streamNdjsonFrom(input));
+    expect(recs[0].parseError).toBeDefined();
+    expect(recs[0].value).toBeUndefined();
+    expect(recs[1].value).toEqual({ id: "ok" });
+  });
+});
+
+describe("streamNdjsonFile", () => {
+  it("streams records from a file", async () => {
+    const file = join(tmp, "data.ndjson");
+    writeFileSync(file, '{"id":"a"}\n{"id":"b"}\n');
+    const recs = await drain(streamNdjsonFile(file));
+    expect(recs.map((r) => (r.value as { id: string }).id)).toEqual(["a", "b"]);
+  });
+});
+
+describe("recordsFromArray", () => {
+  it("maps an array to records with index-based line numbers", () => {
+    const recs = recordsFromArray([{ id: "a" }, { id: "b" }]);
+    expect(recs).toHaveLength(2);
+    expect(recs[1]).toMatchObject({ lineNumber: 2, value: { id: "b" } });
+  });
+
+  it("throws on non-array input", () => {
+    expect(() => recordsFromArray({ id: "a" })).toThrow(/array/);
+  });
+});
+
+describe("fileFingerprint / fingerprintsMatch", () => {
+  it("produces a stable fingerprint for the same content and detects changes", () => {
+    const file = join(tmp, "fp.ndjson");
+    writeFileSync(file, '{"id":"a"}\n');
+    const fp1 = fileFingerprint(file);
+    expect(fp1.size).toBeGreaterThan(0);
+    expect(fp1.headHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(fingerprintsMatch(fp1, { ...fp1 })).toBe(true);
+    expect(fingerprintsMatch(fp1, { ...fp1, size: fp1.size + 1 })).toBe(false);
+    expect(fingerprintsMatch(fp1, { ...fp1, headHash: "different" })).toBe(false);
+  });
+
+  it("hashes an empty file without error", () => {
+    const file = join(tmp, "empty.ndjson");
+    writeFileSync(file, "");
+    const fp = fileFingerprint(file);
+    expect(fp.size).toBe(0);
+    expect(fp.headHash).toMatch(/^[0-9a-f]{64}$/);
+  });
+});

--- a/tests/loader.test.ts
+++ b/tests/loader.test.ts
@@ -1,0 +1,491 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { GdbClientError } from "../src/client.js";
+import { BulkImporter, chunkRecords } from "../src/loader.js";
+import type { ImporterOptions } from "../src/loader.js";
+import type { EntityRecord, FileFingerprint } from "../src/input.js";
+
+const noSleep = () => Promise.resolve();
+const FP: FileFingerprint = { size: 100, mtimeMs: 1, headHash: "abc" };
+
+function records(ids: string[]): EntityRecord[] {
+  return ids.map((id, i) => ({ lineNumber: i + 1, raw: JSON.stringify({ id }), value: { id, type: "T" } }));
+}
+
+async function* fromArray(recs: EntityRecord[]): AsyncGenerator<EntityRecord> {
+  for (const r of recs) yield r;
+}
+
+function baseOpts(overrides: Partial<ImporterOptions> = {}): ImporterOptions {
+  return {
+    mode: "upsert",
+    format: "ndjson",
+    batchSize: 100,
+    maxBytes: 1_000_000,
+    concurrency: 1,
+    retries: 3,
+    timeoutMs: 60_000,
+    continueOnError: false,
+    bisect: false,
+    bisectMax: 8,
+    sleep: noSleep,
+    random: () => 0.5,
+    ...overrides,
+  };
+}
+
+function ok204() {
+  return { status: 204, data: "" };
+}
+
+let tmp: string;
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), "geonic-loader-"));
+});
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("chunkRecords", () => {
+  async function collect(gen: AsyncGenerator<{ records: EntityRecord[]; startLine: number; endLine: number }>) {
+    const out: { ids: string[]; startLine: number; endLine: number }[] = [];
+    for await (const c of gen) {
+      out.push({ ids: c.records.map((r) => (r.value as { id: string }).id), startLine: c.startLine, endLine: c.endLine });
+    }
+    return out;
+  }
+
+  it("splits by entity count", async () => {
+    const chunks = await collect(
+      chunkRecords(fromArray(records(["a", "b", "c", "d", "e"])), {
+        batchSize: 2,
+        maxBytes: 1_000_000,
+        skipUntilLine: 0,
+        isAborted: () => false,
+        onParseError: () => {},
+      }),
+    );
+    expect(chunks.map((c) => c.ids)).toEqual([["a", "b"], ["c", "d"], ["e"]]);
+    expect(chunks[0]).toMatchObject({ startLine: 1, endLine: 2 });
+  });
+
+  it("splits by byte size before count", async () => {
+    // Each entity serializes to > maxBytes/2, so only one fits per chunk.
+    const chunks = await collect(
+      chunkRecords(fromArray(records(["aaaaaaaa", "bbbbbbbb", "cccccccc"])), {
+        batchSize: 100,
+        maxBytes: 40,
+        skipUntilLine: 0,
+        isAborted: () => false,
+        onParseError: () => {},
+      }),
+    );
+    expect(chunks).toHaveLength(3);
+  });
+
+  it("emits an oversize single record as its own chunk", async () => {
+    const chunks = await collect(
+      chunkRecords(fromArray(records(["x"])), {
+        batchSize: 100,
+        maxBytes: 1, // smaller than any record
+        skipUntilLine: 0,
+        isAborted: () => false,
+        onParseError: () => {},
+      }),
+    );
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].ids).toEqual(["x"]);
+  });
+
+  it("skips records at or below skipUntilLine", async () => {
+    const chunks = await collect(
+      chunkRecords(fromArray(records(["a", "b", "c", "d"])), {
+        batchSize: 2,
+        maxBytes: 1_000_000,
+        skipUntilLine: 2,
+        isAborted: () => false,
+        onParseError: () => {},
+      }),
+    );
+    expect(chunks.map((c) => c.ids)).toEqual([["c", "d"]]);
+  });
+
+  it("diverts parse-error records to onParseError", async () => {
+    const onParseError = vi.fn();
+    const recs: EntityRecord[] = [
+      { lineNumber: 1, raw: "{bad", parseError: "unexpected token" },
+      { lineNumber: 2, raw: '{"id":"a"}', value: { id: "a" } },
+    ];
+    const chunks = await collect(
+      chunkRecords(fromArray(recs), {
+        batchSize: 10,
+        maxBytes: 1_000_000,
+        skipUntilLine: 0,
+        isAborted: () => false,
+        onParseError,
+      }),
+    );
+    expect(onParseError).toHaveBeenCalledTimes(1);
+    expect(chunks.map((c) => c.ids)).toEqual([["a"]]);
+  });
+
+  it("stops early when isAborted returns true", async () => {
+    let aborted = false;
+    const gen = chunkRecords(fromArray(records(["a", "b", "c", "d"])), {
+      batchSize: 1,
+      maxBytes: 1_000_000,
+      skipUntilLine: 0,
+      isAborted: () => aborted,
+      onParseError: () => {},
+    });
+    const first = await gen.next();
+    aborted = true;
+    const second = await gen.next();
+    expect(first.done).toBe(false);
+    expect(second.done).toBe(true);
+  });
+});
+
+describe("BulkImporter", () => {
+  it("counts a fully successful load (204)", async () => {
+    const client = { post: vi.fn().mockResolvedValue(ok204()) };
+    const importer = new BulkImporter(client as never, baseOpts({ batchSize: 2 }));
+    const result = await importer.run(fromArray(records(["a", "b", "c"])));
+    expect(result).toMatchObject({ processed: 3, succeeded: 3, failed: 0, aborted: false });
+    expect(client.post).toHaveBeenCalledTimes(2);
+    expect(client.post).toHaveBeenCalledWith(
+      "/entityOperations/upsert",
+      expect.any(Array),
+      undefined,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it("passes options=replace for replace mode", async () => {
+    const client = { post: vi.fn().mockResolvedValue(ok204()) };
+    const importer = new BulkImporter(client as never, baseOpts({ mode: "replace" }));
+    await importer.run(fromArray(records(["a"])));
+    expect(client.post).toHaveBeenCalledWith(
+      "/entityOperations/upsert",
+      expect.any(Array),
+      { options: "replace" },
+      expect.anything(),
+    );
+  });
+
+  it("classifies a 207 partial result and writes both error sinks", async () => {
+    const client = {
+      post: vi.fn().mockResolvedValue({
+        status: 207,
+        data: { created: ["a"], updated: [], errors: [{ entityId: "b", error: { detail: "dup" } }] },
+      }),
+    };
+    const errorsOut = join(tmp, "failed.ndjson");
+    const errorsLog = join(tmp, "errors.log");
+    const importer = new BulkImporter(
+      client as never,
+      baseOpts({ continueOnError: true, errorsOutPath: errorsOut, errorsLogPath: errorsLog }),
+    );
+    const result = await importer.run(fromArray(records(["a", "b"])));
+    expect(result).toMatchObject({ succeeded: 1, failed: 1 });
+    expect(readFileSync(errorsOut, "utf-8").trim()).toBe(JSON.stringify({ id: "b", type: "T" }));
+    const log = JSON.parse(readFileSync(errorsLog, "utf-8").trim());
+    expect(log).toMatchObject({ entityId: "b", status: 207, reason: "dup" });
+  });
+
+  it("describes 207 errors that lack a string detail", async () => {
+    const client = {
+      post: vi.fn().mockResolvedValue({
+        status: 207,
+        data: { created: [], updated: [], errors: [{ entityId: "a", error: { code: 42 } }] },
+      }),
+    };
+    const errorsLog = join(tmp, "errors.log");
+    const importer = new BulkImporter(client as never, baseOpts({ continueOnError: true, errorsLogPath: errorsLog }));
+    await importer.run(fromArray(records(["a"])));
+    expect(readFileSync(errorsLog, "utf-8")).toContain("code");
+  });
+
+  it("stringifies a non-object failure reason", async () => {
+    const client = { post: vi.fn().mockRejectedValue("string failure") };
+    const errorsLog = join(tmp, "errors.log");
+    const importer = new BulkImporter(client as never, baseOpts({ continueOnError: true, errorsLogPath: errorsLog }));
+    await importer.run(fromArray(records(["a"])));
+    expect(readFileSync(errorsLog, "utf-8")).toContain("string failure");
+  });
+
+  it("writes unaccounted records to errors-out when the server under-reports a 207", async () => {
+    // Server returns 207 but neither confirms nor errors the entities.
+    const client = { post: vi.fn().mockResolvedValue({ status: 207, data: { created: [], updated: [], errors: [] } }) };
+    const errorsOut = join(tmp, "failed.ndjson");
+    const importer = new BulkImporter(client as never, baseOpts({ continueOnError: true, errorsOutPath: errorsOut }));
+    const result = await importer.run(fromArray(records(["a", "b"])));
+    expect(result.failed).toBe(2);
+    expect(readFileSync(errorsOut, "utf-8").trim().split("\n")).toHaveLength(2);
+  });
+
+  it("logs a server error whose entityId matches no input record", async () => {
+    const client = {
+      post: vi.fn().mockResolvedValue({
+        status: 207,
+        data: { created: ["a"], updated: [], errors: [{ entityId: "ghost", error: { detail: "orphan" } }] },
+      }),
+    };
+    const errorsLog = join(tmp, "errors.log");
+    const importer = new BulkImporter(client as never, baseOpts({ continueOnError: true, errorsLogPath: errorsLog }));
+    const result = await importer.run(fromArray(records(["a"])));
+    expect(result.succeeded).toBe(1);
+    expect(readFileSync(errorsLog, "utf-8")).toContain("unmatched server error");
+  });
+
+  it("clamps a hostile Retry-After so no worker sleeps beyond the cooldown cap", async () => {
+    // Fake clock so the injected sleep advances Date.now() (the cooldown loop
+    // depends on time actually progressing).
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    try {
+      const client = {
+        post: vi
+          .fn()
+          .mockRejectedValueOnce(new GdbClientError("rate", 429, undefined, 1_000_000_000))
+          .mockResolvedValue(ok204()),
+      };
+      const delays: number[] = [];
+      const importer = new BulkImporter(
+        client as never,
+        baseOpts({
+          batchSize: 1,
+          sleep: (ms) => {
+            delays.push(ms);
+            vi.setSystemTime(Date.now() + ms);
+            return Promise.resolve();
+          },
+        }),
+      );
+      await importer.run(fromArray(records(["a", "b"])));
+      // Retry backoff clamps at 30s; shared cooldown clamps at 60s. Nothing near 1e9.
+      expect(Math.max(...delays)).toBeLessThanOrEqual(60_000);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("records a whole 400 chunk as failed and stops by default", async () => {
+    const client = { post: vi.fn().mockRejectedValue(new GdbClientError("bad", 400)) };
+    const errorsOut = join(tmp, "failed.ndjson");
+    const importer = new BulkImporter(client as never, baseOpts({ batchSize: 2, errorsOutPath: errorsOut }));
+    const result = await importer.run(fromArray(records(["a", "b", "c", "d"])));
+    expect(result.aborted).toBe(true);
+    expect(result.failed).toBe(2); // only the first chunk was attempted before abort
+    expect(client.post).toHaveBeenCalledTimes(1);
+  });
+
+  it("continues past failures with continueOnError", async () => {
+    const client = { post: vi.fn().mockRejectedValue(new GdbClientError("bad", 400)) };
+    const importer = new BulkImporter(client as never, baseOpts({ batchSize: 2, continueOnError: true }));
+    const result = await importer.run(fromArray(records(["a", "b", "c", "d"])));
+    expect(result.aborted).toBe(false);
+    expect(result.failed).toBe(4);
+    expect(client.post).toHaveBeenCalledTimes(2);
+  });
+
+  it("bisects a 400 chunk to isolate the offending entity", async () => {
+    const client = {
+      post: vi.fn().mockImplementation((_path, entities: { id: string }[]) => {
+        if (entities.some((e) => e.id === "bad")) {
+          return Promise.reject(new GdbClientError("bad", 400));
+        }
+        return Promise.resolve(ok204());
+      }),
+    };
+    const errorsOut = join(tmp, "failed.ndjson");
+    const importer = new BulkImporter(
+      client as never,
+      baseOpts({ batchSize: 4, bisect: true, continueOnError: true, errorsOutPath: errorsOut }),
+    );
+    const result = await importer.run(fromArray(records(["a", "b", "bad", "d"])));
+    expect(result.succeeded).toBe(3);
+    expect(result.failed).toBe(1);
+    expect(readFileSync(errorsOut, "utf-8").trim()).toBe(JSON.stringify({ id: "bad", type: "T" }));
+  });
+
+  it("stops bisecting at bisectMax depth", async () => {
+    const client = { post: vi.fn().mockRejectedValue(new GdbClientError("bad", 400)) };
+    const importer = new BulkImporter(
+      client as never,
+      baseOpts({ batchSize: 4, bisect: true, bisectMax: 0, continueOnError: true }),
+    );
+    const result = await importer.run(fromArray(records(["a", "b", "c", "d"])));
+    // depth limit 0 → never splits → whole chunk fails once
+    expect(result.failed).toBe(4);
+    expect(client.post).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a 429 then succeeds", async () => {
+    const client = {
+      post: vi
+        .fn()
+        .mockRejectedValueOnce(new GdbClientError("rate", 429, undefined, 5))
+        .mockResolvedValue(ok204()),
+    };
+    const onRetry = vi.fn();
+    const importer = new BulkImporter(client as never, baseOpts({ onRetry }));
+    const result = await importer.run(fromArray(records(["a"])));
+    expect(result.succeeded).toBe(1);
+    expect(onRetry).toHaveBeenCalledWith(expect.objectContaining({ status: 429 }));
+  });
+
+  it("retries a header-less 429 using the computed backoff for the shared cooldown", async () => {
+    const client = {
+      post: vi
+        .fn()
+        .mockRejectedValueOnce(new GdbClientError("rate", 429)) // no Retry-After
+        .mockResolvedValue(ok204()),
+    };
+    const onRetry = vi.fn();
+    const importer = new BulkImporter(client as never, baseOpts({ onRetry }));
+    const result = await importer.run(fromArray(records(["a"])));
+    expect(result.succeeded).toBe(1);
+    expect(onRetry).toHaveBeenCalledWith(expect.objectContaining({ status: 429 }));
+  });
+
+  it("records a chunk as failed when retries are exhausted", async () => {
+    const client = { post: vi.fn().mockRejectedValue(new GdbClientError("boom", 503)) };
+    const importer = new BulkImporter(client as never, baseOpts({ retries: 1, continueOnError: true }));
+    const result = await importer.run(fromArray(records(["a"])));
+    expect(result.failed).toBe(1);
+    expect(client.post).toHaveBeenCalledTimes(2); // initial + 1 retry
+  });
+
+  it("handles parse-error records", async () => {
+    const client = { post: vi.fn().mockResolvedValue(ok204()) };
+    const errorsLog = join(tmp, "errors.log");
+    const recs: EntityRecord[] = [
+      { lineNumber: 1, raw: "{bad", parseError: "bad json" },
+      { lineNumber: 2, raw: '{"id":"a"}', value: { id: "a", type: "T" } },
+    ];
+    const importer = new BulkImporter(
+      client as never,
+      baseOpts({ continueOnError: true, errorsLogPath: errorsLog }),
+    );
+    const result = await importer.run(fromArray(recs));
+    expect(result.failed).toBe(1);
+    expect(result.succeeded).toBe(1);
+    expect(readFileSync(errorsLog, "utf-8")).toContain("parse error");
+  });
+
+  it("aborts on parse error in stop mode", async () => {
+    const client = { post: vi.fn().mockResolvedValue(ok204()) };
+    const recs: EntityRecord[] = [{ lineNumber: 1, raw: "{bad", parseError: "bad json" }];
+    const importer = new BulkImporter(client as never, baseOpts());
+    const result = await importer.run(fromArray(recs));
+    expect(result.aborted).toBe(true);
+    expect(client.post).not.toHaveBeenCalled();
+  });
+
+  describe("dry run", () => {
+    it("plans without sending", async () => {
+      const client = { post: vi.fn() };
+      const importer = new BulkImporter(client as never, baseOpts({ dryRun: true, batchSize: 2 }));
+      const result = await importer.run(fromArray(records(["a", "b", "c"])));
+      expect(result.planned).toBe(3);
+      expect(result.chunks).toBe(2);
+      expect(client.post).not.toHaveBeenCalled();
+    });
+
+    it("counts parse errors as skipped in dry run", async () => {
+      const client = { post: vi.fn() };
+      const recs: EntityRecord[] = [
+        { lineNumber: 1, raw: "{bad", parseError: "x" },
+        { lineNumber: 2, raw: '{"id":"a"}', value: { id: "a" } },
+      ];
+      const importer = new BulkImporter(client as never, baseOpts({ dryRun: true }));
+      const result = await importer.run(fromArray(recs));
+      expect(result.planned).toBe(1);
+      expect(result.skipped).toBe(1);
+    });
+  });
+
+  describe("resume / checkpoint", () => {
+    it("writes a checkpoint after each committed chunk", async () => {
+      const client = { post: vi.fn().mockResolvedValue(ok204()) };
+      const ckpt = join(tmp, "run.ckpt");
+      const importer = new BulkImporter(
+        client as never,
+        baseOpts({ batchSize: 2, resumePath: ckpt, fingerprint: FP }),
+      );
+      await importer.run(fromArray(records(["a", "b", "c", "d"])));
+      const cp = JSON.parse(readFileSync(ckpt, "utf-8"));
+      expect(cp).toMatchObject({ mode: "upsert", format: "ndjson", committedLines: 4 });
+      expect(cp.fingerprint).toEqual(FP);
+    });
+
+    it("skips already-committed lines on resume", async () => {
+      const client = { post: vi.fn().mockResolvedValue(ok204()) };
+      const ckpt = join(tmp, "run.ckpt");
+      writeFileSync(
+        ckpt,
+        JSON.stringify({ version: 1, fingerprint: FP, mode: "upsert", format: "ndjson", batchSize: 2, committedLines: 2 }),
+      );
+      const importer = new BulkImporter(
+        client as never,
+        baseOpts({ batchSize: 2, resumePath: ckpt, fingerprint: FP }),
+      );
+      const result = await importer.run(fromArray(records(["a", "b", "c", "d"])));
+      expect(result.succeeded).toBe(2); // only c, d
+      expect(client.post).toHaveBeenCalledTimes(1);
+    });
+
+    it("refuses to resume when the file fingerprint differs", async () => {
+      const client = { post: vi.fn() };
+      const ckpt = join(tmp, "run.ckpt");
+      writeFileSync(
+        ckpt,
+        JSON.stringify({ version: 1, fingerprint: { size: 9, mtimeMs: 9, headHash: "zzz" }, mode: "upsert", format: "ndjson", batchSize: 2, committedLines: 2 }),
+      );
+      const importer = new BulkImporter(client as never, baseOpts({ resumePath: ckpt, fingerprint: FP }));
+      await expect(importer.run(fromArray(records(["a"])))).rejects.toThrow(/input file differs/);
+    });
+
+    it("refuses to resume when mode/format differ", async () => {
+      const client = { post: vi.fn() };
+      const ckpt = join(tmp, "run.ckpt");
+      writeFileSync(
+        ckpt,
+        JSON.stringify({ version: 1, fingerprint: FP, mode: "replace", format: "ndjson", batchSize: 2, committedLines: 2 }),
+      );
+      const importer = new BulkImporter(client as never, baseOpts({ resumePath: ckpt, fingerprint: FP }));
+      await expect(importer.run(fromArray(records(["a"])))).rejects.toThrow(/mode\/format/);
+    });
+
+    it("starts fresh when no checkpoint file exists yet", async () => {
+      const client = { post: vi.fn().mockResolvedValue(ok204()) };
+      const ckpt = join(tmp, "absent.ckpt");
+      const importer = new BulkImporter(client as never, baseOpts({ resumePath: ckpt, fingerprint: FP }));
+      const result = await importer.run(fromArray(records(["a"])));
+      expect(result.succeeded).toBe(1);
+    });
+  });
+
+  describe("concurrency", () => {
+    it("processes all chunks and advances the checkpoint contiguously despite out-of-order completion", async () => {
+      // First chunk resolves slower than the second → completion order is reversed.
+      const client = {
+        post: vi.fn().mockImplementation((_p, entities: { id: string }[]) => {
+          const delay = entities.some((e) => e.id === "a") ? 20 : 1;
+          return new Promise((resolve) => setTimeout(() => resolve(ok204()), delay));
+        }),
+      };
+      const ckpt = join(tmp, "c.ckpt");
+      const importer = new BulkImporter(
+        client as never,
+        baseOpts({ batchSize: 1, concurrency: 3, resumePath: ckpt, fingerprint: FP }),
+      );
+      const result = await importer.run(fromArray(records(["a", "b", "c"])));
+      expect(result.succeeded).toBe(3);
+      expect(JSON.parse(readFileSync(ckpt, "utf-8")).committedLines).toBe(3);
+    });
+  });
+});

--- a/tests/retry.test.ts
+++ b/tests/retry.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi } from "vitest";
+import { GdbClientError } from "../src/client.js";
+import { isRetryableError, withRetry } from "../src/retry.js";
+
+const noSleep = () => Promise.resolve();
+
+describe("isRetryableError", () => {
+  it("treats 429 and 5xx as retryable", () => {
+    expect(isRetryableError(new GdbClientError("rate", 429))).toBe(true);
+    expect(isRetryableError(new GdbClientError("boom", 500))).toBe(true);
+    expect(isRetryableError(new GdbClientError("boom", 503))).toBe(true);
+  });
+
+  it("treats 4xx (non-429) as non-retryable", () => {
+    expect(isRetryableError(new GdbClientError("bad", 400))).toBe(false);
+    expect(isRetryableError(new GdbClientError("conflict", 409))).toBe(false);
+  });
+
+  it("treats network errors and timeouts as retryable", () => {
+    const abort = new Error("aborted");
+    abort.name = "AbortError";
+    expect(isRetryableError(abort)).toBe(true);
+    const netErr = new TypeError("fetch failed");
+    expect(isRetryableError(netErr)).toBe(true);
+  });
+
+  it("treats unknown values as non-retryable", () => {
+    expect(isRetryableError("nope")).toBe(false);
+    expect(isRetryableError(new Error("plain"))).toBe(false);
+  });
+});
+
+describe("withRetry", () => {
+  it("returns immediately on success", async () => {
+    const fn = vi.fn().mockResolvedValue("ok");
+    const result = await withRetry(fn, { retries: 3, sleep: noSleep });
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries transient failures up to the limit then throws", async () => {
+    const fn = vi.fn().mockRejectedValue(new GdbClientError("boom", 500));
+    await expect(withRetry(fn, { retries: 2, sleep: noSleep })).rejects.toThrow("boom");
+    expect(fn).toHaveBeenCalledTimes(3); // initial + 2 retries
+  });
+
+  it("does not retry non-retryable errors", async () => {
+    const fn = vi.fn().mockRejectedValue(new GdbClientError("bad", 400));
+    await expect(withRetry(fn, { retries: 5, sleep: noSleep })).rejects.toThrow("bad");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("succeeds after a transient failure", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new GdbClientError("boom", 503))
+      .mockResolvedValue("ok");
+    const onRetry = vi.fn();
+    const result = await withRetry(fn, { retries: 3, sleep: noSleep, onRetry });
+    expect(result).toBe("ok");
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("honors Retry-After for 429 instead of backoff", async () => {
+    const err = new GdbClientError("rate", 429, undefined, 1234);
+    const fn = vi.fn().mockRejectedValueOnce(err).mockResolvedValue("ok");
+    const delays: number[] = [];
+    await withRetry(fn, {
+      retries: 1,
+      sleep: (ms) => {
+        delays.push(ms);
+        return Promise.resolve();
+      },
+    });
+    expect(delays).toEqual([1234]);
+  });
+
+  it("uses exponential backoff with jitter when no Retry-After", async () => {
+    const err = new GdbClientError("boom", 500);
+    const fn = vi.fn().mockRejectedValueOnce(err).mockResolvedValue("ok");
+    const delays: number[] = [];
+    await withRetry(fn, {
+      retries: 1,
+      baseDelayMs: 100,
+      random: () => 0.5,
+      sleep: (ms) => {
+        delays.push(ms);
+        return Promise.resolve();
+      },
+    });
+    // exp = 100 * 2^0 = 100; delay = 50 + 0.5*50 = 75
+    expect(delays).toEqual([75]);
+  });
+
+  it("honors Retry-After on a 503 as well as a 429", async () => {
+    const err = new GdbClientError("unavailable", 503, undefined, 2500);
+    const fn = vi.fn().mockRejectedValueOnce(err).mockResolvedValue("ok");
+    const delays: number[] = [];
+    await withRetry(fn, {
+      retries: 1,
+      sleep: (ms) => {
+        delays.push(ms);
+        return Promise.resolve();
+      },
+    });
+    expect(delays).toEqual([2500]);
+  });
+
+  it("uses the built-in sleep when none is injected", async () => {
+    const err = new GdbClientError("boom", 500);
+    const fn = vi.fn().mockRejectedValueOnce(err).mockResolvedValue("ok");
+    const result = await withRetry(fn, { retries: 1, baseDelayMs: 1, maxDelayMs: 2 });
+    expect(result).toBe("ok");
+  });
+
+  it("caps Retry-After at maxDelayMs", async () => {
+    const err = new GdbClientError("rate", 429, undefined, 999_999);
+    const fn = vi.fn().mockRejectedValueOnce(err).mockResolvedValue("ok");
+    const delays: number[] = [];
+    await withRetry(fn, {
+      retries: 1,
+      maxDelayMs: 5000,
+      sleep: (ms) => {
+        delays.push(ms);
+        return Promise.resolve();
+      },
+    });
+    expect(delays).toEqual([5000]);
+  });
+});


### PR DESCRIPTION
## 概要

巨大 NGSI-LD ロード (~100万件) を API Gateway の **29 秒制限を超えて**確実に投入するクライアント側バルクローダー `geonic import` を追加。本体 geolonia/geonicdb#1409 の代替として、サーバに新しい書き込み経路を作らず（＝既存クォータがそのまま効く）、通常の同期 batch upsert エンドポイントをクライアント側でチャンク分割・リトライ・resume することで解決する。

Closes #151

## 実装

- **ストリーミング入力**: NDJSON を 1 行ずつ読む (`--input-format json` で JSON 配列も可)。`src/input.ts`
- **チャンク分割**: 件数 (`--batch-size`, 既定 100) **かつ** バイト (`--max-bytes`) の両基準で分割。`src/loader.ts`
- **リトライ/バックオフ**: 429(Retry-After 尊重・**プロセス全体クールダウン**で 429 storm 抑止)/5xx/timeout を指数バックオフ + jitter で。Retry-After は上限クランプ (hostile な巨大値でハングしない)。`src/retry.ts` / `src/client.ts`(AbortSignal タイムアウト + Retry-After パース)
- **resume**: チェックポイント再開。入力ファイル同一性 (size/mtime/head-hash) + mode/format 一致を検証、atomic write (tmp→rename)、**upsert + ファイル入力限定** (replace/stdin は不可)
- **失敗の 2 系統出力**: `--errors-out` (再投入可能な NDJSON) と `--errors-log` (理由/ステータス/行番号)。207 はレコード単位で照合し、id 正規化やサーバの under-report でも取りこぼさない
- **bisect**: `--bisect` で 400/413 chunk を二分探索し不正エンティティを特定
- **停止方針**: 既定はエラーで停止、`--continue-on-error` で継続。`--dry-run` で送信せず計画表示 (URL 未設定でも可)
- **冪等性の明示**: retries/resume は at-least-once。replace は再送で上書きするため resume 非対応 + 警告表示

## レビュー

- **自己レビュー** (`/code-review` 高強度 + `/security-review`): Retry-After 上限なしハング、fileFingerprint 短絡読みでハッシュ不定、207 のデータロス、行長無制限 OOM、executeRawRequest 不整合、dry-run が URL 必須 等を検出 → 全て修正
- **Cursor レビュー** (gpt-5.2-codex-high): cooldown 待機後の abort 再チェック漏れ、並行時の成功チャンク未 commit、ヘッダなし 429 の storm、continue-on-error の暗黙データロス、maxBytes のブラケット分 を検出 → abort 所有権を processChunk に集約するリファクタで全て修正

## テスト

- `npm run lint` / `npm run typecheck` / `npm test` (**842 passed**) / `npm run build` すべて green
- 新規テスト: retry (境界/Retry-After/backoff)、loader (チャンク/分類/bisect/resume/cooldown クランプ/207 照合)、input (ストリーミング/fingerprint/行長)、client (Retry-After/signal)、import コマンド (フラグ/ガード/dry-run)
- モックサーバで実 HTTP パスを end-to-end 検証: 207 部分失敗→errors-out、400→bisect 隔離、429→リトライ成功、resume (committedLines 記録→再開で 0 件)、fingerprint/mode 不一致で拒否

## ドキュメント

- README (`### import` セクション + 全オプション表 + at-least-once 注記)、CHANGELOG、CLAUDE.md (構造ツリー) を更新。`geonic help import` / `--help` は commander から動的生成で確認済み

https://claude.ai/code/session_01Nm7gkgtPdr7kJp4ev3mhGC