### PR TITLE
release: v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@
 
 ## [Unreleased]
 
+## [0.21.0] - 2026-07-26
+
 ### 2026-07-26
 - **Feat**: `auth login` が初回強制パスワード変更 (単発型, geonicdb#1532) に対応 (#164, closes #163)。管理者が一時パスワードを発行したユーザーがログインすると、本体は `409 PasswordResetRequired` を返す (本トークンは発行されない)。CLI はこれを検知して新しいパスワードを対話入力させ (確認再入力・不一致で中断)、同じ `POST /auth/login` に `newPassword` を同梱して設定を完了しトークンを取得する (再ログイン不要)。一時パスワードの有効期限切れ (`403 TemporaryPasswordExpired`) は「管理者に再発行を依頼」を促す明示メッセージで終了。マルチテナント再ログインには変更後の新パスワードを使う。email/password フローは元々 TTY 必須のため本対応も対話時のみ。CI/api-key 経路は一時パスワードを持たず影響なし。
+
+## [0.20.0] - 2026-07-25
 
 ### 2026-07-25
 - **Fix**: 開発依存の path traversal 脆弱性 (Dependabot #70, GHSA-frvp-7c67-39w9, CVSS 5.9) を解消 (#160) — `@hono/node-server` を `overrides` で `>=2.0.5` に固定し、脆弱な `1.19.x` を `2.0.11` に更新
@@ -326,7 +330,8 @@
 ### 2026-02-26
 - **Docs**: README にインストール手順・使い方・コマンドリファレンスを追加 (#1)
 
-[Unreleased]: https://github.com/geolonia/geonicdb-cli/compare/v0.20.0...HEAD
+[Unreleased]: https://github.com/geolonia/geonicdb-cli/compare/v0.21.0...HEAD
+[0.21.0]: https://github.com/geolonia/geonicdb-cli/compare/v0.20.0...v0.21.0
 [0.20.0]: https://github.com/geolonia/geonicdb-cli/compare/v0.19.0...v0.20.0
 [0.19.0]: https://github.com/geolonia/geonicdb-cli/compare/v0.18.1...v0.19.0
 [0.18.1]: https://github.com/geolonia/geonicdb-cli/compare/v0.18.0...v0.18.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolonia/geonicdb-cli",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolonia/geonicdb-cli",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolonia/geonicdb-cli",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "A CLI client for the GeonicDB",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## v0.21.0

### 変更
- **Feat**: `auth login` が初回強制パスワード変更 (単発型, geonicdb#1532 / 本体 #1533) に対応 (#164, closes #163)。一時パスワードログインの `409 PasswordResetRequired` を検知して新パスワードを対話設定 → `newPassword` 同梱で完了。`403 TemporaryPasswordExpired` は再発行依頼で終了

### 修正
- **Docs**: #164 の CHANGELOG 追記時に誤って削除していた `## [0.20.0]` ヘッダを復元 (squash 回帰)。0.20.0 のエントリ (2026-07-25/07-21) を正しい版セクションへ戻した

### リリース手順
本 PR マージ後、`v0.21.0` タグを push → `publish.yml` が npm へ自動公開。

- package.json `0.20.0` → `0.21.0` (minor: Feat)
- lint / typecheck / test (859) / build 全緑

https://claude.ai/code/session_012m9hRxLTSipuaVoDf7cpfA