### PR TITLE
feat: 管理者による一時パスワード発行 (reset-password / create --force-reset) (#162)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ## [Unreleased]
 
 ### 2026-07-28
-- **Feat**: 管理者による一時パスワード発行に対応 (closes #162, geonicdb#1532)。`admin users reset-password <id>` を新設し、既存ユーザーに一時パスワードを発行して初回ログインでの強制変更 (単発型) を要求する (応答の `temporaryPassword`/`expiresAt` を stderr のボックスで一度だけ表示)。あわせて `admin users create` に `--force-reset` フラグを追加 — 本体の招待型 (`POST /admin/users` + `passwordResetRequired: true`) を使い、サーバー生成の一時パスワードで作成する (この経路では `password` を指定できない。指定時は送信前にエラー)。既定の `create`（`password` 直指定）は従来どおり非破壊。既存ユーザーへの発行 (reset-password) と作成時発行 (create --force-reset) の 2 経路。README 更新。本体は geonicdb#1567 でマージ済み。
+- **Feat**: 管理者による一時パスワード発行に対応 (closes #162, geonicdb#1532)。`admin users reset-password <id>` を新設し、既存ユーザーに一時パスワードを発行して初回ログインでの強制変更 (単発型) を要求する (応答の `temporaryPassword`/`expiresAt` を stderr のボックスで一度だけ表示)。あわせて `admin users create` に `--force-reset` フラグを追加 — 本体の招待型 (`POST /admin/users` + `passwordResetRequired: true`) を使い、サーバー生成の一時パスワードで作成する (この経路では `password` を指定できない。指定時は送信前にエラー)。既定の `create`（`password` 直指定）は従来どおり非破壊。既存ユーザーへの発行 (reset-password) と作成時発行 (create --force-reset) の 2 経路。README 更新。本体は geonicdb#1567 でマージ済み。(#166)
 
 ## [0.21.0] - 2026-07-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## [Unreleased]
 
+### 2026-07-28
+- **Feat**: 管理者による一時パスワード発行に対応 (closes #162, geonicdb#1532)。`admin users reset-password <id>` を新設し、既存ユーザーに一時パスワードを発行して初回ログインでの強制変更 (単発型) を要求する (応答の `temporaryPassword`/`expiresAt` を stderr のボックスで一度だけ表示)。あわせて `admin users create` に `--force-reset` フラグを追加 — 本体の招待型 (`POST /admin/users` + `passwordResetRequired: true`) を使い、サーバー生成の一時パスワードで作成する (この経路では `password` を指定できない。指定時は送信前にエラー)。既定の `create`（`password` 直指定）は従来どおり非破壊。既存ユーザーへの発行 (reset-password) と作成時発行 (create --force-reset) の 2 経路。README 更新。本体は geonicdb#1567 でマージ済み。
+
 ## [0.21.0] - 2026-07-26
 
 ### 2026-07-26

--- a/README.md
+++ b/README.md
@@ -575,12 +575,13 @@ When combined with a JSON payload, the flag merges into `settings` without dropp
 |---|---|
 | `admin users list` | List all users |
 | `admin users get <id>` | Get a user by ID |
-| `admin users create [json]` | Create a new user |
+| `admin users create [json]` | Create a new user (add `--force-reset` to issue a temporary password and force a first-login change) |
 | `admin users update <id> [json]` | Update a user |
 | `admin users delete <id>` | Delete a user |
 | `admin users activate <id>` | Activate a user |
 | `admin users deactivate <id>` | Deactivate a user |
 | `admin users unlock <id>` | Unlock a user |
+| `admin users reset-password <id>` | Issue a one-time temporary password and force a change on next login |
 
 #### admin policies
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@types/node": "^22.13.0",
         "@vitest/coverage-v8": "^4.1.8",
         "eslint": "^10.8.0",
-        "geonicdb": "github:geolonia/geonicdb#4f9f72cc6610137e7aa82cec6d62cbbb297b5f0f",
+        "geonicdb": "github:geolonia/geonicdb#f3d6acb4a930803b749491f0c869c9b034d52cfa",
         "mongodb": "^7.1.0",
         "mongodb-memory-server": "^11.0.1",
         "prettier": "^3.4.2",
@@ -66,18 +66,18 @@
       }
     },
     "node_modules/@aws-sdk/client-apigatewaymanagementapi": {
-      "version": "3.1091.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-apigatewaymanagementapi/-/client-apigatewaymanagementapi-3.1091.0.tgz",
-      "integrity": "sha512-AkAt1EdjcAOUkSKcvW8MYmJBzjIiBG9EtMtWWFhEtKrgBYJuxt3K3ManuYXH1jH/EWeBCNdGVzjBv1jVJxHaQg==",
+      "version": "3.1095.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-apigatewaymanagementapi/-/client-apigatewaymanagementapi-3.1095.0.tgz",
+      "integrity": "sha512-tPLLSUa2huKWlNLLorWNSNLzxp5uiQbEQ/bOKrGeslu5W2fyDdHdKc09DIYFFbrsL2LoXLqAG85+XllJwytTCg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/credential-provider-node": "^3.972.70",
+        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/credential-provider-node": "^3.972.72",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/fetch-http-handler": "^5.6.6",
-        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -86,18 +86,18 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudtrail": {
-      "version": "3.1091.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudtrail/-/client-cloudtrail-3.1091.0.tgz",
-      "integrity": "sha512-ssH26MEUzdfYmXy1I9LcYRSA2N9nTI4/CqGC2Ko+iBkFWiwnhjUe7/OVV9rM8xzAv45tTGOMe+SgHsAxX23jVQ==",
+      "version": "3.1095.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudtrail/-/client-cloudtrail-3.1095.0.tgz",
+      "integrity": "sha512-ijm4PrjosarWN0Eg9q0dUlBP9YU4dNzHgQtqhyTgNlI5allbnmWrA2G9NR4BeHewoqvR+s7ib9fO+Qsrw66YYA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/credential-provider-node": "^3.972.70",
+        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/credential-provider-node": "^3.972.72",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/fetch-http-handler": "^5.6.6",
-        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -106,20 +106,20 @@
       }
     },
     "node_modules/@aws-sdk/client-dynamodb": {
-      "version": "3.1091.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1091.0.tgz",
-      "integrity": "sha512-7NxnvP3pPAcUpSb9UxEKKSyppxfjvBV3MEoyFZ8NbxrAIMjCj0hUQxNbVBGTqvEf3hQBklf6ZlfE+WmGwczJRw==",
+      "version": "3.1095.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1095.0.tgz",
+      "integrity": "sha512-b1Y9NW5U1mOpkmLMnjZeUCo5FchTYfE3ththqXX6MA0beHpDwPydm5UPCJ0gcyHGvlPEYCU7NwANZwGHy+zCzA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/credential-provider-node": "^3.972.70",
-        "@aws-sdk/dynamodb-codec": "^3.973.33",
-        "@aws-sdk/middleware-endpoint-discovery": "^3.972.25",
+        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/credential-provider-node": "^3.972.72",
+        "@aws-sdk/dynamodb-codec": "^3.973.35",
+        "@aws-sdk/middleware-endpoint-discovery": "^3.972.26",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/fetch-http-handler": "^5.6.6",
-        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -128,19 +128,19 @@
       }
     },
     "node_modules/@aws-sdk/client-eventbridge": {
-      "version": "3.1091.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-eventbridge/-/client-eventbridge-3.1091.0.tgz",
-      "integrity": "sha512-yZUnlGSJhhBGhtZbK5jbH5Fg7YgIp0Zl2n0mZ+savYsoXVoPrpsWyTMXbxjkxw6r+5vcFDEUDpOimVqpkf7fJA==",
+      "version": "3.1095.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-eventbridge/-/client-eventbridge-3.1095.0.tgz",
+      "integrity": "sha512-qZ3G3aD9C5EP4wYSSRXvaUsI1jPkTKarUYRgXkg93gUF58Rmdp/ijJY3slFdH8uoJ7V0vop91G78Z41Rim+X5Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/credential-provider-node": "^3.972.70",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.41",
+        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/credential-provider-node": "^3.972.72",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.42",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/fetch-http-handler": "^5.6.6",
-        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -149,18 +149,18 @@
       }
     },
     "node_modules/@aws-sdk/client-kms": {
-      "version": "3.1091.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.1091.0.tgz",
-      "integrity": "sha512-0pwcfA3TUICjJsi7qvr4SQY7aQWuWU9XwUgg3scgmVRHLbM5RFdb8qFX+0G7nEti9MHxoC73jaVeeUxWFF7+Ew==",
+      "version": "3.1095.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.1095.0.tgz",
+      "integrity": "sha512-inNKi30hcvb/pQtS6Of4vDbWE4qWjTQx00G8H70ID565762qpBm9HZk6OVB13WCUvnORUnLqgPSad+ebrEVb5Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/credential-provider-node": "^3.972.70",
+        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/credential-provider-node": "^3.972.72",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/fetch-http-handler": "^5.6.6",
-        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -169,18 +169,18 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.1091.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1091.0.tgz",
-      "integrity": "sha512-VrJUAZAU6/pEUzy5bqXhBV2xqBcIp5an3rS7BYYaCZhLCAg1avI8EtxodQKhT6PNxBbfAmcoYHcb/JJ4Fn1ZCw==",
+      "version": "3.1095.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1095.0.tgz",
+      "integrity": "sha512-CiBryu8nC+8PVx72ybrxIPLOMoGLW0hGMWMvgqBWm8ZYOeE+w+c7HcLsuLhEiPzKMON8Xng0lPKCIm1ANWsv+Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/credential-provider-node": "^3.972.70",
+        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/credential-provider-node": "^3.972.72",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/fetch-http-handler": "^5.6.6",
-        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -189,18 +189,18 @@
       }
     },
     "node_modules/@aws-sdk/client-sns": {
-      "version": "3.1091.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sns/-/client-sns-3.1091.0.tgz",
-      "integrity": "sha512-4tgghB5bt0s0gSS7DafBaAeROU+1o0oYQz2SWQuAHS6oNRigDd42vzlNckm+d7tTRMY6cIGZ4wcyLlYRZb/cYw==",
+      "version": "3.1095.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sns/-/client-sns-3.1095.0.tgz",
+      "integrity": "sha512-B97JUxfcu/bTyqti3FZipDdIlH4g+YZ90CdpXT99+h6hww9dK6JMwNBHfJVHvmrYTy+NtflQf7HNQweXowIysg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/credential-provider-node": "^3.972.70",
+        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/credential-provider-node": "^3.972.72",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/fetch-http-handler": "^5.6.6",
-        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -209,19 +209,19 @@
       }
     },
     "node_modules/@aws-sdk/client-sqs": {
-      "version": "3.1091.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.1091.0.tgz",
-      "integrity": "sha512-OeGdH0oH5V8M65OImgevRQZlZEVubSWbC8OamK3a2y/ZYCL6HPsshniZSWijYVUXff8RQq0bLPgn17kijn6J9Q==",
+      "version": "3.1095.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.1095.0.tgz",
+      "integrity": "sha512-E9kLDfzlBxwnu5GaV+zyUQP88EwbTMyKca6MatmIJAaxhl12Yml7uDQaFxtSMLxNVEWP4oqFrByR8PZQJGTUKw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/credential-provider-node": "^3.972.70",
-        "@aws-sdk/middleware-sdk-sqs": "^3.972.37",
+        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/credential-provider-node": "^3.972.72",
+        "@aws-sdk/middleware-sdk-sqs": "^3.972.38",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/fetch-http-handler": "^5.6.6",
-        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -230,17 +230,17 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.975.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.3.tgz",
-      "integrity": "sha512-7ur3kCKuvPLqlsZ2XlvnNBVQ7KkpSu6Y6dOTwSPHLrFpTEfZM8isLBJc4cgv96WB7GifeVM436mpycwxBd2vEA==",
+      "version": "3.977.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.1.tgz",
+      "integrity": "sha512-KVtQRtc00ES/y+Sc3vYXeP6pCIcNlBJCZOwvqSy8ZpVGmbM5+IG+AfhuTKQ2oXmIVqZJewaGMMpzPkywC6xg0w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.974.2",
-        "@aws-sdk/xml-builder": "^3.972.36",
+        "@aws-sdk/xml-builder": "^3.972.37",
         "@aws/lambda-invoke-store": "^0.3.0",
-        "@smithy/core": "^3.29.4",
-        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/core": "^3.29.8",
+        "@smithy/signature-v4": "^5.6.9",
         "@smithy/types": "^4.16.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
@@ -250,15 +250,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.59",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.59.tgz",
-      "integrity": "sha512-Ny5e4Mfh3QPmiAc0AiUe+cbTXDlxkU3Rc+EpWOfyWeWEy6yp7Fa1KmfNeCc+1a8by9zQ9gtohmiQUkMPScF3ng==",
+      "version": "3.972.61",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.61.tgz",
+      "integrity": "sha512-qihs2ekMb89Nxd2JenCgVFhjbkb3EIo7HEBCBzyZACKVJdrLUZBLOmAE3xr0Sayml8n/jZSzwO/IufIiIzO7PQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/core": "^3.977.0",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -267,17 +267,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.61",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.61.tgz",
-      "integrity": "sha512-8jAjgStl5Ytq4+HF3X/9f+EmRinaRbGRRtQGktlPfBRVx73H+R1y48vIeXerQtYGFaUqkEp3fT6jP854rVO2yQ==",
+      "version": "3.972.63",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.63.tgz",
+      "integrity": "sha512-yfozsS8wkWZEi/n6IsrodcFKBWZ0iNAezhJbTReMNc0z1Px17qdeAeuL1/wziCAmCZyXiW7QzP75ggJkBQv8jQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/core": "^3.977.0",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/fetch-http-handler": "^5.6.6",
-        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -286,23 +286,23 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.973.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.4.tgz",
-      "integrity": "sha512-e6ZvVsj90aRALf1kHP+J4iqC1496ZpVgqI/+u0LJ5HL7q7ATauGy4gdDvRCP13L1pN/fMiZLah162PGIYkbUVQ==",
+      "version": "3.973.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.6.tgz",
+      "integrity": "sha512-jGLTW1bj148GL/6/IMlfY2fMYS9FtHOG+NahkFD4y0qkzYudNUahelxryY68/HGMslYuHClk1XaS/3b3eJzEkg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/credential-provider-env": "^3.972.59",
-        "@aws-sdk/credential-provider-http": "^3.972.61",
-        "@aws-sdk/credential-provider-login": "^3.972.66",
-        "@aws-sdk/credential-provider-process": "^3.972.59",
-        "@aws-sdk/credential-provider-sso": "^3.973.3",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.65",
-        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/credential-provider-env": "^3.972.61",
+        "@aws-sdk/credential-provider-http": "^3.972.63",
+        "@aws-sdk/credential-provider-login": "^3.972.68",
+        "@aws-sdk/credential-provider-process": "^3.972.61",
+        "@aws-sdk/credential-provider-sso": "^3.973.5",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.67",
+        "@aws-sdk/nested-clients": "^3.997.35",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/credential-provider-imds": "^4.4.9",
+        "@smithy/core": "^3.29.8",
+        "@smithy/credential-provider-imds": "^4.4.13",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -311,16 +311,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.66",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.66.tgz",
-      "integrity": "sha512-g2fsqm87r/nKthLZ0VkkDBElkGg0PvSa8d97HQ6EilMbJTZ6hxa8FxkSZyJfgPfFdZn0TTmkOffQmTSUcAHIng==",
+      "version": "3.972.68",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.68.tgz",
+      "integrity": "sha512-w6tNci6g7RqFpLhj1f5xseBvaNojb4Pkgp5Jp5apl9hrJtaf2AA+rX9+qlhlWUK6kcyAFYPA7emO+55zj+S98Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/nested-clients": "^3.997.35",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -329,21 +329,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.70",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.70.tgz",
-      "integrity": "sha512-3xzvkGdykBunxqh8WudmUpSyLWvIhfI6aBQo1b5rb3mDO5mNLadK+0hiI0qBQBMVynJbfLO+Ajy9dztMwy9O8w==",
+      "version": "3.972.72",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.72.tgz",
+      "integrity": "sha512-blQ7F5QGzylnzeh5549zQLoCAiMHkXFLjFovEMaVy4b2X8JhUu+u9NXro1hyK95YHdVFNmBHKs2hIHtZchxKlQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.59",
-        "@aws-sdk/credential-provider-http": "^3.972.61",
-        "@aws-sdk/credential-provider-ini": "^3.973.4",
-        "@aws-sdk/credential-provider-process": "^3.972.59",
-        "@aws-sdk/credential-provider-sso": "^3.973.3",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.65",
+        "@aws-sdk/credential-provider-env": "^3.972.61",
+        "@aws-sdk/credential-provider-http": "^3.972.63",
+        "@aws-sdk/credential-provider-ini": "^3.973.6",
+        "@aws-sdk/credential-provider-process": "^3.972.61",
+        "@aws-sdk/credential-provider-sso": "^3.973.5",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.67",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/credential-provider-imds": "^4.4.9",
+        "@smithy/core": "^3.29.8",
+        "@smithy/credential-provider-imds": "^4.4.13",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -352,15 +352,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.59",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.59.tgz",
-      "integrity": "sha512-DlZF2/MhLlatDdlrIy3CUCpfdbLrKx+3SMjVo+WyHnPpwzkc/M3vwAHw4OVJf7DMvO+4vfRqSCMc/E9I1auN0g==",
+      "version": "3.972.61",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.61.tgz",
+      "integrity": "sha512-xzRuj+fUVO4nkafKQJVKAF97kGpeQbfjuwmRrtGZNf42/1dkmcz6o7dswBy7alY0htQn5sCL1GWQYEykviWZkA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/core": "^3.977.0",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -369,17 +369,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.973.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.3.tgz",
-      "integrity": "sha512-hmdDHoy2G5Es2e8IgelNMYUuSQI6uCIAKZMJ2u2PdKDhxvbk1uWD/g4+R7R5c/tJfKEB1+KjjWiaoCr/S+ZTiQ==",
+      "version": "3.973.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.5.tgz",
+      "integrity": "sha512-fZRjjWhLFelsDoOYjqShQTrIGYC3Pf9Mx9Czf+1ikfQDgktxjze33dVo1q1/ZQ+T0qbtejVoHNHrfD5aJVpv/w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/nested-clients": "^3.997.33",
-        "@aws-sdk/token-providers": "3.1088.0",
+        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/nested-clients": "^3.997.35",
+        "@aws-sdk/token-providers": "3.1095.0",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -388,16 +388,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.65",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.65.tgz",
-      "integrity": "sha512-gHQb/Kt0chjk/JQDa/GJDqmAvEuVn8n7z10wK2h0LFM9TUDRkohgOO4aEF+s2sBLM0br7Cl5W6P7phgjrrJvLQ==",
+      "version": "3.972.67",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.67.tgz",
+      "integrity": "sha512-FTNZ05gkPBA6CKbU3N4zPgybV+stdazwMOya75CmGdcJL7p8Fw/BdHP8WVxJd0mvzyPK2cg/C3gli58Ir4HgCw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/nested-clients": "^3.997.35",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -406,14 +406,14 @@
       }
     },
     "node_modules/@aws-sdk/dynamodb-codec": {
-      "version": "3.973.33",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.33.tgz",
-      "integrity": "sha512-/awY2mG1zvTy22j4ryZL8jfWQdcuppsw17Mxw1tjG92hO+52JoFZaaTWrJIQp066t/aj4JC4II29UJb6g644vA==",
+      "version": "3.973.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.35.tgz",
+      "integrity": "sha512-h4l4YbioeEW2vM4OkelGkQ+pboFnTEaRAt8uH/b6oklm0p3NhISHXdbTk8x3/UOvLUNW+5ItU+B5JHTP9QfJBw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "@smithy/core": "^3.29.4",
+        "@aws-sdk/core": "^3.977.0",
+        "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -436,15 +436,15 @@
       }
     },
     "node_modules/@aws-sdk/lib-dynamodb": {
-      "version": "3.1091.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.1091.0.tgz",
-      "integrity": "sha512-PV9SKp5Kwi/IaqejwPcJXBaY3A13g7XX4IYTNzVuq44wB2ffHw7VrarugLCaQSPFGbIlEmfkZNbcLrU3sv9MKA==",
+      "version": "3.1095.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.1095.0.tgz",
+      "integrity": "sha512-Lx/d3Ou5KL/JttC1JSWA9fkvkVvFYwiVLnvvXCaHaW3AeUkgMcF8K3dCRWtbM9xW40hXdD3catwisgYXEfmbxQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/core": "^3.977.0",
         "@aws-sdk/util-dynamodb": "^3.996.7",
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -452,19 +452,19 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-dynamodb": "^3.1091.0"
+        "@aws-sdk/client-dynamodb": "^3.1095.0"
       }
     },
     "node_modules/@aws-sdk/middleware-endpoint-discovery": {
-      "version": "3.972.25",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.25.tgz",
-      "integrity": "sha512-5G2aVPmbWC5dFI76D0vsNg2L0fgWP4uybcetf+06dzeZuRtpihnow88fOl5zm3+ABdIw27FKgyFzV4yB5Bm29Q==",
+      "version": "3.972.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.26.tgz",
+      "integrity": "sha512-suOMAYAM43aSyC3cLBvvJIuNyg96nUsPvYQUrq4G+8Prt2qTpFETgaiXX7JP1gIcK5FF0Z2IdyEsPXseZATOPw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/endpoint-cache": "^3.972.9",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -473,14 +473,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-sqs": {
-      "version": "3.972.37",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.972.37.tgz",
-      "integrity": "sha512-ObKPWZWpog+4zZQ2q+LdBwf/nm+HF2afgBxCtyHeqjRlsnATuKOV3dPYnzCGyjRZ/RHTEre4LRrYRcIxlWhzVQ==",
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.972.38.tgz",
+      "integrity": "sha512-izM6iWpd/s50WMcYOjLJfWm7McNiJKeit/NNUQ4JQIU0rBmNPMvf7AsJN7tk28N+afPYbpPIUSE3BNWZwtwf8w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -489,18 +489,18 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.33",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.33.tgz",
-      "integrity": "sha512-dVZOroI/r3/ENvqNGgjMPul+jjlz9GddfVusgTXlVjfZj5isibOxecLkGQbRPp8XOuX+RAfjXLFgPkD1JS5xrw==",
+      "version": "3.997.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.35.tgz",
+      "integrity": "sha512-2MJfseVG/aXvIyOIBlYA/Oaf6qFDdsu4D8RKsEUdOQpVuLaor0BdxIBBtJLBNQQEe6Ku3YMvLljwb1MwVUpzRw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.41",
+        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.42",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/fetch-http-handler": "^5.6.6",
-        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -509,14 +509,14 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.41",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.41.tgz",
-      "integrity": "sha512-QMUytg+FQMGouc8gHS00KoYih3+N6cqmVI/pQGOIo7Nr7OpQaiXjSYOuL+vsPZ1tymY4LAQ8MYcHJmws5LRxng==",
+      "version": "3.996.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.42.tgz",
+      "integrity": "sha512-DBV4naZP6HYBlAvPpoQzOP12Wvfou/5rN8yJPXjBTBylU5qwCbh/tXr2MddHoIjgoRkEl/eS+IljiUqvmwey1Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/signature-v4": "^5.6.9",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -525,16 +525,16 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1088.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1088.0.tgz",
-      "integrity": "sha512-4ObatWt2qpJg5FBk4LOOKrTQYzaqeewAtdO3r9ZO8lH9YqLtpTzLyIdy0mJ+nVdfYOnqISkKNfmzP22bNDhwyw==",
+      "version": "3.1095.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1095.0.tgz",
+      "integrity": "sha512-65SudS6y4nzaYHybtqcpm3sHe5jLhdMn68HRKS1nUx690BtQeaAQOoujQ+dpOjBATIVGVgKKjEP8tR+U06QJQA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/nested-clients": "^3.997.35",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
+        "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -573,9 +573,9 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.36",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.36.tgz",
-      "integrity": "sha512-RdGmS1GLrtaTOLE1ElSluMldNrpk9Emq6uYs8SS8iHlu5xTAmM9rRkM91o48+rIRryBtyO9t+uLYCoMG6jVMVA==",
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz",
+      "integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1849,13 +1849,13 @@
       }
     },
     "node_modules/@opentelemetry/configuration": {
-      "version": "0.220.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/configuration/-/configuration-0.220.0.tgz",
-      "integrity": "sha512-glfIVKnZevRin8fY/9uES/mhRtMT1lGINLHc9MIo5fTQZXswEEHamJtgjv4MTtzgnhHGC92mIS/0lzAUZMyE0w==",
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/configuration/-/configuration-0.221.0.tgz",
+      "integrity": "sha512-uE9y56Zdi9Gt/RdxYnVOo3YmFZkKJJMA0gqtBe8wh8gdtF5Asqe+Oh/TWiDtFb1s+31jNY4CWgnfIB1KOITfFA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/core": "2.10.0",
         "yaml": "^2.8.3"
       },
       "engines": {
@@ -1866,9 +1866,9 @@
       }
     },
     "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.9.0.tgz",
-      "integrity": "sha512-OQ0vzvbZBiUhjqLnUaoNfYmP8553Crr3aggB4y0ZUi815mZ7idpdJXQmoKdeBKJelYttoBlLSSHubmyw3wvX4w==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.10.0.tgz",
+      "integrity": "sha512-bvyMcgLEkozzSzpEEEo1OMoeQ97bxj6Qs2uN3mPrSdDvObMI1myffD/BPqcLlzZO9//d1SqQA/WPw7Cz2AiqhA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1879,9 +1879,9 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
-      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.10.0.tgz",
+      "integrity": "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1895,18 +1895,16 @@
       }
     },
     "node_modules/@opentelemetry/exporter-logs-otlp-grpc": {
-      "version": "0.220.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.220.0.tgz",
-      "integrity": "sha512-s0sRPCSlXYqlgObOpCftomJllp3LfUL9FobQ5csg2172ydVhSEnu1ptpsVBJadazs5nUNp7vDuLE03FAFWTLOQ==",
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.221.0.tgz",
+      "integrity": "sha512-txG1G0IrYSsKKMeiWZfj/i5cQmWB+h+hf3HzPpF3RqZVwp+iQQEIsv8Vtmzy6RWVdHdJZfygmVrBI39YTBvWcw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@grpc/grpc-js": "^1.14.3",
-        "@opentelemetry/core": "2.9.0",
-        "@opentelemetry/otlp-exporter-base": "0.220.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.220.0",
-        "@opentelemetry/otlp-transformer": "0.220.0",
-        "@opentelemetry/sdk-logs": "0.220.0"
+        "@opentelemetry/otlp-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-transformer": "0.221.0",
+        "@opentelemetry/sdk-logs": "0.221.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -1916,17 +1914,15 @@
       }
     },
     "node_modules/@opentelemetry/exporter-logs-otlp-http": {
-      "version": "0.220.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.220.0.tgz",
-      "integrity": "sha512-8186thl+pTw64iz/qEEen5oJZoZ/gO73XruChdaGlYdWOdBIQ42r+vHLf6a7vIDqTD4b8ZOoMlyxptanECaI9A==",
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.221.0.tgz",
+      "integrity": "sha512-nKXkr4Tomi6fjYVOf+ytcW3dZAVr4v4Bv5gsT6dr2gvpUPJpKgHB4XbMufMsPotRE3g0XH2GwVVCkN2w6SON+Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.220.0",
-        "@opentelemetry/core": "2.9.0",
-        "@opentelemetry/otlp-exporter-base": "0.220.0",
-        "@opentelemetry/otlp-transformer": "0.220.0",
-        "@opentelemetry/sdk-logs": "0.220.0"
+        "@opentelemetry/otlp-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-transformer": "0.221.0",
+        "@opentelemetry/sdk-logs": "0.221.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -1936,15 +1932,15 @@
       }
     },
     "node_modules/@opentelemetry/exporter-logs-otlp-proto": {
-      "version": "0.220.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.220.0.tgz",
-      "integrity": "sha512-8LZAxdJ0ENDAFwr4j0oY35mHBltiSzvlhdQAPGiC7p9VnxtuSq4SW1gfBAdW6t6hiQG6OwUl8w7KHaOdJPKHWg==",
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.221.0.tgz",
+      "integrity": "sha512-AH6EY+47gXFaWYgG3hfeOneGiE9xIZGtDBk+9g0sM8NZWzsQhhmqPbQQXJzS7pyCh5jRRr2nYNXVrkCmoojRvQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/otlp-exporter-base": "0.220.0",
-        "@opentelemetry/otlp-transformer": "0.220.0",
-        "@opentelemetry/sdk-logs": "0.220.0"
+        "@opentelemetry/otlp-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-transformer": "0.221.0",
+        "@opentelemetry/sdk-logs": "0.221.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -1954,20 +1950,15 @@
       }
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-grpc": {
-      "version": "0.220.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.220.0.tgz",
-      "integrity": "sha512-U128izvJfX/dW9jRGP0gIfadR1Hg7ft3UEGIeRxLFK70m2BWw6AtNCOnsUygpw2zCgR/ygdWbGpcL6TmhW0ZGw==",
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.221.0.tgz",
+      "integrity": "sha512-KOgCtO15FC6C1T/xOqBcr7EyUs7B+7yomGNb5Y97d3s38rPbCCk5sewkmE2b0/itOkQ/PptX8CLlD+kn2mEtTg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@grpc/grpc-js": "^1.14.3",
-        "@opentelemetry/core": "2.9.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.220.0",
-        "@opentelemetry/otlp-exporter-base": "0.220.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.220.0",
-        "@opentelemetry/otlp-transformer": "0.220.0",
-        "@opentelemetry/resources": "2.9.0",
-        "@opentelemetry/sdk-metrics": "2.9.0"
+        "@opentelemetry/exporter-metrics-otlp-http": "0.221.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-transformer": "0.221.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -1977,17 +1968,17 @@
       }
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
-      "version": "0.220.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.220.0.tgz",
-      "integrity": "sha512-Yqt3RBw/bRVncaE9qIIhk4WfjbAQqXuP9FgAaU+IKPndnLEp/cUqZlSC324+bpmduRz7DoTjig8Ub0PeILWXUA==",
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.221.0.tgz",
+      "integrity": "sha512-sRfCKbOzgy8xZQV2as0RzIZlnCmCseCKZGLfRcrpo2CBngJDr+rPtX0zkG0+oUCV5kfQPUoW3W3C96Ag3Y/Clg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.9.0",
-        "@opentelemetry/otlp-exporter-base": "0.220.0",
-        "@opentelemetry/otlp-transformer": "0.220.0",
-        "@opentelemetry/resources": "2.9.0",
-        "@opentelemetry/sdk-metrics": "2.9.0"
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/otlp-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-transformer": "0.221.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-metrics": "2.10.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -1997,18 +1988,15 @@
       }
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-proto": {
-      "version": "0.220.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.220.0.tgz",
-      "integrity": "sha512-lyO+IQBdSvqHN/ZOW/OzrSWemtfD+HgWngn+HBNLhjy0YrCQQTz0OE/kSekH2Pl340dn9DWzhqHdz5Eftr+HLA==",
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.221.0.tgz",
+      "integrity": "sha512-YMF4LveY2I3yhw61rn6nmC9FE8U24IZHPeKU1Duc5+sbwjMd8FwZAwba318ImdThCg/HuVQvhm2y6bfgNPnfYg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.9.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.220.0",
-        "@opentelemetry/otlp-exporter-base": "0.220.0",
-        "@opentelemetry/otlp-transformer": "0.220.0",
-        "@opentelemetry/resources": "2.9.0",
-        "@opentelemetry/sdk-metrics": "2.9.0"
+        "@opentelemetry/exporter-metrics-otlp-http": "0.221.0",
+        "@opentelemetry/otlp-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-transformer": "0.221.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -2018,15 +2006,15 @@
       }
     },
     "node_modules/@opentelemetry/exporter-prometheus": {
-      "version": "0.220.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.220.0.tgz",
-      "integrity": "sha512-JZD5DL/NBpVd2BHefvYosm3G40UZ/KzExLv5tc0eZe0CtrsHHtcOk3YPUxR2EINmUeBf8+w5UReTV8fFPn95lA==",
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.221.0.tgz",
+      "integrity": "sha512-kW79a20qWESIuAdDrxzg9WKM98twV/NBWBFRAH57ap/+ssZhiCo0hckzKT0zpuwR/gSHrFAQhJL0bYDrnEM34g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.9.0",
-        "@opentelemetry/resources": "2.9.0",
-        "@opentelemetry/sdk-metrics": "2.9.0",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-metrics": "2.10.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -2037,17 +2025,16 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
-      "version": "0.220.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.220.0.tgz",
-      "integrity": "sha512-bv1xmNhmNwIM6MdUBw4yYuJeVcEViVLk3uD69vOQMwueHBnfyl/u0HnBlB1FNY/Te0UOzJzvcbyR8wN6b+iGbA==",
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.221.0.tgz",
+      "integrity": "sha512-zXminlZedtq9LvOW64CnNkOqk15zV75k8JgtdTuWFge6+jk2m4GmAUm6L2eIiG1o2a2bZxXw2PDrszm+bps0IA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@grpc/grpc-js": "^1.14.3",
-        "@opentelemetry/otlp-exporter-base": "0.220.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.220.0",
-        "@opentelemetry/otlp-transformer": "0.220.0",
-        "@opentelemetry/sdk-trace": "2.9.0"
+        "@opentelemetry/otlp-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-transformer": "0.221.0",
+        "@opentelemetry/sdk-trace": "2.10.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -2057,17 +2044,15 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-http": {
-      "version": "0.220.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.220.0.tgz",
-      "integrity": "sha512-/+ExB3lRkf+erv4PnoywyL7RHKITidxtUpUTS55k7OQ0dB42S7gEF1gry7swb9MSm1hYLUhJg4QQh9W8SpwwqA==",
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.221.0.tgz",
+      "integrity": "sha512-AySXiKoC+meiWm6zdVj5T2LnPDZuatveBby1cMOeQteIWsYXAUxs8Sru13G2pVSPrUXz6vF+og7QVBX6GdC/oQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.9.0",
-        "@opentelemetry/otlp-exporter-base": "0.220.0",
-        "@opentelemetry/otlp-transformer": "0.220.0",
-        "@opentelemetry/resources": "2.9.0",
-        "@opentelemetry/sdk-trace": "2.9.0"
+        "@opentelemetry/otlp-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-transformer": "0.221.0",
+        "@opentelemetry/sdk-trace": "2.10.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -2077,17 +2062,15 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
-      "version": "0.220.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.220.0.tgz",
-      "integrity": "sha512-voTAD8XgJxlK7zLkXh8EzMB09zrQr3tyY/BsnDTlDiQU/UdK58MZ63A3mUjdEDrxMjCVmBHU3WQJhRmQe+Dvzg==",
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.221.0.tgz",
+      "integrity": "sha512-Z9i2T7vgZbWe9rSLYxXVIbeW+XyzUq4rZanW3ZyVNwVDqCsh0EJKUgBWWQ0CZfeuUA+RQPzKgJQHMuWAUnKqXw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.9.0",
-        "@opentelemetry/otlp-exporter-base": "0.220.0",
-        "@opentelemetry/otlp-transformer": "0.220.0",
-        "@opentelemetry/resources": "2.9.0",
-        "@opentelemetry/sdk-trace": "2.9.0"
+        "@opentelemetry/otlp-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-transformer": "0.221.0",
+        "@opentelemetry/sdk-trace": "2.10.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -2097,15 +2080,15 @@
       }
     },
     "node_modules/@opentelemetry/exporter-zipkin": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-2.9.0.tgz",
-      "integrity": "sha512-RwINoce2BH8T4obT5pMcAla2sWma1YZvYuaktWmTluQ0PkQdvv5D060rWI1+kawX+J2qBRcMbwrZJJNcMJUauQ==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-2.10.0.tgz",
+      "integrity": "sha512-7gsvgf0UDoJ4l9ObrwBmz5G/ZogiPk+lq+g5GpLp24YQF/vPM/BSsnOfcLnfinast5ASUgLo78uSC/ObjlnXgg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.9.0",
-        "@opentelemetry/resources": "2.9.0",
-        "@opentelemetry/sdk-trace": "2.9.0",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-trace": "2.10.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -2134,14 +2117,14 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-aws-sdk": {
-      "version": "0.75.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.75.0.tgz",
-      "integrity": "sha512-RLosRcyIojBDzX6uPcooDlpJH5UFzbOZXwLp4NKl2FHy0UgmMfQU+mmul12wEohKTDiGumWouw43yRF69NAfbQ==",
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.76.0.tgz",
+      "integrity": "sha512-gg2QaDtWeFezRt2mAl9vBQ38y60tzUShKg1KA9uTgsMJimUHaBnB3X8kEH9Of8jKWT4DDoDcSA37gPcoEc0hiA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.220.0",
+        "@opentelemetry/instrumentation": "^0.221.0",
         "@opentelemetry/semantic-conventions": "^1.34.0"
       },
       "engines": {
@@ -2151,17 +2134,79 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/instrumentation-http": {
-      "version": "0.220.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.220.0.tgz",
-      "integrity": "sha512-Szt4dO2Boz2CDr38DaSw/lnqwhwKl+IAdgNGEGgSm2Anb+fwPtIAGmIwkhsLLN69QQZQE96JxjMKYY4rlRkYKw==",
+    "node_modules/@opentelemetry/instrumentation-aws-sdk/node_modules/@opentelemetry/api-logs": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.221.0.tgz",
+      "integrity": "sha512-OlanaW1vv7ufTqQ3/fPLI4arGt5ZoM+P8abOMki6uEYnpRazepSWDwDnnw+la7kE26SHVC18//SMccrDvLKOXQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.9.0",
-        "@opentelemetry/instrumentation": "0.220.0",
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-aws-sdk/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.221.0.tgz",
+      "integrity": "sha512-cCk80Z/iRDf/5gfsKMB4f74LqVA5yKETB/9ojPzVW/6/f70iu89nJvGxsFCxx4XfSohaOofkU19kiYm84AiAlw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.221.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-http": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.221.0.tgz",
+      "integrity": "sha512-oIP91CPIANuYr09tGFElPFKAh6JUar+awJf1kBRYlaeo9b0gDwZHEB2zBfFlvdNFHm0wAVutMZODVi5smKT30g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/instrumentation": "0.221.0",
         "@opentelemetry/semantic-conventions": "^1.29.0",
         "forwarded-parse": "2.1.2"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/api-logs": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.221.0.tgz",
+      "integrity": "sha512-OlanaW1vv7ufTqQ3/fPLI4arGt5ZoM+P8abOMki6uEYnpRazepSWDwDnnw+la7kE26SHVC18//SMccrDvLKOXQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.221.0.tgz",
+      "integrity": "sha512-cCk80Z/iRDf/5gfsKMB4f74LqVA5yKETB/9ojPzVW/6/f70iu89nJvGxsFCxx4XfSohaOofkU19kiYm84AiAlw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.221.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -2206,14 +2251,14 @@
       }
     },
     "node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.220.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.220.0.tgz",
-      "integrity": "sha512-CXYo8UD5Mn9YbgebO2EL4wejtA+gxLmLiu6HCk2KH2BR7XhFN6/6p1UlCb23DYCjeYkndevLHuejCCN1yx4+OQ==",
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.221.0.tgz",
+      "integrity": "sha512-UFPIq80OH3Ns/oPFHRj14d4DTOxUo+MUFU8hUiCq5jTqFhdeJnfVSANHT+xp92409cA+oxzvlZCe6NM1wvCuBA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.9.0",
-        "@opentelemetry/otlp-transformer": "0.220.0"
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/otlp-transformer": "0.221.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -2223,16 +2268,16 @@
       }
     },
     "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
-      "version": "0.220.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.220.0.tgz",
-      "integrity": "sha512-/eIkBPMBTIvM3x/0mDX4aJeSkYifYClnBPr68PL1h5LV4VQv4+SV6CGrpiZ4fIWDnobVmhTWCm1J/QRdAWUfvA==",
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.221.0.tgz",
+      "integrity": "sha512-rQDmNgyiGCTrescjnzH2ntVyUKVIq6I2UjuK8+stT/Xg0ZOT71FVJqwjFdspQl6Yol/Yqsut9bDo+ame8oTmDQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.14.3",
-        "@opentelemetry/core": "2.9.0",
-        "@opentelemetry/otlp-exporter-base": "0.220.0",
-        "@opentelemetry/otlp-transformer": "0.220.0"
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/otlp-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-transformer": "0.221.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -2242,18 +2287,18 @@
       }
     },
     "node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.220.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.220.0.tgz",
-      "integrity": "sha512-lXGrv7KXZ0gNH9SVNUaa6vv6phVYGvJxfXAlMbzbakiXru75f5MZl8Z7oqiMMQD77riVHJCFlQvbZs/VVN2/4A==",
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.221.0.tgz",
+      "integrity": "sha512-lg6lkOU08Az23jVcn/0Els9HP+V8PnR4Km6p0KgpTggS0n/WuhnmY64rSh83Of9iR9nD+dpWr6adlcX8KzAwjg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.220.0",
-        "@opentelemetry/core": "2.9.0",
-        "@opentelemetry/resources": "2.9.0",
-        "@opentelemetry/sdk-logs": "0.220.0",
-        "@opentelemetry/sdk-metrics": "2.9.0",
-        "@opentelemetry/sdk-trace": "2.9.0"
+        "@opentelemetry/api-logs": "0.221.0",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-logs": "0.221.0",
+        "@opentelemetry/sdk-metrics": "2.10.0",
+        "@opentelemetry/sdk-trace": "2.10.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -2262,14 +2307,27 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/propagator-b3": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-2.9.0.tgz",
-      "integrity": "sha512-WrOT1WsOUG+B7hstD2RYoMPIOK76G8E9AQHhMjUvrQaGx/oA7rPWQvvr1Rqv7+yy4R0ZMVwWLC4vW2xnkgWPAQ==",
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/api-logs": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.221.0.tgz",
+      "integrity": "sha512-OlanaW1vv7ufTqQ3/fPLI4arGt5ZoM+P8abOMki6uEYnpRazepSWDwDnnw+la7kE26SHVC18//SMccrDvLKOXQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.9.0"
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-b3": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-2.10.0.tgz",
+      "integrity": "sha512-GnA5B24H+1w8BO21J0q+IWNB0z1v+AGbcquTdIt/dufibhnhgxaA8YKvz0I3akRZhB1jHT+/tlzK+qlAjEDybQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -2279,13 +2337,13 @@
       }
     },
     "node_modules/@opentelemetry/propagator-jaeger": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-2.9.0.tgz",
-      "integrity": "sha512-4mYGty27rYvSM0jtp1ZUOqd3LfVRCYg9H5G9OFzSx5HViYToU21MFhWfco7x1HwXr7ER8yGOiCIHZUwjPksc0Q==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-2.10.0.tgz",
+      "integrity": "sha512-yw/IX8DL470dSMZJoE82ScfYGp7JWZ/G8kFJo35ZILUVTB2jFPTOaioN+8s09pH0RHsWNhweVZb+ZnjJJpCChg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.9.0"
+        "@opentelemetry/core": "2.10.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -2295,13 +2353,13 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
-      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.10.0.tgz",
+      "integrity": "sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/core": "2.10.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -2312,15 +2370,15 @@
       }
     },
     "node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.220.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.220.0.tgz",
-      "integrity": "sha512-WywcTkQtv2iNmt+6y5Kcd4rzvx9bLVsBa2Nwcmg01IUaBTkTow3W4d9KE5vNBpEDtb9tp21WcRBY/lANRrApYA==",
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.221.0.tgz",
+      "integrity": "sha512-FaDcazjyMp7TZZZAsqbo4IkovP0UegoCu0EBkiNt+qCqvUf7FPAsfcrZ3+ZEkKgXZ/jHafop+JoGPDk3A0SmLg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.220.0",
-        "@opentelemetry/core": "2.9.0",
-        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/api-logs": "0.221.0",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -2330,15 +2388,28 @@
         "@opentelemetry/api": ">=1.4.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.9.0.tgz",
-      "integrity": "sha512-Xx8RGS4H5XEBl01WuCreMIpiah9cCXMbSkeuIePPdD2cUpq/vUzYmj8E/MK1OsbOc93FuAD4jfn2WOacKwLn7Q==",
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/api-logs": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.221.0.tgz",
+      "integrity": "sha512-OlanaW1vv7ufTqQ3/fPLI4arGt5ZoM+P8abOMki6uEYnpRazepSWDwDnnw+la7kE26SHVC18//SMccrDvLKOXQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.9.0",
-        "@opentelemetry/resources": "2.9.0"
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.10.0.tgz",
+      "integrity": "sha512-t6r1VSvXNtSDnPXU1FbZeetJb7yyovHmgu0wRSoftxtE0g2rSNhQZQUy69sRUCL+iioJpX8SN/S6wq6ZtvLySQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -2348,38 +2419,38 @@
       }
     },
     "node_modules/@opentelemetry/sdk-node": {
-      "version": "0.220.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.220.0.tgz",
-      "integrity": "sha512-wHtGyHhSKHNH3fym33xRu4Ef/HXTFvX8eQ42xdQdEO9LYx9Y2qNyBDJytyqVlvmo6abWZlNYTUthuAGUMYqYnQ==",
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.221.0.tgz",
+      "integrity": "sha512-UbYuvtBrQQB5Prsh9KOKy4kxzexFxfMs5MkteHeWMoswsEB7kiNhyUVkAOFW/qsEzNHtrkgyghrD2ilZJa+5YA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.220.0",
-        "@opentelemetry/configuration": "0.220.0",
-        "@opentelemetry/context-async-hooks": "2.9.0",
-        "@opentelemetry/core": "2.9.0",
-        "@opentelemetry/exporter-logs-otlp-grpc": "0.220.0",
-        "@opentelemetry/exporter-logs-otlp-http": "0.220.0",
-        "@opentelemetry/exporter-logs-otlp-proto": "0.220.0",
-        "@opentelemetry/exporter-metrics-otlp-grpc": "0.220.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.220.0",
-        "@opentelemetry/exporter-metrics-otlp-proto": "0.220.0",
-        "@opentelemetry/exporter-prometheus": "0.220.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.220.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.220.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.220.0",
-        "@opentelemetry/exporter-zipkin": "2.9.0",
-        "@opentelemetry/instrumentation": "0.220.0",
-        "@opentelemetry/otlp-exporter-base": "0.220.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.220.0",
-        "@opentelemetry/propagator-b3": "2.9.0",
-        "@opentelemetry/propagator-jaeger": "2.9.0",
-        "@opentelemetry/resources": "2.9.0",
-        "@opentelemetry/sdk-logs": "0.220.0",
-        "@opentelemetry/sdk-metrics": "2.9.0",
-        "@opentelemetry/sdk-trace": "2.9.0",
-        "@opentelemetry/sdk-trace-base": "2.9.0",
-        "@opentelemetry/sdk-trace-node": "2.9.0",
+        "@opentelemetry/api-logs": "0.221.0",
+        "@opentelemetry/configuration": "0.221.0",
+        "@opentelemetry/context-async-hooks": "2.10.0",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/exporter-logs-otlp-grpc": "0.221.0",
+        "@opentelemetry/exporter-logs-otlp-http": "0.221.0",
+        "@opentelemetry/exporter-logs-otlp-proto": "0.221.0",
+        "@opentelemetry/exporter-metrics-otlp-grpc": "0.221.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.221.0",
+        "@opentelemetry/exporter-metrics-otlp-proto": "0.221.0",
+        "@opentelemetry/exporter-prometheus": "0.221.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.221.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.221.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.221.0",
+        "@opentelemetry/exporter-zipkin": "2.10.0",
+        "@opentelemetry/instrumentation": "0.221.0",
+        "@opentelemetry/otlp-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.221.0",
+        "@opentelemetry/propagator-b3": "2.10.0",
+        "@opentelemetry/propagator-jaeger": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-logs": "0.221.0",
+        "@opentelemetry/sdk-metrics": "2.10.0",
+        "@opentelemetry/sdk-trace": "2.10.0",
+        "@opentelemetry/sdk-trace-base": "2.10.0",
+        "@opentelemetry/sdk-trace-node": "2.10.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -2389,15 +2460,46 @@
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-trace": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.9.0.tgz",
-      "integrity": "sha512-sGA19HvtrrSKYsseHphluH6j3p6Xa3fqc7c7y8f/7mYWejc1lyDFcpSdD1kYa50HCLUeEo4zA5bW0pniaPszuw==",
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/api-logs": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.221.0.tgz",
+      "integrity": "sha512-OlanaW1vv7ufTqQ3/fPLI4arGt5ZoM+P8abOMki6uEYnpRazepSWDwDnnw+la7kE26SHVC18//SMccrDvLKOXQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.9.0",
-        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.221.0.tgz",
+      "integrity": "sha512-cCk80Z/iRDf/5gfsKMB4f74LqVA5yKETB/9ojPzVW/6/f70iu89nJvGxsFCxx4XfSohaOofkU19kiYm84AiAlw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.221.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.10.0.tgz",
+      "integrity": "sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -2408,15 +2510,15 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.9.0.tgz",
-      "integrity": "sha512-cp9zmTl62R8PJrpvFcmc8N2JQU/xfa0S+61q511Nji+QxCfZ8Ifvg7H27G8cANe4crg4RTrWsVvanHiXjSp6ag==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.10.0.tgz",
+      "integrity": "sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.9.0",
-        "@opentelemetry/resources": "2.9.0",
-        "@opentelemetry/sdk-trace": "2.9.0",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-trace": "2.10.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -2427,15 +2529,15 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-node": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.9.0.tgz",
-      "integrity": "sha512-ec9a7ps37huy5itYk0MalaZdSLlM6AXWp/FhtEjgMpp5leEGojBDvAl/UWttQnkMZOvFHKzRESn8TD3yKTF5nQ==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.10.0.tgz",
+      "integrity": "sha512-GZK/G6oZyBLGlH1pUgeDch7D91KoHd2uotUGIkWCPi9GI5T9X0p4L7nNAMDR1BQjkRYoDqo+ddfVx9t5Uhys+Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/context-async-hooks": "2.9.0",
-        "@opentelemetry/core": "2.9.0",
-        "@opentelemetry/sdk-trace-base": "2.9.0"
+        "@opentelemetry/context-async-hooks": "2.10.0",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/sdk-trace-base": "2.10.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -3145,9 +3247,9 @@
       ]
     },
     "node_modules/@smithy/core": {
-      "version": "3.29.6",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.6.tgz",
-      "integrity": "sha512-TO3w25cdGWBeYqKNDaqH3v4O3jjMPpKwf39YlG5X5xhqWfpOWJbi5gQi1lrllukuwohdhY0TPB8jBEv6UC50Vg==",
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.30.0.tgz",
+      "integrity": "sha512-dl2yRglDxfzH9uJ4fSo4zTaAHa0zH7+V7BZMRWy8hEYIKT1BiqMUK/CN6T3ADQ3kbA5N1tmUulroJ2UtONS7Kw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3159,13 +3261,13 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.4.11",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.11.tgz",
-      "integrity": "sha512-6CUvZwS0tCcVCrcvh2TpwTXxmAkuY6JGNPeKODYRLjHtUUhFLGS3dNkNdRvT/ttJyqimqnhFMTS2nqp4pDZ7oQ==",
+      "version": "4.4.14",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.14.tgz",
+      "integrity": "sha512-QgbuahIb2qxQeZQvNK0sw3aF3JH5zwH8j2lLp5DUasVXexGGMWULAR+7z0omPXFolCP/m5wN9M5lm9EGdSviTQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.6",
+        "@smithy/core": "^3.30.0",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -3174,13 +3276,13 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.6.8",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.8.tgz",
-      "integrity": "sha512-AFuLou893FesRZeQcKMh87P9x4PF2/ksPOYLLI1ctW7WJxm55SWInFSHAhaNRBPBmbgZyUcCCDKepBX+1jZBBw==",
+      "version": "5.6.11",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.11.tgz",
+      "integrity": "sha512-o0Zkj1nKqJAoq+a+BrkhU39tRftMNjLwpc/z06Frfl43wpbHrJMaSAVZE4vTqlxtVkNaGaT0bIDxOp7tkFTuQQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.6",
+        "@smithy/core": "^3.30.0",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -3189,13 +3291,13 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.9.8",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.8.tgz",
-      "integrity": "sha512-ArSSIN4t1wLutcIkHzaL6N11J7xpZK7W3T0pFz9cep9zIpEr9x5+lhJRcVUgObGI3OIMbnROq7w8bwzx+Nkf8A==",
+      "version": "4.9.11",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.11.tgz",
+      "integrity": "sha512-slbzbz8taEOzoXv/9y34YNBoE+ZHmddLykCgjDAjvMAsu2nM5s2Gzwa5OGF721tD8s+CKeFUBds5lSj9lcbuDg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.6",
+        "@smithy/core": "^3.30.0",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -3204,13 +3306,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.6.7",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.7.tgz",
-      "integrity": "sha512-32PmEsuZV9lz7SZk3gJcm+EfIAoIVu83AJyEzgALpwmSqLvuacdAu0fvCVNMbDbegyk1S0lHUDrMWIfR47Micw==",
+      "version": "5.6.10",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.10.tgz",
+      "integrity": "sha512-EXhWePm3SXJAX38npIy4TXL2Aex/OVgCClTjelN2QHw/U+8CQUH8C7AaxsVzQcYieYPseywn48s89DmvuGjiAg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.6",
+        "@smithy/core": "^3.30.0",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -5346,34 +5448,34 @@
     },
     "node_modules/geonicdb": {
       "version": "0.14.0",
-      "resolved": "git+ssh://git@github.com/geolonia/geonicdb.git#4f9f72cc6610137e7aa82cec6d62cbbb297b5f0f",
-      "integrity": "sha512-FmTWPwSSU+fM/8Zt9DHwhfJfP7WPKDlwKEAlrmwFaV9xvQJT3ykvD9/83l/NzAPDmsgauFUM+vc4vrBe2eVHtA==",
+      "resolved": "git+ssh://git@github.com/geolonia/geonicdb.git#f3d6acb4a930803b749491f0c869c9b034d52cfa",
+      "integrity": "sha512-Hj78Hxqp+k9wKV3dI0Nma+NvJUh/2SMJbMywzInuuSbQv5Eeoi047raN6Yrd/Ws4aq1PSdUHtMTy7y07ISLi8Q==",
       "dev": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@a2a-js/sdk": "^0.3.14",
-        "@aws-sdk/client-apigatewaymanagementapi": "^3.1090.0",
-        "@aws-sdk/client-cloudtrail": "^3.1090.0",
-        "@aws-sdk/client-dynamodb": "^3.1090.0",
-        "@aws-sdk/client-eventbridge": "^3.1090.0",
-        "@aws-sdk/client-kms": "^3.1090.0",
-        "@aws-sdk/client-secrets-manager": "^3.1090.0",
-        "@aws-sdk/client-sns": "^3.1090.0",
-        "@aws-sdk/client-sqs": "^3.1090.0",
-        "@aws-sdk/lib-dynamodb": "^3.1090.0",
+        "@aws-sdk/client-apigatewaymanagementapi": "^3.1095.0",
+        "@aws-sdk/client-cloudtrail": "^3.1095.0",
+        "@aws-sdk/client-dynamodb": "^3.1095.0",
+        "@aws-sdk/client-eventbridge": "^3.1095.0",
+        "@aws-sdk/client-kms": "^3.1095.0",
+        "@aws-sdk/client-secrets-manager": "^3.1095.0",
+        "@aws-sdk/client-sns": "^3.1095.0",
+        "@aws-sdk/client-sqs": "^3.1095.0",
+        "@aws-sdk/lib-dynamodb": "^3.1095.0",
         "@marcbachmann/cel-js": "^7.6.1",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/context-async-hooks": "^2.9.0",
-        "@opentelemetry/exporter-trace-otlp-http": "^0.220.0",
-        "@opentelemetry/instrumentation-aws-sdk": "^0.75.0",
-        "@opentelemetry/instrumentation-http": "^0.220.0",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.221.0",
+        "@opentelemetry/instrumentation-aws-sdk": "^0.76.0",
+        "@opentelemetry/instrumentation-http": "^0.221.0",
         "@opentelemetry/instrumentation-mongodb": "^0.73.0",
         "@opentelemetry/instrumentation-undici": "^0.30.0",
         "@opentelemetry/resources": "^2.9.0",
-        "@opentelemetry/sdk-node": "^0.220.0",
-        "@opentelemetry/sdk-trace-base": "^2.9.0",
-        "@opentelemetry/semantic-conventions": "^1.41.1",
+        "@opentelemetry/sdk-node": "^0.221.0",
+        "@opentelemetry/sdk-trace-base": "^2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.43.0",
         "express": "^5.2.1",
         "fresh": "^2.0.0",
         "js-yaml": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@types/node": "^22.13.0",
     "@vitest/coverage-v8": "^4.1.8",
     "eslint": "^10.8.0",
-    "geonicdb": "github:geolonia/geonicdb#4f9f72cc6610137e7aa82cec6d62cbbb297b5f0f",
+    "geonicdb": "github:geolonia/geonicdb#f3d6acb4a930803b749491f0c869c9b034d52cfa",
     "mongodb": "^7.1.0",
     "mongodb-memory-server": "^11.0.1",
     "prettier": "^3.4.2",

--- a/src/commands/admin/users.ts
+++ b/src/commands/admin/users.ts
@@ -1,8 +1,40 @@
 import type { Command } from "commander";
+import type { ClientResponse } from "../../types.js";
 import { withErrorHandler, createClient, getFormat, outputResponse, parseNonNegativeInt, fetchPaginatedList } from "../../helpers.js";
 import { parseJsonInput } from "../../input.js";
-import { printSuccess } from "../../output.js";
+import { printSuccess, printTemporaryPasswordBox } from "../../output.js";
 import { addExamples } from "../help.js";
+
+/** Response shape carrying a server-issued temporary password (geonicdb#1532). */
+interface TemporaryPasswordResponse {
+  temporaryPassword?: unknown;
+  expiresAt?: unknown;
+}
+
+/**
+ * Emit a temporary-password response consistently for both invite-create and
+ * reset-password. The full response goes to stdout (so scripts can capture the
+ * value, matching the API-key command), and the password is highlighted on
+ * stderr. Fails loudly *before* printing success if the server did not return a
+ * usable temporary password, so a "success" line is never followed by a crash.
+ */
+function emitTemporaryPassword(
+  response: ClientResponse<TemporaryPasswordResponse>,
+  format: ReturnType<typeof getFormat>,
+  successMessage: string,
+): void {
+  outputResponse(response, format);
+  const temporaryPassword = response.data?.temporaryPassword;
+  if (typeof temporaryPassword !== "string") {
+    throw new Error(
+      "Server did not return a temporary password; the account may not be in a forced-reset state.",
+    );
+  }
+  const expiresAt =
+    typeof response.data?.expiresAt === "string" ? response.data.expiresAt : undefined;
+  printSuccess(successMessage);
+  printTemporaryPasswordBox(temporaryPassword, expiresAt);
+}
 
 export function registerUsersCommand(parent: Command): void {
   const users = parent
@@ -77,6 +109,12 @@ export function registerUsersCommand(parent: Command): void {
     .summary("Create a new user")
     .description(
       "Create a new user\n\n" +
+        "By default the password from the JSON 'password' field is set directly and\n" +
+        "the account is active immediately.\n\n" +
+        "Use --force-reset to instead issue a server-generated one-time temporary\n" +
+        "password: the user is forced to set a new password on their first login\n" +
+        "(single-shot). In that mode do NOT provide a 'password' field (the server\n" +
+        "generates it); the temporary password is displayed once.\n\n" +
         "JSON payload example:\n" +
         "  {\n" +
         '    "email": "user@example.com",\n' +
@@ -87,27 +125,57 @@ export function registerUsersCommand(parent: Command): void {
         "Roles: super_admin, tenant_admin, user\n" +
         "primaryTenantId is required for tenant_admin and user roles.",
     )
+    .option(
+      "--force-reset",
+      "Issue a server-generated temporary password and force a change on first login (omit 'password')",
+    )
     .action(
       withErrorHandler(async (json: unknown, _opts: unknown, cmd: Command) => {
         const body = await parseJsonInput(json as string | undefined);
         const client = createClient(cmd);
         const format = getFormat(cmd);
-        const response = await client.rawRequest("POST", "/admin/users", {
-          body,
-        });
-        outputResponse(response, format);
-        printSuccess("User created.");
+        const forceReset = Boolean(cmd.opts().forceReset);
+
+        if (!forceReset) {
+          // 従来動作 (非破壊): JSON の password を直接設定し、強制変更なしで有効化する。
+          const response = await client.rawRequest("POST", "/admin/users", { body });
+          outputResponse(response, format);
+          printSuccess("User created.");
+          return;
+        }
+
+        // 招待モード (--force-reset): サーバーが一時パスワードを生成する。
+        // JSON ペイロードはオブジェクトである必要がある (配列/文字列を spread すると
+        // {"0": ...} のような不正なボディになるため、送信前に弾く)。
+        if (typeof body !== "object" || body === null || Array.isArray(body)) {
+          throw new Error("JSON payload must be an object.");
+        }
+        // password の同梱は禁止 (サーバーも 400 を返すが、送信前に fail fast する)。
+        const createBody = { ...(body as Record<string, unknown>) };
+        if (createBody.password !== undefined) {
+          throw new Error(
+            "--force-reset issues a server-generated temporary password; do not include a 'password' field.",
+          );
+        }
+        createBody.passwordResetRequired = true;
+
+        const response = await client.rawRequest<TemporaryPasswordResponse>(
+          "POST",
+          "/admin/users",
+          { body: createBody },
+        );
+        emitTemporaryPassword(response, format, "User created (forced password reset).");
       }),
     );
 
   addExamples(create, [
     {
-      description: "Create a tenant admin",
+      description: "Create a tenant admin with a password",
       command: `geonic admin users create '{"email":"admin@example.com","password":"SecurePass12345!","role":"tenant_admin","primaryTenantId":"<tenant-id>"}'`,
     },
     {
-      description: "Create a user for a tenant",
-      command: `geonic admin users create '{"email":"user@example.com","password":"SecurePass12345!","role":"user","primaryTenantId":"<tenant-id>"}'`,
+      description: "Invite a user (server issues a one-time temporary password)",
+      command: `geonic admin users create --force-reset '{"email":"user@example.com","role":"user","primaryTenantId":"<tenant-id>"}'`,
     },
     {
       description: "Create from a JSON file",
@@ -249,6 +317,42 @@ export function registerUsersCommand(parent: Command): void {
     {
       description: "Unlock a locked user account",
       command: "geonic admin users unlock <user-id>",
+    },
+  ]);
+
+  // users reset-password
+  const resetPassword = users
+    .command("reset-password <id>")
+    .summary("Issue a one-time temporary password for a user")
+    .description(
+      "Issue a one-time temporary password for an existing user and force a\n" +
+        "password change on their next login (single-shot, geonicdb#1532).\n\n" +
+        "The temporary password is displayed once and cannot be retrieved again.\n" +
+        "It expires after a fixed validity window (7 days by default). Existing\n" +
+        "password-derived sessions are revoked; API keys and OAuth clients are kept.\n\n" +
+        "Permissions: super_admin can reset any user; tenant_admin can reset users\n" +
+        "in their own tenant.",
+    )
+    .action(
+      withErrorHandler(async (id: unknown, _opts: unknown, cmd: Command) => {
+        const client = createClient(cmd);
+        const format = getFormat(cmd);
+        const response = await client.rawRequest<TemporaryPasswordResponse>(
+          "POST",
+          `/admin/users/${encodeURIComponent(String(id))}/reset-password`,
+        );
+        emitTemporaryPassword(response, format, "Temporary password issued.");
+      }),
+    );
+
+  addExamples(resetPassword, [
+    {
+      description: "Issue a temporary password for a user",
+      command: "geonic admin users reset-password <user-id>",
+    },
+    {
+      description: "Show the response in JSON format",
+      command: "geonic admin users reset-password <user-id> --format json",
     },
   ]);
 }

--- a/src/output.ts
+++ b/src/output.ts
@@ -47,6 +47,38 @@ export function printApiKeyBox(key: string): void {
   console.error(chalk.yellow("⚠ この API キー値を安全に保存してください。二度と表示されません。"));
 }
 
+/**
+ * Print an admin-issued temporary password in a highlighted box.
+ *
+ * The decorative box is written to stderr (like {@link printApiKeyBox}) so it
+ * does not corrupt piped stdout (e.g. a `--format json` response). The password
+ * value itself is also emitted to stdout by the command's normal response
+ * output (so scripts can capture it, matching the API-key command); the box is
+ * a human-facing convenience, accompanied by a reminder that the user must set
+ * a new password on their next login.
+ */
+export function printTemporaryPasswordBox(password: string, expiresAt?: string): void {
+  const border = "─".repeat(password.length + 4);
+  console.error("");
+  console.error(chalk.green(`  ┌${border}┐`));
+  console.error(chalk.green(`  │  ${chalk.bold(password)}  │`));
+  console.error(chalk.green(`  └${border}┘`));
+  console.error("");
+  if (expiresAt) {
+    console.error(chalk.dim(`  有効期限: ${expiresAt}`));
+  }
+  console.error(
+    chalk.yellow(
+      "⚠ この一時パスワードを安全な経路で本人に伝えてください。二度と表示されません。",
+    ),
+  );
+  console.error(
+    chalk.yellow(
+      "  本人は次回ログイン時に新しいパスワードの設定を求められます (単発型の初回強制変更)。",
+    ),
+  );
+}
+
 export function printCount(count: number): void {
   console.log(chalk.dim(`Count: ${count}`));
 }

--- a/tests/admin-users.test.ts
+++ b/tests/admin-users.test.ts
@@ -44,6 +44,7 @@ vi.mock("../src/output.js", () => ({
   printWarning: vi.fn(),
   printOutput: vi.fn(),
   printCount: vi.fn(),
+  printTemporaryPasswordBox: vi.fn(),
 }));
 
 vi.mock("../src/commands/help.js", () => ({
@@ -54,7 +55,7 @@ vi.mock("../src/commands/help.js", () => ({
 import type { Command } from "commander";
 import { createClient, getFormat, outputResponse } from "../src/helpers.js";
 import { parseJsonInput } from "../src/input.js";
-import { printSuccess } from "../src/output.js";
+import { printSuccess, printTemporaryPasswordBox } from "../src/output.js";
 import { addExamples } from "../src/commands/help.js";
 import { registerUsersCommand } from "../src/commands/admin/users.js";
 
@@ -111,17 +112,93 @@ describe("admin users commands", () => {
     });
   });
 
-  describe("users create", () => {
-    it("posts body and prints success", async () => {
-      const body = { email: "user@example.com" };
+  const resetPayload = {
+    userId: "u2",
+    temporaryPassword: "Tmp-Passw0rd-xyz",
+    expiresAt: "2026-08-04T00:00:00.000Z",
+    passwordResetRequired: true,
+    message: "Temporary password issued. The user must set a new password on next login.",
+  };
+
+  describe("users create (default)", () => {
+    it("posts body as-is and prints success (non-breaking)", async () => {
+      const body = { email: "user@example.com", password: "SecurePass12345!" };
       vi.mocked(parseJsonInput).mockResolvedValue(body);
       client.rawRequest.mockResolvedValue(mockResponse({ id: "u2" }, 201));
       const program = makeProgram();
-      await runCommand(program, ["admin", "users", "create", '{"email":"user@example.com"}']);
+      await runCommand(program, ["admin", "users", "create", '{"email":"user@example.com","password":"SecurePass12345!"}']);
+      expect(client.rawRequest).toHaveBeenCalledTimes(1);
       expect(client.rawRequest).toHaveBeenCalledWith("POST", "/admin/users", { body });
       expect(outputResponse).toHaveBeenCalled();
       expect(printSuccess).toHaveBeenCalledWith("User created.");
+      expect(printTemporaryPasswordBox).not.toHaveBeenCalled();
     });
+  });
+
+  describe("users create --force-reset (invite)", () => {
+    it("injects passwordResetRequired and shows the temporary password", async () => {
+      vi.mocked(parseJsonInput).mockResolvedValue({ email: "user@example.com", role: "user" });
+      client.rawRequest.mockResolvedValue(mockResponse({ id: "u2", ...resetPayload }, 201));
+      const program = makeProgram();
+      await runCommand(program, [
+        "admin", "users", "create", "--force-reset",
+        '{"email":"user@example.com","role":"user"}',
+      ]);
+
+      // Single POST to /admin/users with passwordResetRequired: true and no password.
+      expect(client.rawRequest).toHaveBeenCalledTimes(1);
+      const [method, path, opts] = client.rawRequest.mock.calls[0];
+      expect(method).toBe("POST");
+      expect(path).toBe("/admin/users");
+      const createBody = (opts as { body: Record<string, unknown> }).body;
+      expect(createBody.passwordResetRequired).toBe(true);
+      expect(createBody.password).toBeUndefined();
+
+      expect(printSuccess).toHaveBeenCalledWith("User created (forced password reset).");
+      expect(printTemporaryPasswordBox).toHaveBeenCalledWith(
+        resetPayload.temporaryPassword,
+        resetPayload.expiresAt,
+      );
+    });
+
+    it("rejects a JSON password field before sending the request", async () => {
+      vi.mocked(parseJsonInput).mockResolvedValue({ email: "user@example.com", password: "ChosenPass12345!" });
+      const program = makeProgram();
+      await expect(
+        runCommand(program, [
+          "admin", "users", "create", "--force-reset",
+          '{"email":"user@example.com","password":"ChosenPass12345!"}',
+        ]),
+      ).rejects.toThrow(/do not include a 'password' field/);
+      // No request must be sent when the input is contradictory.
+      expect(client.rawRequest).not.toHaveBeenCalled();
+    });
+
+    it("rejects a non-object JSON payload before sending the request", async () => {
+      vi.mocked(parseJsonInput).mockResolvedValue(["user@example.com"]);
+      const program = makeProgram();
+      await expect(
+        runCommand(program, ["admin", "users", "create", "--force-reset", '["user@example.com"]']),
+      ).rejects.toThrow(/must be an object/);
+      expect(client.rawRequest).not.toHaveBeenCalled();
+    });
+
+    it("errors (without printing success) when the server returns no temporary password", async () => {
+      vi.mocked(parseJsonInput).mockResolvedValue({ email: "user@example.com", role: "user" });
+      client.rawRequest.mockResolvedValue(mockResponse({ id: "u2" }, 201)); // no temporaryPassword
+      const program = makeProgram();
+      await expect(
+        runCommand(program, [
+          "admin", "users", "create", "--force-reset",
+          '{"email":"user@example.com","role":"user"}',
+        ]),
+      ).rejects.toThrow(/did not return a temporary password/);
+      expect(printSuccess).not.toHaveBeenCalled();
+      expect(printTemporaryPasswordBox).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("users create (metadata)", () => {
 
     // #118: server schema accepts only `primaryTenantId`. Help and examples must reflect that.
     it("references primaryTenantId (not legacy tenantId) in description", () => {
@@ -208,6 +285,31 @@ describe("admin users commands", () => {
       await runCommand(program, ["admin", "users", "unlock", "u1"]);
       expect(client.rawRequest).toHaveBeenCalledWith("POST", "/admin/users/u1/unlock");
       expect(printSuccess).toHaveBeenCalledWith("User unlocked.");
+    });
+  });
+
+  describe("users reset-password", () => {
+    it("posts reset-password and shows the temporary password", async () => {
+      client.rawRequest.mockResolvedValue(mockResponse(resetPayload));
+      const program = makeProgram();
+      await runCommand(program, ["admin", "users", "reset-password", "u2"]);
+      expect(client.rawRequest).toHaveBeenCalledWith("POST", "/admin/users/u2/reset-password");
+      expect(outputResponse).toHaveBeenCalled();
+      expect(printSuccess).toHaveBeenCalledWith("Temporary password issued.");
+      expect(printTemporaryPasswordBox).toHaveBeenCalledWith(
+        resetPayload.temporaryPassword,
+        resetPayload.expiresAt,
+      );
+    });
+
+    it("URL-encodes the user id", async () => {
+      client.rawRequest.mockResolvedValue(mockResponse(resetPayload));
+      const program = makeProgram();
+      await runCommand(program, ["admin", "users", "reset-password", "urn:user:1"]);
+      expect(client.rawRequest).toHaveBeenCalledWith(
+        "POST",
+        "/admin/users/urn%3Auser%3A1/reset-password",
+      );
     });
   });
 });

--- a/tests/e2e/features/users.feature
+++ b/tests/e2e/features/users.feature
@@ -55,3 +55,26 @@ Feature: Admin user management
     When I run `geonic admin users unlock $ID` replacing ID
     Then the exit code should be 0
     And the output should contain "User unlocked."
+
+  Scenario: Create a user with a forced password reset (invite, geonicdb#1532)
+    Given I am logged in as super admin
+    When I run `geonic admin users create --force-reset '{"email":"testuser06@example.com","role":"super_admin"}'`
+    Then the exit code should be 0
+    And the output should contain "User created (forced password reset)."
+    And stdout should contain "temporaryPassword"
+
+  Scenario: Reject --force-reset with a password field
+    Given I am logged in as super admin
+    When I run `geonic admin users create --force-reset '{"email":"testuser07@example.com","password":"TestPassword123!","role":"super_admin"}'`
+    Then the exit code should be 1
+    And the output should contain "do not include a 'password' field"
+
+  Scenario: Reset a user's password
+    Given I am logged in as super admin
+    And I run `geonic admin users create '{"email":"testuser08@example.com","password":"TestPassword123!","role":"super_admin"}'`
+    And I run `geonic admin users list --format json`
+    And I save the ID from the JSON output where "email" is "testuser08@example.com"
+    When I run `geonic admin users reset-password $ID` replacing ID
+    Then the exit code should be 0
+    And the output should contain "Temporary password issued."
+    And stdout should contain "temporaryPassword"


### PR DESCRIPTION
## 概要

本体 geonicdb の招待型・単発型強制パスワード変更 (geonicdb#1532) に CLI を追随させる (closes #162)。管理者が一時パスワードを発行する 2 経路をサポート:

1. **既存ユーザーのリセット** — `geonic admin users reset-password <id>`（新設）。`POST /admin/users/{id}/reset-password` を叩き、サーバー生成の一時パスワードを発行して初回ログインでの強制変更を要求する。
2. **作成時発行（招待）** — `geonic admin users create --force-reset`（フラグ追加）。本体の招待型 `POST /admin/users` + `passwordResetRequired: true` を使い、サーバー生成の一時パスワードで作成する。

ユーザー側の初回ログイン（一時PW→新パスワード設定）は既にマージ済み (#164 / #163)。本 PR は**管理者の発行側**を担う。

## 変更点

- `src/commands/admin/users.ts`:
  - `reset-password <id>` コマンド新設（`encodeURIComponent`、権限は super_admin=全ユーザー / tenant_admin=自テナント）
  - `create` に `--force-reset` フラグ追加。`passwordResetRequired: true` を注入し、`password` 同梱は**送信前に拒否**（サーバーも 400、二重防御）。非オブジェクト payload も送信前に拒否
  - 一時PW発行レスポンスの共通ハンドラ `emitTemporaryPassword()`：応答を stdout（スクリプト連携用、api-key コマンドと同一方針）、一時PW を stderr のボックスで表示。**一時PW が欠落していれば成功表示の前に fail-loud**（success 直後のクラッシュを防ぐ）
- `src/output.ts`: `printTemporaryPasswordBox()`（stderr のハイライトボックス、有効期限併記）
- **既定の `create`（`password` 直指定）は完全に非破壊**
- `package.json`: `geonicdb` devDep を本体マージコミット (f3d6acb4, 招待 endpoint 入り) へ bump
- README / CHANGELOG / E2E（`create --force-reset` / `--force-reset`+password のエラー / `reset-password`）追加

## テスト

- `npm run lint` / `npm run typecheck` — 0 errors
- `npx vitest run` — 865 passed
- `npm run test:e2e` — 152 scenarios passed（本体を実起動し招待 endpoint に対して検証）

## レビュー

- `/code-review`（自己）— 指摘なし
- `/cursor-review`（gpt-5.3-codex-xhigh + gemini-3.1-pro）— Critical なし。指摘対応済み: 一時PW欠落時の fail-loud ガード、非オブジェクト payload ガード、`printTemporaryPasswordBox` の JSDoc 正確化（値は stdout にも出る＝スクリプト連携用、box は stderr で JSON を壊さないため）。stdout への一時PW出力は api-key と同一の意図的設計として維持（gemini も意図的と判断）

## 関連
- 本体: geonicdb#1567（マージ済み）/ geonicdb#1532（closed）
