### PR TITLE
feat(auth): auth login に初回強制パスワード変更 (単発型) 対応を追加 (#163)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 
 ## [Unreleased]
 
-## [0.20.0] - 2026-07-25
+### 2026-07-26
+- **Feat**: `auth login` が初回強制パスワード変更 (単発型, geonicdb#1532) に対応 (#PR, closes #163)。管理者が一時パスワードを発行したユーザーがログインすると、本体は `409 PasswordResetRequired` を返す (本トークンは発行されない)。CLI はこれを検知して新しいパスワードを対話入力させ (確認再入力・不一致で中断)、同じ `POST /auth/login` に `newPassword` を同梱して設定を完了しトークンを取得する (再ログイン不要)。一時パスワードの有効期限切れ (`403 TemporaryPasswordExpired`) は「管理者に再発行を依頼」を促す明示メッセージで終了。マルチテナント再ログインには変更後の新パスワードを使う。email/password フローは元々 TTY 必須のため本対応も対話時のみ。CI/api-key 経路は一時パスワードを持たず影響なし。
 
 ### 2026-07-25
 - **Fix**: 開発依存の path traversal 脆弱性 (Dependabot #70, GHSA-frvp-7c67-39w9, CVSS 5.9) を解消 (#160) — `@hono/node-server` を `overrides` で `>=2.0.5` に固定し、脆弱な `1.19.x` を `2.0.11` に更新

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ## [Unreleased]
 
 ### 2026-07-26
-- **Feat**: `auth login` が初回強制パスワード変更 (単発型, geonicdb#1532) に対応 (#PR, closes #163)。管理者が一時パスワードを発行したユーザーがログインすると、本体は `409 PasswordResetRequired` を返す (本トークンは発行されない)。CLI はこれを検知して新しいパスワードを対話入力させ (確認再入力・不一致で中断)、同じ `POST /auth/login` に `newPassword` を同梱して設定を完了しトークンを取得する (再ログイン不要)。一時パスワードの有効期限切れ (`403 TemporaryPasswordExpired`) は「管理者に再発行を依頼」を促す明示メッセージで終了。マルチテナント再ログインには変更後の新パスワードを使う。email/password フローは元々 TTY 必須のため本対応も対話時のみ。CI/api-key 経路は一時パスワードを持たず影響なし。
+- **Feat**: `auth login` が初回強制パスワード変更 (単発型, geonicdb#1532) に対応 (#164, closes #163)。管理者が一時パスワードを発行したユーザーがログインすると、本体は `409 PasswordResetRequired` を返す (本トークンは発行されない)。CLI はこれを検知して新しいパスワードを対話入力させ (確認再入力・不一致で中断)、同じ `POST /auth/login` に `newPassword` を同梱して設定を完了しトークンを取得する (再ログイン不要)。一時パスワードの有効期限切れ (`403 TemporaryPasswordExpired`) は「管理者に再発行を依頼」を促す明示メッセージで終了。マルチテナント再ログインには変更後の新パスワードを使う。email/password フローは元々 TTY 必須のため本対応も対話時のみ。CI/api-key 経路は一時パスワードを持たず影響なし。
 
 ### 2026-07-25
 - **Fix**: 開発依存の path traversal 脆弱性 (Dependabot #70, GHSA-frvp-7c67-39w9, CVSS 5.9) を解消 (#160) — `@hono/node-server` を `overrides` で `>=2.0.5` に固定し、脆弱な `1.19.x` を `2.0.11` に更新

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -128,7 +128,7 @@ function createLoginCommand(): Command {
             err.status === 409 &&
             err.ngsiError?.error === "PasswordResetRequired"
           ) {
-            printInfo("初回ログインです。新しいパスワードを設定してください。");
+            printInfo("First login: you must set a new password to continue.");
             const newPassword = await promptPassword("New password");
             const confirmPassword = await promptPassword("Confirm new password");
             if (newPassword !== confirmPassword) {
@@ -147,7 +147,7 @@ function createLoginCommand(): Command {
             err.ngsiError?.error === "TemporaryPasswordExpired"
           ) {
             printError(
-              "一時パスワードの有効期限が切れています。管理者に再発行を依頼してください。",
+              "Your temporary password has expired. Ask an administrator to re-issue it.",
             );
             process.exit(1);
           } else {

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -7,6 +7,7 @@ import {
   getFormat,
   outputResponse,
 } from "../helpers.js";
+import { GdbClientError } from "../client.js";
 import { loadConfig, saveConfig, getCurrentProfile, validateUrl } from "../config.js";
 import { printSuccess, printError, printInfo, printWarning } from "../output.js";
 import { isInteractive, promptEmail, promptPassword, promptTenantSelection } from "../prompt.js";
@@ -107,12 +108,53 @@ function createLoginCommand(): Command {
 
         // Step 1: tenantless login. Server returns either a single-tenant token
         // or, for multi-tenant users, a primary-tenant token plus availableTenants.
-        const response = await client.rawRequest("POST", "/auth/login", {
-          body: { email, password },
-          skipTenantHeader: true,
-        });
+        //
+        // 初回強制パスワード変更 (単発型, geonicdb#1532): 管理者が一時パスワードを発行した
+        // ユーザーは、一時パスワードだけでは本トークンを受け取れず 409 PasswordResetRequired が返る。
+        // その場で新しいパスワードを入力させ、同じ login 呼び出し (newPassword 同梱) で設定を完了する
+        // (再ログイン不要)。一時パスワードの有効期限切れは 403 TemporaryPasswordExpired。
+        // 以降のテナント再ログインには、変更後の新パスワード (effectivePassword) を使う。
+        let effectivePassword = password;
+        let data: Record<string, unknown>;
+        try {
+          const response = await client.rawRequest("POST", "/auth/login", {
+            body: { email, password },
+            skipTenantHeader: true,
+          });
+          data = response.data as Record<string, unknown>;
+        } catch (err) {
+          if (
+            err instanceof GdbClientError &&
+            err.status === 409 &&
+            err.ngsiError?.error === "PasswordResetRequired"
+          ) {
+            printInfo("初回ログインです。新しいパスワードを設定してください。");
+            const newPassword = await promptPassword("New password");
+            const confirmPassword = await promptPassword("Confirm new password");
+            if (newPassword !== confirmPassword) {
+              printError("Passwords do not match.");
+              process.exit(1);
+            }
+            const response = await client.rawRequest("POST", "/auth/login", {
+              body: { email, password, newPassword },
+              skipTenantHeader: true,
+            });
+            data = response.data as Record<string, unknown>;
+            effectivePassword = newPassword;
+          } else if (
+            err instanceof GdbClientError &&
+            err.status === 403 &&
+            err.ngsiError?.error === "TemporaryPasswordExpired"
+          ) {
+            printError(
+              "一時パスワードの有効期限が切れています。管理者に再発行を依頼してください。",
+            );
+            process.exit(1);
+          } else {
+            throw err;
+          }
+        }
 
-        const data = response.data as Record<string, unknown>;
         let token = (data.accessToken ?? data.token) as string | undefined;
         let refreshToken = data.refreshToken as string | undefined;
 
@@ -172,7 +214,9 @@ function createLoginCommand(): Command {
 
           if (selected && selected.tenantId !== finalTenantId) {
             const reloginResponse = await client.rawRequest("POST", "/auth/login", {
-              body: { email, password, tenantId: selected.tenantId },
+              // #1532: 強制パスワード変更を完了した場合、一時パスワードは失効しているため
+              // 変更後の新パスワード (effectivePassword) で再ログインする。
+              body: { email, password: effectivePassword, tenantId: selected.tenantId },
               skipTenantHeader: true,
             });
             const reloginData = reloginResponse.data as Record<string, unknown>;

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -321,7 +321,7 @@ describe("auth commands", () => {
 
       const program = makeProgram();
       await expect(runCommand(program, ["auth", "login"])).rejects.toThrow("process.exit");
-      expect(printError).toHaveBeenCalledWith(expect.stringContaining("有効期限"));
+      expect(printError).toHaveBeenCalledWith(expect.stringContaining("expired"));
       expect(exitSpy).toHaveBeenCalledWith(1);
     });
 

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -68,6 +68,7 @@ import { isInteractive, promptEmail, promptPassword, promptTenantSelection } fro
 import { getTokenStatus, formatDuration } from "../src/token.js";
 import { clientCredentialsGrant } from "../src/oauth.js";
 import { registerAuthCommands } from "../src/commands/auth.js";
+import { GdbClientError } from "../src/client.js";
 
 describe("auth commands", () => {
   let client: MockClient;
@@ -256,6 +257,71 @@ describe("auth commands", () => {
       expect(printError).toHaveBeenCalledWith(
         expect.stringContaining("Interactive terminal required"),
       );
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it("handles forced password change (409) by prompting for a new password and completing login (#1532)", async () => {
+      vi.mocked(isInteractive).mockReturnValue(true);
+      vi.mocked(promptEmail).mockResolvedValue("reset@example.com");
+      vi.mocked(promptPassword)
+        .mockResolvedValueOnce("temppass12345") // initial (temporary) password
+        .mockResolvedValueOnce("BrandNewPass123") // New password
+        .mockResolvedValueOnce("BrandNewPass123"); // Confirm new password
+      client.rawRequest
+        .mockRejectedValueOnce(
+          new GdbClientError("Password reset required", 409, { error: "PasswordResetRequired" }),
+        )
+        .mockResolvedValueOnce(
+          mockResponse({ accessToken: "post-reset-token", refreshToken: "ref-reset" }),
+        );
+
+      const program = makeProgram();
+      await runCommand(program, ["auth", "login"]);
+
+      // 2nd request completes the reset with newPassword in the same login call.
+      expect(client.rawRequest).toHaveBeenNthCalledWith(2, "POST", "/auth/login", {
+        body: { email: "reset@example.com", password: "temppass12345", newPassword: "BrandNewPass123" },
+        skipTenantHeader: true,
+      });
+      expect(saveConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ token: "post-reset-token", refreshToken: "ref-reset" }),
+        "default",
+      );
+      expect(printSuccess).toHaveBeenCalledWith(expect.stringContaining("Login successful"));
+    });
+
+    it("aborts the forced password change when confirmation does not match (#1532)", async () => {
+      vi.mocked(isInteractive).mockReturnValue(true);
+      vi.mocked(promptEmail).mockResolvedValue("reset@example.com");
+      vi.mocked(promptPassword)
+        .mockResolvedValueOnce("temppass12345")
+        .mockResolvedValueOnce("BrandNewPass123")
+        .mockResolvedValueOnce("Mismatch99999"); // confirmation differs
+      client.rawRequest.mockRejectedValueOnce(
+        new GdbClientError("Password reset required", 409, { error: "PasswordResetRequired" }),
+      );
+
+      const program = makeProgram();
+      await expect(runCommand(program, ["auth", "login"])).rejects.toThrow("process.exit");
+      expect(printError).toHaveBeenCalledWith(expect.stringContaining("do not match"));
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      // No second login request when confirmation fails.
+      expect(client.rawRequest).toHaveBeenCalledTimes(1);
+    });
+
+    it("prints a clear error and exits when the temporary password is expired (403) (#1532)", async () => {
+      vi.mocked(isInteractive).mockReturnValue(true);
+      vi.mocked(promptEmail).mockResolvedValue("reset@example.com");
+      vi.mocked(promptPassword).mockResolvedValue("expiredtemp12");
+      client.rawRequest.mockRejectedValueOnce(
+        new GdbClientError("Temporary password expired", 403, {
+          error: "TemporaryPasswordExpired",
+        }),
+      );
+
+      const program = makeProgram();
+      await expect(runCommand(program, ["auth", "login"])).rejects.toThrow("process.exit");
+      expect(printError).toHaveBeenCalledWith(expect.stringContaining("有効期限"));
       expect(exitSpy).toHaveBeenCalledWith(1);
     });
 


### PR DESCRIPTION
## 概要

`auth login` を本体の**初回強制パスワード変更 (単発型, geonicdb#1532 / 本体 PR #1533)** に対応させる。

管理者が一時パスワードを発行 (`POST /admin/users/{userId}/reset-password`) したユーザーは、一時パスワードだけでは本トークンを受け取れず、本体が `409 PasswordResetRequired` を返す。CLI はこれを検知して新しいパスワードを対話入力させ、同じ login 呼び出しで設定を完了する。

Closes #163

## 変更点 (`src/commands/auth.ts`)

- Step1 の tenantless login を try/catch で囲み、`GdbClientError` を判定:
  - **`409` + `error==="PasswordResetRequired"`**: 「初回ログインです。新しいパスワードを設定してください。」を表示 → `promptPassword("New password")` + 確認再入力 (不一致で中断) → `POST /auth/login` に `newPassword` を同梱して再送 → トークン取得。以降のテナント再ログインには変更後の新パスワード (`effectivePassword`) を使う
  - **`403` + `error==="TemporaryPasswordExpired"`**: 「一時パスワードの有効期限が切れています。管理者に再発行を依頼してください。」で終了
  - それ以外はそのまま throw (従来どおり)
- サーバの機械可読キー (`err.ngsiError.error`) で分岐 (文言に依存しない)

## 設計メモ

- CLI は **409 に反応して** newPassword を送るため、旧サーバへ誤って newPassword を送る経路は無く、400-fallback は不要
- email/password フローは元々 TTY 必須のため、409 の対話入力も対話時のみ。CI/api-key→JWT 交換は一時パスワードを持たず本フローに該当しない
- `me password` は無変更 (単発型では強制変更が login に閉じる)

## テスト

`tests/auth.test.ts` に 3 件追加:
- 409 → 新パスワード prompt → newPassword 同梱で再送 → トークン保存 + Login successful
- 確認再入力の不一致で中断 (2nd request を送らない)
- 403 期限切れの明示エラーで終了

`npm run lint && npm run typecheck && npm test` (859 passed) + `npm run build` 全緑。

https://claude.ai/code/session_012m9hRxLTSipuaVoDf7cpfA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - `auth login` で初回ログイン時にパスワード変更を求められた場合、新しいパスワードを対話形式で設定できるようになりました。
  - パスワード変更後は自動的に再ログインし、認証トークンを取得できます。
  - 複数テナント利用時も、変更後のパスワードで再認証されます。

- **改善**
  - 一時パスワードの有効期限切れ時に、再発行を案内するメッセージを表示して終了するようになりました。
  - 確認用パスワードが一致しない場合は、ログインを実行せずエラーを表示します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->