### PR TITLE
release: v0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## [Unreleased]
 
+## [0.22.0] - 2026-07-28
+
 ### 2026-07-28
 - **Feat**: 管理者による一時パスワード発行に対応 (closes #162, geonicdb#1532)。`admin users reset-password <id>` を新設し、既存ユーザーに一時パスワードを発行して初回ログインでの強制変更 (単発型) を要求する (応答の `temporaryPassword`/`expiresAt` を stderr のボックスで一度だけ表示)。あわせて `admin users create` に `--force-reset` フラグを追加 — 本体の招待型 (`POST /admin/users` + `passwordResetRequired: true`) を使い、サーバー生成の一時パスワードで作成する (この経路では `password` を指定できない。指定時は送信前にエラー)。既定の `create`（`password` 直指定）は従来どおり非破壊。既存ユーザーへの発行 (reset-password) と作成時発行 (create --force-reset) の 2 経路。README 更新。本体は geonicdb#1567 でマージ済み。(#166)
 
@@ -333,7 +335,8 @@
 ### 2026-02-26
 - **Docs**: README にインストール手順・使い方・コマンドリファレンスを追加 (#1)
 
-[Unreleased]: https://github.com/geolonia/geonicdb-cli/compare/v0.21.0...HEAD
+[Unreleased]: https://github.com/geolonia/geonicdb-cli/compare/v0.22.0...HEAD
+[0.22.0]: https://github.com/geolonia/geonicdb-cli/compare/v0.21.0...v0.22.0
 [0.21.0]: https://github.com/geolonia/geonicdb-cli/compare/v0.20.0...v0.21.0
 [0.20.0]: https://github.com/geolonia/geonicdb-cli/compare/v0.19.0...v0.20.0
 [0.19.0]: https://github.com/geolonia/geonicdb-cli/compare/v0.18.1...v0.19.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolonia/geonicdb-cli",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolonia/geonicdb-cli",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolonia/geonicdb-cli",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "A CLI client for the GeonicDB",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## v0.22.0

管理者による一時パスワード発行 (#166, closes #162) をリリース。

- `admin users reset-password <id>` 新設
- `admin users create --force-reset` 追加
- 既定 create は非破壊

CHANGELOG の [Unreleased] 2026-07-28 エントリを [0.22.0] へ確定。version 0.21.0 → 0.22.0。マージ後に v0.22.0 タグを push して npm 自動公開。

互換性: CLI はバージョン独立。新コマンドは本体の招待/reset-password エンドポイント (geonicdb#1533/#1567) を要求し、未対応サーバでは 404/400 で明示的に失敗 (silently fail なし)。既存コマンド (既定 create / login 等) は挙動不変。