### PR TITLE
fix(client): ld+json エンティティ書き込みで @context を自動付与 (closes #168)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ## [Unreleased]
 
 ### 2026-07-29
-- **Fix**: `application/ld+json` のエンティティ書き込みで JSON-LD `@context` を自動付与するようにした (closes #168, 本体 geonicdb#1583 対応)。CLI は全リクエストを `application/ld+json` で送るため、本体が `@context` 必須化 (geonicdb#1583) された後は `@context` 無しのペイロードでの `entities create`/`entities update`/`entities attrs` 等が `400 BadRequestData` になる。エンティティ書き込みボディに `@context` が無ければ NGSI-LD core context (`https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld`) を注入して後方互換を保つ。利用者が指定した `@context` は非上書き。注入は本体 geonicdb#1583 が実際に `@context` を必須化した範囲 (`/ngsi-ld/v1/entities` のエンティティ書き込み) に合わせ、オブジェクトボディに限定する。本体が `@context` を要求しない経路 — バッチ (`entityOperations`、配列) / temporal / subscriptions / registrations / admin / auth 等 — には付与しない (これらへの必須化は本体側 geonicdb#1599 で追跡中。本体が拡張された時点で CLI も追従する)。(#PR)
+- **Fix**: `application/ld+json` のエンティティ書き込みで JSON-LD `@context` を自動付与するようにした (closes #168, 本体 geonicdb#1583 対応)。CLI は全リクエストを `application/ld+json` で送るため、本体が `@context` 必須化 (geonicdb#1583) された後は `@context` 無しのペイロードでの `entities create`/`entities update`/`entities attrs` 等が `400 BadRequestData` になる。エンティティ書き込みボディに `@context` が無ければ NGSI-LD core context (`https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld`) を注入して後方互換を保つ。利用者が指定した `@context` は非上書き。注入は本体 geonicdb#1583 が実際に `@context` を必須化した範囲 (`/ngsi-ld/v1/entities` のエンティティ書き込み) に合わせ、オブジェクトボディに限定する。本体が `@context` を要求しない経路 — バッチ (`entityOperations`、配列) / temporal / subscriptions / registrations / admin / auth 等 — には付与しない (これらへの必須化は本体側 geonicdb#1599 で追跡中。本体が拡張された時点で CLI も追従する)。(#169)
 
 ## [0.22.0] - 2026-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## [Unreleased]
 
+### 2026-07-29
+- **Fix**: `application/ld+json` のエンティティ書き込みで JSON-LD `@context` を自動付与するようにした (closes #168, 本体 geonicdb#1583 対応)。CLI は全リクエストを `application/ld+json` で送るため、本体が `@context` 必須化 (geonicdb#1583) された後は `@context` 無しのペイロードでの `entities create`/`entities update`/`entities attrs` 等が `400 BadRequestData` になる。エンティティ書き込みボディに `@context` が無ければ NGSI-LD core context (`https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld`) を注入して後方互換を保つ。利用者が指定した `@context` は非上書き。注入は本体 geonicdb#1583 が実際に `@context` を必須化した範囲 (`/ngsi-ld/v1/entities` のエンティティ書き込み) に合わせ、オブジェクトボディに限定する。本体が `@context` を要求しない経路 — バッチ (`entityOperations`、配列) / temporal / subscriptions / registrations / admin / auth 等 — には付与しない (これらへの必須化は本体側 geonicdb#1599 で追跡中。本体が拡張された時点で CLI も追従する)。(#PR)
+
 ## [0.22.0] - 2026-07-28
 
 ### 2026-07-28

--- a/README.md
+++ b/README.md
@@ -744,9 +744,14 @@ curl \
   -X POST \
   -H 'Content-Type: application/ld+json' \
   -H 'Accept: application/ld+json' \
-  -d '{"id":"Room1","type":"Room"}' \
+  -d '{"id":"Room1","type":"Room","@context":"https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"}' \
   'http://localhost:3000/ngsi-ld/v1/entities'
 ```
+
+> Entity writes are sent as `application/ld+json`, which requires an inline JSON-LD
+> `@context`. When your payload omits `@context`, the CLI injects the NGSI-LD core
+> context automatically (a `@context` you provide is preserved). Batch
+> (`entityOperations`) and other resources are not affected.
 
 ## Configuration
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -2,6 +2,13 @@ import type { ClientOptions, ClientResponse, NgsiError } from "./types.js";
 import { clientCredentialsGrant } from "./oauth.js";
 import { getTokenStatus } from "./token.js";
 
+/**
+ * NGSI-LD core @context. Injected into `application/ld+json` entity-write bodies
+ * that omit `@context` so writes stay spec-compliant (#168): the server requires
+ * an inline `@context` for `application/ld+json` (ETSI GS CIM 009 clause 6.3.5).
+ */
+const NGSI_LD_CORE_CONTEXT = "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld";
+
 export class DryRunSignal extends Error {
   constructor() {
     super("dry-run");
@@ -262,6 +269,36 @@ export class GdbClient {
     return false;
   }
 
+  /**
+   * #168: NGSI-LD entity writes require an inline JSON-LD `@context` under
+   * `application/ld+json` (server geolonia/geonicdb#1583). The CLI always sends
+   * `application/ld+json`, so inject the core context when an entity-write object
+   * body omits it; otherwise the server returns 400 BadRequestData. A
+   * caller-supplied `@context` is preserved (never overwritten). Arrays (batch
+   * bodies) and non-object bodies are left untouched.
+   *
+   * Scoped to the `/entities` endpoints ONLY, mirroring the exact range where the
+   * server enforces `@context` (geonicdb#1583: create/replace/append/patch-attrs).
+   * Other resources must not receive an injected `@context`:
+   *   - admin/auth/... use strict server schemas that reject the unexpected key.
+   *   - batch (`/entityOperations`, array bodies), temporal, subscriptions and
+   *     registrations are not yet `@context`-required server-side (tracked in
+   *     geonicdb#1599); extend this scope when the server does.
+   */
+  private maybeInjectCoreContext(resourcePath: string, body: unknown): unknown {
+    const isEntityWrite = resourcePath.startsWith(`${this.getBasePath()}/entities`);
+    if (
+      !isEntityWrite ||
+      body === null ||
+      typeof body !== "object" ||
+      Array.isArray(body) ||
+      "@context" in (body as Record<string, unknown>)
+    ) {
+      return body;
+    }
+    return { ...(body as Record<string, unknown>), "@context": NGSI_LD_CORE_CONTEXT };
+  }
+
   private async executeRequest<T>(
     method: string,
     path: string,
@@ -274,7 +311,10 @@ export class GdbClient {
   ): Promise<ClientResponse<T>> {
     const url = this.buildUrl(`${this.getBasePath()}${path}`, options?.params);
     const headers = this.buildHeaders(options?.headers);
-    const body = options?.body ? JSON.stringify(options.body) : undefined;
+    const injectedBody = options?.body
+      ? this.maybeInjectCoreContext(`${this.getBasePath()}${path}`, options.body)
+      : undefined;
+    const body = injectedBody ? JSON.stringify(injectedBody) : undefined;
 
     this.logRequest(method, url, headers, body);
     this.handleDryRun(method, url, headers, body);
@@ -325,7 +365,13 @@ export class GdbClient {
     if (options?.skipTenantHeader) {
       delete headers["NGSILD-Tenant"];
     }
-    const body = options?.body ? JSON.stringify(options.body) : undefined;
+    // executeRawRequest takes absolute paths (auth/admin/health). The scope check
+    // in maybeInjectCoreContext leaves non-/entities paths untouched, so this is a
+    // no-op for those; kept for consistency in case an entities path is ever routed here.
+    const injectedBody = options?.body
+      ? this.maybeInjectCoreContext(path, options.body)
+      : undefined;
+    const body = injectedBody ? JSON.stringify(injectedBody) : undefined;
 
     this.logRequest(method, url, headers, body);
     this.handleDryRun(method, url, headers, body);

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -88,7 +88,7 @@ describe("GdbClient", () => {
     await expect(client.get("/entities/missing")).rejects.toThrow("Entity not found");
   });
 
-  it("sends POST with JSON body", async () => {
+  it("sends POST with JSON body (injects core @context for entity writes, #168)", async () => {
     const client = new GdbClient({ baseUrl: "http://localhost:3000" });
     const entity = { id: "Room:001", type: "Room" };
 
@@ -101,13 +101,71 @@ describe("GdbClient", () => {
 
     await client.post("/entities", entity);
 
+    const sentBody = JSON.parse(
+      (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body as string,
+    );
+    // #168: entity writes get the core @context injected when the body omits it.
+    expect(sentBody).toEqual({
+      ...entity,
+      "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
+    });
     expect(fetch).toHaveBeenCalledWith(
       expect.any(String),
-      expect.objectContaining({
-        method: "POST",
-        body: JSON.stringify(entity),
-      }),
+      expect.objectContaining({ method: "POST" }),
     );
+  });
+
+  it("preserves a caller-supplied @context on entity writes (#168)", async () => {
+    const client = new GdbClient({ baseUrl: "http://localhost:3000" });
+    const custom = "https://example.com/my-context.jsonld";
+    const entity = { id: "Room:001", type: "Room", "@context": custom };
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({}), { status: 201 }),
+    );
+
+    await client.put("/entities/Room:001", entity);
+
+    const sentBody = JSON.parse(
+      (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body as string,
+    );
+    expect(sentBody["@context"]).toBe(custom);
+  });
+
+  // Batch is excluded to match the server's current #1583 scope (entity endpoints
+  // only); server-side batch @context enforcement is tracked in geonicdb#1599.
+  it("does NOT inject @context into batch (array) bodies (#168)", async () => {
+    const client = new GdbClient({ baseUrl: "http://localhost:3000" });
+    const batch = [{ id: "Room:001", type: "Room" }];
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({}), { status: 201 }),
+    );
+
+    await client.post("/entityOperations/upsert", batch);
+
+    const sentBody = JSON.parse(
+      (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body as string,
+    );
+    expect(sentBody).toEqual(batch);
+    expect(Array.isArray(sentBody)).toBe(true);
+  });
+
+  it("does NOT inject @context into non-entity endpoints (#168)", async () => {
+    const client = new GdbClient({ baseUrl: "http://localhost:3000" });
+    const body = { description: "sub", type: "Subscription" };
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({}), { status: 201 }),
+    );
+
+    await client.post("/subscriptions", body);
+
+    const sentBody = JSON.parse(
+      (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body as string,
+    );
+    expect("@context" in sentBody).toBe(false);
+    expect(sentBody).toEqual(body);
   });
 
   it("appends query params to URL", async () => {
@@ -926,7 +984,11 @@ describe("GdbClient", () => {
       expect(fetchSpy).not.toHaveBeenCalled();
       const output = logSpy.mock.calls[0][0] as string;
       expect(output).toContain("-X POST");
-      expect(output).toContain(`-d '${JSON.stringify(entity)}'`);
+      // #168: entity-write bodies carry the injected core @context; the dry-run
+      // curl must mirror the actual request body.
+      expect(output).toContain(
+        `-d '${JSON.stringify({ ...entity, "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld" })}'`,
+      );
       logSpy.mockRestore();
     });
 


### PR DESCRIPTION
## 概要

本体 GeonicDB (geolonia/geonicdb#1583) で `Content-Type: application/ld+json` のエンティティ書き込みが JSON-LD `@context` をボディに必須化された。CLI は全リクエストを `application/ld+json` で送るため、`@context` 無しのペイロードでの `entities create` / `entities update` / `entities attrs` が本体デプロイ後に `400 BadRequestData` になる（後方互換の破壊）。

本 PR は CLI 側でエンティティ書き込みボディに `@context` が無ければ NGSI-LD core context を自動注入して後方互換を保つ（方針 A・課長承認済み）。

## 変更

- `src/client.ts`: `maybeInjectCoreContext(resourcePath, body)` を追加。両送信経路 (`executeRequest` / `executeRawRequest`) のボディ直列化前に適用。
  - **スコープは本体 #1583 の実効範囲 (`/ngsi-ld/v1/entities`) に一致**。オブジェクトボディで `@context` 欠落時のみ注入。
  - 利用者指定の `@context` は非上書き。配列（バッチ）・非エンティティ経路 (subscriptions/registrations/admin/auth/temporal) は対象外。
- `tests/client.test.ts`: 注入/保持/バッチ非注入/非エンティティ非注入を検証（既存2件は注入後の挙動に更新、新規3件追加）。
- `README.md` / `CHANGELOG.md` 更新。

## スコープの根拠

本体マージ済み main を確認したところ、`@context` ガード (`requireLdJsonContext`) は entities.controller の5経路 (create/replace/append/patch-attrs) のみで、temporal/batch コントローラには無い。したがって CLI も同じ範囲に限定するのが正。batch/temporal への必須化は本体 geonicdb#1599 で追跡中で、本体が拡張された時点で CLI も追従する。

## テスト

- `npm run lint` 0 errors / `npm run typecheck` OK / `npx vitest run` **868 passed** (40 files)
- 実 `--dry-run` で確認: `@context` 無し→core 注入 / 有り→保持 / batch(配列)→非注入

## リリース順序

CLI はバージョン独立。本体 #1583 (PR geolonia/geonicdb#1596, マージ済み) の**デプロイ前**に本 CLI をリリースすること。

## レビュー

Cursor 2系統 (gpt-5.3-codex-xhigh / gemini-3.1-pro) レビュー済み。temporal/batch 未対応の指摘は「本体がそこで @context を要求しないため意図的に範囲外（#1599 追跡）」として棄却（マージ済み main の grep で実証）。README 不一致は修正。

Closes #168