### PR TITLE
feat(temporal): NGSILD-Warning 打ち切りの可視化 + --last-n バリデーション (#150)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@
 
 ## [Unreleased]
 
-## [0.19.0] - 2026-07-20
+### 2026-07-21
+- **Feat**: temporal 読み取り (`temporal entities list`/`get`、`temporal entityOperations query`) で本体の履歴打ち切りを可視化 (#150, geonicdb#1437)
+  - `lastN` 未指定時、本体は属性ごとの時系列を既定で最新 100 件にキャップする。打ち切り時に付く `NGSILD-Warning` (RFC 7234 warn-code 199) ヘッダを stderr に `Warning:` として表示し、silently drop を防ぐ
+  - `--last-n` を正整数バリデーション (`>= 1`) に変更。上限 (本体 1000) は CLI にハードコードせず、超過時は本体の 400 をそのまま提示（API との乖離を避ける）
+  - README に履歴打ち切りの挙動と全履歴取得の手段（`--last-n` 最大 1000 / 時間窓の絞り込み）を明記
 
 ### 2026-07-20
 - **Feat**: `geonic import` — 巨大データセット向けのクライアント駆動バルクローダーを追加 (#152, closes #151, geonicdb#1409)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ## [Unreleased]
 
 ### 2026-07-21
-- **Feat**: temporal 読み取り (`temporal entities list`/`get`、`temporal entityOperations query`) で本体の履歴打ち切りを可視化 (#150, geonicdb#1437)
+- **Feat**: temporal 読み取り (`temporal entities list`/`get`、`temporal entityOperations query`) で本体の履歴打ち切りを可視化 (#157, closes #150, geonicdb#1437)
   - `lastN` 未指定時、本体は属性ごとの時系列を既定で最新 100 件にキャップする。打ち切り時に付く `NGSILD-Warning` (RFC 7234 warn-code 199) ヘッダを stderr に `Warning:` として表示し、silently drop を防ぐ
   - `--last-n` を正整数バリデーション (`>= 1`) に変更。上限 (本体 1000) は CLI にハードコードせず、超過時は本体の 400 をそのまま提示（API との乖離を避ける）
   - README に履歴打ち切りの挙動と全履歴取得の手段（`--last-n` 最大 1000 / 時間窓の絞り込み）を明記

--- a/README.md
+++ b/README.md
@@ -446,6 +446,8 @@ Notes:
 
 Temporal entities list/get support: `--time-rel`, `--time-at`, `--end-time-at`, `--last-n`.
 
+> **History truncation**: Without `--last-n`, the server caps the returned history to the **100 most recent instances per attribute** (default). When it does, the server returns an `NGSILD-Warning` header and the CLI echoes it as a `Warning:` line on **stderr** so truncation is never a silent drop. To retrieve more, set `--last-n` (**max 1000**) or narrow the window with `--time-at`/`--end-time-at` — with an explicit `--last-n` the server does not truncate, so no warning is emitted. The CLI surfaces whatever `NGSILD-Warning` the server sends, verbatim.
+
 #### temporal entityOperations
 
 | Subcommand | Description |

--- a/src/commands/temporal.ts
+++ b/src/commands/temporal.ts
@@ -4,6 +4,8 @@ import {
   createClient,
   getFormat,
   outputResponse,
+  parsePositiveInt,
+  surfaceNgsiWarning,
 } from "../helpers.js";
 import { parseJsonInput } from "../input.js";
 import { printSuccess } from "../output.js";
@@ -20,7 +22,11 @@ function addTemporalListOptions(cmd: Command): Command {
     .option("--time-rel <rel>", "Temporal relationship (before, after, between)")
     .option("--time-at <time>", "Temporal query start time (ISO 8601)")
     .option("--end-time-at <time>", "Temporal query end time (ISO 8601)")
-    .option("--last-n <n>", "Return last N temporal values", parseInt)
+    .option(
+      "--last-n <n>",
+      "Return last N instances per attribute (server default caps to 100; max 1000)",
+      parsePositiveInt,
+    )
     .option("--limit <n>", "Maximum number of entities to return", parseInt)
     .option("--offset <n>", "Skip first N entities", parseInt)
     .option("--count", "Include total count in response");
@@ -49,6 +55,7 @@ function createListAction() {
     if (cmdOpts.count) params["count"] = "true";
 
     const response = await client.get("/temporal/entities", params);
+    surfaceNgsiWarning(response.headers);
     outputResponse(response, format, cmdOpts.count);
   });
 }
@@ -59,7 +66,11 @@ function addTemporalGetOptions(cmd: Command): Command {
     .option("--time-rel <rel>", "Temporal relationship (before, after, between)")
     .option("--time-at <time>", "Temporal query start time (ISO 8601)")
     .option("--end-time-at <time>", "Temporal query end time (ISO 8601)")
-    .option("--last-n <n>", "Return last N temporal values", parseInt);
+    .option(
+      "--last-n <n>",
+      "Return last N instances per attribute (server default caps to 100; max 1000)",
+      parsePositiveInt,
+    );
 }
 
 function createGetAction() {
@@ -80,6 +91,7 @@ function createGetAction() {
       `/temporal/entities/${encodeURIComponent(String(id))}`,
       params,
     );
+    surfaceNgsiWarning(response.headers);
     outputResponse(response, format);
   });
 }
@@ -122,6 +134,7 @@ function createQueryAction() {
       body,
       params,
     );
+    surfaceNgsiWarning(response.headers);
     outputResponse(response, format);
   });
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -100,6 +100,43 @@ export function parseNonNegativeInt(value: string): number {
 }
 
 /**
+ * Commander.js option parser for flags that require a positive integer (>= 1),
+ * such as `--last-n`. Rejects 0, negatives, and non-integers before the request
+ * is built so garbage never reaches the server. The upper bound (e.g. the
+ * temporal lastN max) is intentionally NOT enforced here — the server is the
+ * source of truth and returns a descriptive 400, avoiding a hardcoded limit
+ * that could drift from the API.
+ */
+export function parsePositiveInt(value: string): number {
+  const n = Number(value);
+  // Number.isSafeInteger rejects non-integers, Infinity, and NaN in one check,
+  // so an over-long digit string can't slip through as `Infinity` (< 1 is false).
+  if (!/^\d+$/.test(value) || !Number.isSafeInteger(n) || n < 1) {
+    throw new InvalidArgumentError("Must be a positive integer (>= 1).");
+  }
+  return n;
+}
+
+/**
+ * Surface an `NGSILD-Warning` response header (RFC 7234 warn-code 199) on
+ * stderr. The NGSI-LD Temporal API attaches this when it truncates history to
+ * the default cap (see geonicdb#1437), which would otherwise be a silent drop.
+ * The raw header looks like `199 - "temporal history truncated to ..."`; we
+ * strip the warn-code/quotes for readability. No-op when the header is absent.
+ */
+export function surfaceNgsiWarning(headers: Headers): void {
+  const raw = headers.get("NGSILD-Warning");
+  if (!raw) return;
+  // Extract the human-readable text: `<code> - "<text>"` → `<text>`.
+  const match = raw.match(/^\s*\d+\s*-\s*"?(.*?)"?\s*$/);
+  // Strip control characters (C0/C1, incl. ESC) so a malformed or hostile
+  // server-supplied header can't inject ANSI sequences into the terminal.
+  // eslint-disable-next-line no-control-regex
+  const text = (match ? match[1] : raw).replace(/[\u0000-\u001F\u007F-\u009F]/g, "");
+  printWarning(`Warning: ${text}`);
+}
+
+/**
  * Build a pagination query-param record from parsed CLI options.
  * Centralizes the limit/offset → string conversion shared by every list command.
  */

--- a/tests/helpers.test.ts
+++ b/tests/helpers.test.ts
@@ -22,7 +22,10 @@ import {
   outputResponse,
   withErrorHandler,
   fetchPaginatedList,
+  parsePositiveInt,
+  surfaceNgsiWarning,
 } from "../src/helpers.js";
+import { InvalidArgumentError } from "commander";
 
 function fakeCmd(cliOpts: Partial<GlobalOptions> = {}): Command {
   return { optsWithGlobals: () => ({ ...cliOpts }) } as unknown as Command;
@@ -507,6 +510,67 @@ describe("helpers", () => {
       const client = clientWithPages(pageResponse(Array.from({ length: 20 }, (_, i) => ({ id: i }))));
       await fetchPaginatedList(client, "/admin/users", { limit: 20 });
       expect(printWarning).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("parsePositiveInt", () => {
+    it("accepts positive integers", () => {
+      expect(parsePositiveInt("1")).toBe(1);
+      expect(parsePositiveInt("1000")).toBe(1000);
+    });
+
+    it("rejects zero, negatives, and non-integers", () => {
+      expect(() => parsePositiveInt("0")).toThrow(InvalidArgumentError);
+      expect(() => parsePositiveInt("-1")).toThrow(InvalidArgumentError);
+      expect(() => parsePositiveInt("1.5")).toThrow(InvalidArgumentError);
+      expect(() => parsePositiveInt("abc")).toThrow(InvalidArgumentError);
+      expect(() => parsePositiveInt("")).toThrow(InvalidArgumentError);
+    });
+
+    it("does not enforce an upper bound (server is the source of truth)", () => {
+      expect(parsePositiveInt("5000")).toBe(5000);
+    });
+
+    it("rejects an over-long digit string that would coerce to Infinity", () => {
+      expect(() => parsePositiveInt("9".repeat(400))).toThrow(InvalidArgumentError);
+    });
+  });
+
+  describe("surfaceNgsiWarning", () => {
+    it("prints the human-readable text stripped of warn-code and quotes", () => {
+      const headers = new Headers({
+        "NGSILD-Warning":
+          '199 - "temporal history truncated to the 100 most recent instances per attribute; narrow timeAt/endTimeAt or set lastN (max 1000)"',
+      });
+      surfaceNgsiWarning(headers);
+      expect(printWarning).toHaveBeenCalledWith(
+        "Warning: temporal history truncated to the 100 most recent instances per attribute; narrow timeAt/endTimeAt or set lastN (max 1000)",
+      );
+    });
+
+    it("falls back to the raw header when it does not match the RFC 7234 shape", () => {
+      const headers = new Headers({ "NGSILD-Warning": "something unexpected" });
+      surfaceNgsiWarning(headers);
+      expect(printWarning).toHaveBeenCalledWith("Warning: something unexpected");
+    });
+
+    it("is case-insensitive on the header name", () => {
+      const headers = new Headers({ "ngsild-warning": '199 - "capped"' });
+      surfaceNgsiWarning(headers);
+      expect(printWarning).toHaveBeenCalledWith("Warning: capped");
+    });
+
+    it("does nothing when the header is absent", () => {
+      surfaceNgsiWarning(new Headers());
+      expect(printWarning).not.toHaveBeenCalled();
+    });
+
+    it("strips control characters so a hostile header can't inject ANSI escapes", () => {
+      const headers = new Headers({
+        "NGSILD-Warning": '199 - "truncated\x1b[31m\x07 evil"',
+      });
+      surfaceNgsiWarning(headers);
+      expect(printWarning).toHaveBeenCalledWith("Warning: truncated[31m evil");
     });
   });
 

--- a/tests/temporal.test.ts
+++ b/tests/temporal.test.ts
@@ -2,13 +2,19 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createMockClient, mockResponse, createTestProgram, runCommand } from "./test-helpers.js";
 import type { MockClient } from "./test-helpers.js";
 
-vi.mock("../src/helpers.js", () => ({
-  createClient: vi.fn(),
-  getFormat: vi.fn(),
-  outputResponse: vi.fn(),
-  withErrorHandler: (fn: (...args: unknown[]) => unknown) => fn,
-  resolveOptions: vi.fn(),
-}));
+vi.mock("../src/helpers.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/helpers.js")>();
+  return {
+    createClient: vi.fn(),
+    getFormat: vi.fn(),
+    outputResponse: vi.fn(),
+    withErrorHandler: (fn: (...args: unknown[]) => unknown) => fn,
+    resolveOptions: vi.fn(),
+    // Use the real parser so the `--last-n` option wiring is genuinely exercised.
+    parsePositiveInt: actual.parsePositiveInt,
+    surfaceNgsiWarning: vi.fn(),
+  };
+});
 
 vi.mock("../src/input.js", () => ({
   parseJsonInput: vi.fn(),
@@ -28,7 +34,7 @@ vi.mock("../src/commands/help.js", () => ({
   addNotes: vi.fn(),
 }));
 
-import { createClient, getFormat, outputResponse } from "../src/helpers.js";
+import { createClient, getFormat, outputResponse, surfaceNgsiWarning } from "../src/helpers.js";
 import { parseJsonInput } from "../src/input.js";
 import { printSuccess } from "../src/output.js";
 import { registerTemporalCommand } from "../src/commands/temporal.js";
@@ -54,6 +60,23 @@ describe("temporal commands", () => {
       await runCommand(program, ["temporal", "entities", "list"]);
       expect(client.get).toHaveBeenCalledWith("/temporal/entities", {});
       expect(outputResponse).toHaveBeenCalled();
+    });
+
+    it("surfaces the NGSILD-Warning header from the response", async () => {
+      const res = mockResponse([]);
+      client.get.mockResolvedValue(res);
+      const program = makeProgram();
+      await runCommand(program, ["temporal", "entities", "list"]);
+      expect(surfaceNgsiWarning).toHaveBeenCalledWith(res.headers);
+    });
+
+    it("rejects a non-positive --last-n before issuing a request", async () => {
+      client.get.mockResolvedValue(mockResponse([]));
+      const program = makeProgram();
+      await expect(
+        runCommand(program, ["temporal", "entities", "list", "--last-n", "0"]),
+      ).rejects.toThrow(/positive integer/);
+      expect(client.get).not.toHaveBeenCalled();
     });
 
     it("passes all filter options as params", async () => {
@@ -129,6 +152,23 @@ describe("temporal commands", () => {
         },
       );
     });
+
+    it("surfaces the NGSILD-Warning header from the response", async () => {
+      const res = mockResponse({ id: "urn:sensor:001" });
+      client.get.mockResolvedValue(res);
+      const program = makeProgram();
+      await runCommand(program, ["temporal", "entities", "get", "urn:sensor:001"]);
+      expect(surfaceNgsiWarning).toHaveBeenCalledWith(res.headers);
+    });
+
+    it("rejects a non-positive --last-n before issuing a request", async () => {
+      client.get.mockResolvedValue(mockResponse({ id: "urn:sensor:001" }));
+      const program = makeProgram();
+      await expect(
+        runCommand(program, ["temporal", "entities", "get", "urn:sensor:001", "--last-n", "0"]),
+      ).rejects.toThrow(/positive integer/);
+      expect(client.get).not.toHaveBeenCalled();
+    });
   });
 
   describe("temporal entities create", () => {
@@ -172,6 +212,15 @@ describe("temporal commands", () => {
         { aggrMethods: "totalCount,sum", aggrPeriodDuration: "PT1H" },
       );
       expect(outputResponse).toHaveBeenCalled();
+    });
+
+    it("surfaces the NGSILD-Warning header from the response", async () => {
+      vi.mocked(parseJsonInput).mockResolvedValue({ entities: [{ type: "Sensor" }] });
+      const res = mockResponse([]);
+      client.post.mockResolvedValue(res);
+      const program = makeProgram();
+      await runCommand(program, ["temporal", "entityOperations", "query", "{}"]);
+      expect(surfaceNgsiWarning).toHaveBeenCalledWith(res.headers);
     });
 
     it("posts body without aggr options", async () => {


### PR DESCRIPTION
## 概要

本体 geonicdb#1437 で NGSI-LD Temporal API の挙動が変わり、`lastN` 未指定時は属性ごとの時系列が **最新 100 件に既定でキャップ**され、打ち切り時に `NGSILD-Warning` (RFC 7234 warn-code 199) ヘッダが返るようになった。CLI はこのヘッダを無視していたため、ユーザーから見ると履歴が **silently drop** されていた。本 PR で打ち切りを可視化し、`--last-n` の入力バリデーションを整える。

Closes #150

## 変更点

- **helpers `surfaceNgsiWarning()`**: レスポンスの `NGSILD-Warning` を stderr に `Warning:` として表示。warn-code/引用符を除去して可読化し、**制御文字を除去**してサーバ由来文字列による ANSI エスケープ注入を防止。ヘッダ不在時は no-op。
- **helpers `parsePositiveInt()`**: `--last-n` 用の正整数パーサ (`>= 1` の安全整数のみ)。上限 (本体 1000) は **CLI にハードコードせず**、超過時は本体の記述的な 400 をそのまま提示する（API との乖離を避ける）。過大な桁列が `Infinity` として通り抜けないよう `Number.isSafeInteger` でガード。
- **temporal コマンド**: `--last-n` を `parsePositiveInt` に切替 (list/get)、`list` / `get` / `entityOperations query` の各読み取りパスで警告を可視化。
- **README / CHANGELOG**: 履歴打ち切りの挙動と全履歴取得の手段（`--last-n` 最大 1000 / `--time-at`・`--end-time-at` での時間窓）を明記。

## テスト結果

- `npm run lint` — 0 errors
- `npm run typecheck` — pass
- `npm test` (unit) — **856 passed** (新規 14 件: parser、警告可視化 list/get/query、`--last-n 0` 拒否、制御文字除去)
- `npm run test:e2e` — **149 scenarios passed** (pinned geonicdb `913ceecf`。本変更は後方互換のため既存 E2E に影響なし)

## 補足

- `--last-n` の**明示指定時**はサーバが打ち切らない (=警告ヘッダを返さない) 前提。CLI はサーバが返した `NGSILD-Warning` をそのまま可視化する実装。
- クロスプロジェクト影響: 本体 API の**追従**であり CLI 単体の変更。SDK 等への影響なし。
