### PR TITLE
release: v0.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## [Unreleased]
 
+## [0.22.1] - 2026-07-30
+
 ### 2026-07-29
 - **Fix**: `application/ld+json` のエンティティ書き込みで JSON-LD `@context` を自動付与するようにした (closes #168, 本体 geonicdb#1583 対応)。CLI は全リクエストを `application/ld+json` で送るため、本体が `@context` 必須化 (geonicdb#1583) された後は `@context` 無しのペイロードでの `entities create`/`entities update`/`entities attrs` 等が `400 BadRequestData` になる。エンティティ書き込みボディに `@context` が無ければ NGSI-LD core context (`https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld`) を注入して後方互換を保つ。利用者が指定した `@context` は非上書き。注入は本体 geonicdb#1583 が実際に `@context` を必須化した範囲 (`/ngsi-ld/v1/entities` のエンティティ書き込み) に合わせ、オブジェクトボディに限定する。本体が `@context` を要求しない経路 — バッチ (`entityOperations`、配列) / temporal / subscriptions / registrations / admin / auth 等 — には付与しない (これらへの必須化は本体側 geonicdb#1599 で追跡中。本体が拡張された時点で CLI も追従する)。(#169)
 
@@ -338,7 +340,8 @@
 ### 2026-02-26
 - **Docs**: README にインストール手順・使い方・コマンドリファレンスを追加 (#1)
 
-[Unreleased]: https://github.com/geolonia/geonicdb-cli/compare/v0.22.0...HEAD
+[Unreleased]: https://github.com/geolonia/geonicdb-cli/compare/v0.22.1...HEAD
+[0.22.1]: https://github.com/geolonia/geonicdb-cli/compare/v0.22.0...v0.22.1
 [0.22.0]: https://github.com/geolonia/geonicdb-cli/compare/v0.21.0...v0.22.0
 [0.21.0]: https://github.com/geolonia/geonicdb-cli/compare/v0.20.0...v0.21.0
 [0.20.0]: https://github.com/geolonia/geonicdb-cli/compare/v0.19.0...v0.20.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolonia/geonicdb-cli",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolonia/geonicdb-cli",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolonia/geonicdb-cli",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "A CLI client for the GeonicDB",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## リリース v0.22.1

`[Unreleased]` を確定してパッチリリースする。

### 内容
- **Fix**: `application/ld+json` のエンティティ書き込みで JSON-LD `@context` を自動付与 (#169, closes #168, 本体 geonicdb#1583 対応)。本体の `@context` 必須化に対する後方互換対応。

### バージョン
- 0.22.0 → **0.22.1**（Fix のみのためパッチ）
- `package.json` / `package-lock.json` を更新、CHANGELOG を確定、compare リンク追加

### リリース順序
- 本 PR マージ後に `v0.22.1` タグを push → `publish.yml` が CI 通過を確認して npm 公開。
- **本体 geonicdb#1583 (PR #1596) のデプロイ前に公開すること。**

コード変更なし（version + CHANGELOG のみ）。lint / typecheck / vitest(868) 通過。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * バージョン0.22.1（2026年7月30日）のリリース情報を追加しました。
  * リリース間の変更履歴リンクを更新しました。

* **変更**
  * アプリケーションのバージョンを0.22.1に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->