### PR TITLE
release: v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## [Unreleased]
 
+## [0.19.0] - 2026-07-20
+
 ### 2026-07-20
 - **Feat**: `geonic import` — 巨大データセット向けのクライアント駆動バルクローダーを追加 (#152, closes #151, geonicdb#1409)
   - NDJSON をストリーミングで読み、件数 + バイトの両基準でチャンク分割して batch upsert に投入。API Gateway の 29 秒制限を回避
@@ -305,7 +307,8 @@
 ### 2026-02-26
 - **Docs**: README にインストール手順・使い方・コマンドリファレンスを追加 (#1)
 
-[Unreleased]: https://github.com/geolonia/geonicdb-cli/compare/v0.18.1...HEAD
+[Unreleased]: https://github.com/geolonia/geonicdb-cli/compare/v0.19.0...HEAD
+[0.19.0]: https://github.com/geolonia/geonicdb-cli/compare/v0.18.1...v0.19.0
 [0.18.1]: https://github.com/geolonia/geonicdb-cli/compare/v0.18.0...v0.18.1
 [0.18.0]: https://github.com/geolonia/geonicdb-cli/compare/v0.17.0...v0.18.0
 [0.17.0]: https://github.com/geolonia/geonicdb-cli/compare/v0.16.2...v0.17.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolonia/geonicdb-cli",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolonia/geonicdb-cli",
-      "version": "0.18.1",
+      "version": "0.19.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolonia/geonicdb-cli",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "description": "A CLI client for the GeonicDB",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## v0.19.0

`package.json` を 0.19.0 に上げ、CHANGELOG を `[0.19.0]` として確定。マージ後に `v0.19.0` タグを打ち、`publish.yml`（OIDC provenance）で npm 公開する。

### 含まれる変更（0.18.1 以降）
- **Feat**: `geonic import` — 巨大データセット向けクライアント駆動バルクローダー (#152, closes #151, geonicdb#1409)
- **Fix**: 開発依存の脆弱性 7 件を解消 (#153, Dependabot #135 を包含)

semver: 新機能追加のため minor bump。lint/typecheck/test(842)/build 緑。

https://claude.ai/code/session_01Nm7gkgtPdr7kJp4ev3mhGC
