### PR TITLE
fix(deps): @hono/node-server を >=2.0.5 に固定し path traversal を解消 (Dependabot #70)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 
 ## [Unreleased]
 
+### 2026-07-25
+- **Fix**: 開発依存の path traversal 脆弱性 (Dependabot #70, GHSA-frvp-7c67-39w9, CVSS 5.9) を解消 (#160) — `@hono/node-server` を `overrides` で `>=2.0.5` に固定し、脆弱な `1.19.x` を `2.0.11` に更新
+  - 依存経路は `geonicdb`(devDependency) → `@modelcontextprotocol/sdk` → `@hono/node-server ^1.19.9`。1.x に修正版がなく (初回 patch は 2.0.5) メジャー跨ぎが必要なため `overrides` で強制
+  - 実害はなし: (1) devDependency のみで公開パッケージ (`files: ["dist"]`) には非同梱、(2) 脆弱な `serveStatic` 経路は未使用 (MCP SDK は `getRequestListener` のみ import)、(3) Windows 限定
+  - node-server 2.x の API 互換 (`getRequestListener`/`serve`) を確認。build/lint/typecheck/unit (856)/E2E (149) 全緑
+
 ### 2026-07-21
 - **Feat**: temporal 読み取り (`temporal entities list`/`get`、`temporal entityOperations query`) で本体の履歴打ち切りを可視化 (#157, closes #150, geonicdb#1437)
   - `lastN` 未指定時、本体は属性ごとの時系列を既定で最新 100 件にキャップする。打ち切り時に付く `NGSILD-Warning` (RFC 7234 warn-code 199) ヘッダを stderr に `Warning:` として表示し、silently drop を防ぐ

--- a/package-lock.json
+++ b/package-lock.json
@@ -1628,13 +1628,13 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.11.tgz",
+      "integrity": "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
   },
   "overrides": {
     "fast-xml-parser": ">=5.3.8",
-    "esbuild": "^0.28.1"
+    "esbuild": "^0.28.1",
+    "@hono/node-server": ">=2.0.5"
   },
   "devDependencies": {
     "@cucumber/cucumber": "^12.7.0",


### PR DESCRIPTION
## 概要

Dependabot alert **#70** (`@hono/node-server` の path traversal / GHSA-frvp-7c67-39w9, medium, CVSS 5.9) を解消する。`overrides` で `@hono/node-server` を `>=2.0.5` に固定し、脆弱な `1.19.x` を `2.0.11` に更新した。

## 依存経路 (dev-only / transitive)

```
geonicdb-cli
└─ geonicdb (devDependency, git pin)      ← E2E 用にローカルサーバを起動
   └─ @modelcontextprotocol/sdk@1.29.0
      └─ @hono/node-server ^1.19.9         ← 脆弱 (<2.0.5)
```

1.x に修正版がなく (初回 patch は 2.0.5)、MCP SDK の spec `^1.19.9` が 1.x に固定するため、`overrides` でメジャー跨ぎを強制した。

## 実害評価: 実質ゼロ (それでも衛生上修正)

- **devDependency のみ** — E2E でローカル geonicdb サーバを起動するために引き込まれる。CLI の実行時依存ではない。
- **公開パッケージに非同梱** — `files: ["dist"]` のため、npm 公開物には依存チェーンごと含まれない。
- **脆弱な経路が未使用** — 欠陥は `serveStatic` にある。MCP SDK は `@hono/node-server` から `getRequestListener` のみを import しており serve-static には到達しない。
- **Windows 限定** — Windows のパス解決が `\` をセパレータ扱いすることに依存する。

## 検証

- `@hono/node-server` 解決: `1.19.14 → 2.0.11`。lockfile に `<2.0.5` は残存なし。
- node-server 2.x の API 互換確認: `getRequestListener` / `serve` とも export 継続、MCP `streamableHttp` の import 成功。
- **lint ✓ / typecheck ✓ / unit 856/856 ✓ / E2E 149 scenarios・829 steps ✓**
  - E2E は geonicdb サーバ (MCP→node-server 経路) を実起動するため、メジャー跨ぎの負荷試験を兼ねる。
- 差分は最小: `package.json` (override 1 行) + `package-lock.json`。

## 注記

CLI 自体のコード変更はなし。本体 (geonicdb) の変更もなし → クロスプロジェクト影響なし。
