### PR TITLE
feat(types): types list で EntityTypeList を unwrap し型名一覧を維持 (closes #172)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## [Unreleased]
 
+### 2026-08-04
+- **Feat**: `types list` が本体 geonicdb#1706 (#1694) の破壊的変更に追従 (closes #172)。`GET /types` の `details` 未指定レスポンスが ETSI OpenAPI v1.8.1 準拠の `EntityTypeList` オブジェクト (`{id,type,typeList,@context}`) へ変わったため、`types list` は `typeList` (型名の配列) を unwrap して従来どおり型名一覧を表示する。応答が既に配列 (旧 backend) ならそのまま通す (shape-tolerant)。`--details` を追加し、指定時は `EntityType` オブジェクト配列をそのまま整形する。あわせて `output.formatTable` が scalar のみの配列を 1 行 1 要素で描画するよう修正 (従来はインデックス列で誤描画)。geonicdb 依存を #1706 を含む origin/main に更新。(#173)
+
 ## [0.22.1] - 2026-07-30
 
 ### 2026-07-29

--- a/README.md
+++ b/README.md
@@ -430,7 +430,8 @@ Notes:
 
 | Subcommand | Description |
 |---|---|
-| `types list` | List available entity types |
+| `types list` | List available entity type names |
+| `types list --details` | Show full `EntityType` objects (typeName, attributeNames, etc.) |
 | `types get <typeName>` | Get details for a type |
 
 ### temporal — Temporal entity operations

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@types/node": "^22.13.0",
         "@vitest/coverage-v8": "^4.1.8",
         "eslint": "^10.8.0",
-        "geonicdb": "github:geolonia/geonicdb#f3d6acb4a930803b749491f0c869c9b034d52cfa",
+        "geonicdb": "github:geolonia/geonicdb#19ee77a428e3f2288ef51c3665d78d104d6ec82a",
         "mongodb": "^7.1.0",
         "mongodb-memory-server": "^11.0.1",
         "prettier": "^3.4.2",
@@ -5447,9 +5447,9 @@
       }
     },
     "node_modules/geonicdb": {
-      "version": "0.14.0",
-      "resolved": "git+ssh://git@github.com/geolonia/geonicdb.git#f3d6acb4a930803b749491f0c869c9b034d52cfa",
-      "integrity": "sha512-Hj78Hxqp+k9wKV3dI0Nma+NvJUh/2SMJbMywzInuuSbQv5Eeoi047raN6Yrd/Ws4aq1PSdUHtMTy7y07ISLi8Q==",
+      "version": "0.15.0",
+      "resolved": "git+ssh://git@github.com/geolonia/geonicdb.git#19ee77a428e3f2288ef51c3665d78d104d6ec82a",
+      "integrity": "sha512-eDwvozoud3QKPsY69tNbleGuEF1SaJ/mNERf5ZNCMezoNLdPtr40ultqtav1q7eF1Dus3nGgdWudSckAg3fJNw==",
       "dev": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {
@@ -5478,7 +5478,7 @@
         "@opentelemetry/semantic-conventions": "^1.43.0",
         "express": "^5.2.1",
         "fresh": "^2.0.0",
-        "js-yaml": "^5.2.1",
+        "js-yaml": "^5.2.3",
         "mongodb": "^7.5.0",
         "mqtt": "^5.15.1",
         "proj4": "^2.20.9",
@@ -6080,9 +6080,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.2.tgz",
-      "integrity": "sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.3.tgz",
+      "integrity": "sha512-n+mUVyUX5bVv7G/G2zyIHOhdxfuU1dY2NOFzTQUWiMUbFss8b57NFlgCCaggU78wSw5KVS9cllzeLyzyR+n5nw==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@types/node": "^22.13.0",
     "@vitest/coverage-v8": "^4.1.8",
     "eslint": "^10.8.0",
-    "geonicdb": "github:geolonia/geonicdb#f3d6acb4a930803b749491f0c869c9b034d52cfa",
+    "geonicdb": "github:geolonia/geonicdb#19ee77a428e3f2288ef51c3665d78d104d6ec82a",
     "mongodb": "^7.1.0",
     "mongodb-memory-server": "^11.0.1",
     "prettier": "^3.4.2",

--- a/src/commands/types.ts
+++ b/src/commands/types.ts
@@ -9,6 +9,20 @@ import {
 } from "../helpers.js";
 import { addExamples } from "./help.js";
 
+function unwrapEntityTypeList(data: unknown, details?: boolean): unknown {
+  if (details) return data;
+  if (
+    data &&
+    typeof data === "object" &&
+    !Array.isArray(data) &&
+    (data as { type?: unknown }).type === "EntityTypeList" &&
+    Array.isArray((data as { typeList?: unknown }).typeList)
+  ) {
+    return (data as { typeList: unknown[] }).typeList;
+  }
+  return data;
+}
+
 export function registerTypesCommand(program: Command): void {
   const types = program
     .command("types")
@@ -20,14 +34,27 @@ export function registerTypesCommand(program: Command): void {
     .description("List all entity types currently stored in the broker")
     .option("--limit <n>", "Maximum number of results", parseNonNegativeInt)
     .option("--offset <n>", "Skip N results", parseNonNegativeInt)
+    .option("--details", "Show full EntityType objects")
     .action(
       withErrorHandler(async (_opts: unknown, cmd: Command) => {
         const client = createClient(cmd);
         const format = getFormat(cmd);
-        const params = buildPaginationParams(cmd.opts());
+        const opts = cmd.opts<{
+          limit?: number;
+          offset?: number;
+          details?: boolean;
+        }>();
+        const params = buildPaginationParams(opts);
+        if (opts.details) params["details"] = "true";
 
         const response = await client.get("/types", params);
-        outputResponse(response, format);
+        outputResponse(
+          {
+            ...response,
+            data: unwrapEntityTypeList(response.data, opts.details),
+          },
+          format,
+        );
       }),
     );
 
@@ -43,6 +70,10 @@ export function registerTypesCommand(program: Command): void {
     {
       description: "List with pagination",
       command: "geonic types list --limit 50 --offset 100",
+    },
+    {
+      description: "Show full EntityType objects",
+      command: "geonic types list --details --format json",
     },
   ]);
 

--- a/src/output.ts
+++ b/src/output.ts
@@ -92,6 +92,9 @@ function formatTable(data: unknown): string {
   }
 
   if (data.length === 0) return "(empty)";
+  if (data.every((item) => item === null || typeof item !== "object")) {
+    return data.map((item) => cellValue(item)).join("\n");
+  }
 
   const items = data as Record<string, unknown>[];
   const keys = collectKeys(items);

--- a/tests/e2e/features/types.feature
+++ b/tests/e2e/features/types.feature
@@ -31,7 +31,7 @@ Feature: Entity types
   Scenario: List entity types in table without wrapper metadata
     Given I am logged in
     And I run `geonic entities create '{"id":"urn:ngsi-ld:Room:1722","type":"Room"}'`
-    When I run `geonic types list`
+    When I run `geonic types list --format table`
     Then the exit code should be 0
     And the output should contain "Room"
     And the output should not contain "@context"

--- a/tests/e2e/features/types.feature
+++ b/tests/e2e/features/types.feature
@@ -16,3 +16,33 @@ Feature: Entity types
     When I run `geonic types get Room`
     Then the exit code should be 0
     And stdout should be valid JSON
+
+  @issue-172
+  Scenario: List entity types as unwrapped JSON array
+    Given I am logged in
+    And I run `geonic entities create '{"id":"urn:ngsi-ld:Room:1721","type":"Room"}'`
+    When I run `geonic types list --format json`
+    Then the exit code should be 0
+    And stdout should be valid JSON
+    And the output should contain "Room"
+    And the output should not contain "EntityTypeList"
+
+  @issue-172
+  Scenario: List entity types in table without wrapper metadata
+    Given I am logged in
+    And I run `geonic entities create '{"id":"urn:ngsi-ld:Room:1722","type":"Room"}'`
+    When I run `geonic types list`
+    Then the exit code should be 0
+    And the output should contain "Room"
+    And the output should not contain "@context"
+
+  @issue-172
+  Scenario: List entity type details with --details
+    Given I am logged in
+    And I run `geonic entities create '{"id":"urn:ngsi-ld:Room:1723","type":"Room","temperature":{"type":"Property","value":26}}'`
+    When I run `geonic types list --details --format json`
+    Then the exit code should be 0
+    And stdout should be valid JSON
+    And the output should contain "\"type\": \"EntityType\""
+    And the output should contain "\"typeName\": \"Room\""
+    And the output should contain "attributeNames"

--- a/tests/output.test.ts
+++ b/tests/output.test.ts
@@ -36,6 +36,11 @@ describe("output", () => {
       expect(result).toContain("Room:002");
     });
 
+    it("renders scalar arrays as one item per line", () => {
+      const result = stripAnsi(formatOutput(["Room", "Car"], "table"));
+      expect(result).toBe("Room\nCar");
+    });
+
     it("shows (empty) for empty arrays", () => {
       const result = formatOutput([], "table");
       expect(result).toBe("(empty)");

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -97,6 +97,34 @@ describe("types command", () => {
       );
     });
 
+    it("passes through a non-EntityTypeList object unchanged", async () => {
+      // Only { type: "EntityTypeList", typeList: [...] } is unwrapped; any other
+      // object shape must reach outputResponse untouched (shape-tolerant).
+      const data = { id: "x", type: "SomethingElse", typeList: ["Room"] };
+      mockClient.get.mockResolvedValue(mockResponse(data));
+
+      await runCommand(program, ["types", "list"]);
+
+      expect(outputResponse).toHaveBeenCalledWith(
+        expect.objectContaining({ data }),
+        "json",
+      );
+    });
+
+    it("passes through an EntityTypeList object whose typeList is not an array", async () => {
+      // Guards the Array.isArray(typeList) check: a malformed wrapper must not be
+      // unwrapped and must reach outputResponse unchanged.
+      const data = { id: "x", type: "EntityTypeList", typeList: "not-an-array" };
+      mockClient.get.mockResolvedValue(mockResponse(data));
+
+      await runCommand(program, ["types", "list"]);
+
+      expect(outputResponse).toHaveBeenCalledWith(
+        expect.objectContaining({ data }),
+        "json",
+      );
+    });
+
     it("sends details=true and does not unwrap when --details is used", async () => {
       const wrapped = {
         id: "urn:ngsi-ld:EntityTypeList:test",

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -66,6 +66,53 @@ describe("types command", () => {
         offset: "5",
       });
     });
+
+    it("unwraps EntityTypeList to typeList", async () => {
+      mockClient.get.mockResolvedValue(
+        mockResponse({
+          id: "urn:ngsi-ld:EntityTypeList:test",
+          type: "EntityTypeList",
+          typeList: ["Room", "Car"],
+          "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.9.jsonld",
+        }),
+      );
+
+      await runCommand(program, ["types", "list"]);
+
+      expect(outputResponse).toHaveBeenCalledWith(
+        expect.objectContaining({ data: ["Room", "Car"] }),
+        "json",
+      );
+    });
+
+    it("passes through array responses unchanged", async () => {
+      const data = [{ typeName: "Room" }];
+      mockClient.get.mockResolvedValue(mockResponse(data));
+
+      await runCommand(program, ["types", "list"]);
+
+      expect(outputResponse).toHaveBeenCalledWith(
+        expect.objectContaining({ data }),
+        "json",
+      );
+    });
+
+    it("sends details=true and does not unwrap when --details is used", async () => {
+      const wrapped = {
+        id: "urn:ngsi-ld:EntityTypeList:test",
+        type: "EntityTypeList",
+        typeList: ["Room"],
+      };
+      mockClient.get.mockResolvedValue(mockResponse(wrapped));
+
+      await runCommand(program, ["types", "list", "--details"]);
+
+      expect(mockClient.get).toHaveBeenCalledWith("/types", { details: "true" });
+      expect(outputResponse).toHaveBeenCalledWith(
+        expect.objectContaining({ data: wrapped }),
+        "json",
+      );
+    });
   });
 
   describe("get", () => {


### PR DESCRIPTION
## 背景 / 根本原因

本体 geonicdb #1706 (#1694) で、`GET /ngsi-ld/v1/types` と `GET /ngsi-ld/v1/attributes` の `details` 未指定レスポンスが、素の配列から ETSI OpenAPI v1.8.1 準拠の **`EntityTypeList` / `AttributeList` オブジェクト** (`{ id, type, typeList | attributeList, @context }`) へ変わった（破壊的変更。`details=true` は従来どおり配列）。

CLI の `gdb types list` は `/types` の応答をそのまま整形するため、本体更新後は:
- table 出力が「型名の一覧」でなく `id / type / typeList / @context` の key-value 表示に**劣化**（`formatObjectTable` フォールバック。クラッシュはしない）。
- json 出力もラッパーオブジェクトに変わる。

本 PR は CLI を本体に追従させる。

## 修正内容

- **`types list`**: 応答が `EntityTypeList` オブジェクトなら `typeList`（型名の配列）へ **unwrap** して従来どおり型名一覧を表示。応答が既に配列（旧 backend / `--details`）ならそのまま通す（**shape-tolerant**、予期しない形状でも throw せず passthrough）。
- **`types list --details`**: `details=true` を送り、`EntityType` オブジェクト配列をそのまま整形（unwrap しない）。
- **`output.formatTable`**: scalar のみの配列を 1 行 1 要素で描画するよう修正（従来はインデックス列で誤描画）。unwrap 後の型名配列が table で綺麗に出る。オブジェクト配列の出力は不変。
- **deps**: `geonicdb` を #1706 を含む origin/main (`19ee77a4`) へ bump（E2E ハーネスがこの本体で `createServer` 起動 → 新レスポンスを実挙動で再現）。
- README 更新（`types list` は型名一覧、`--details` で完全な EntityType）。

## reproduction 証跡（red → green → 変異 → 復元）

reproduction-first。dep bump 後に既存 E2E 緑を確認 → `@issue-172` を追加し実装前の赤を実測 → 実装で緑 → 変異注入で再赤 → 復元で緑。

```
# 依存 bump 後・実装前ベースライン（既存 E2E 緑）: 152 scenarios passed
# @issue-172 実装前: 3 scenarios (3 failed) — EntityTypeList/@context 残留・--details unknown option
# 実装後: 3 scenarios (3 passed)
# 変異(unwrap 判定 1 行破壊): 3 scenarios (2 failed, 1 passed)  ← unwrap 依存 2 本が赤
# 復元後: 3 scenarios (3 passed)
```

独立検証（Claude が自分の手で変異注入・実測）でも同結果を確認済み。

## テスト

- E2E `@issue-172`（`tests/e2e/features/types.feature`）: json 出力が `EntityTypeList` を含まない / table 出力が `@context` を含まない / `--details` で `EntityType`・`typeName`・`attributeNames` が出る。
- Unit: `tests/types.test.ts`（unwrap・配列 passthrough・`--details` の非 unwrap）、`tests/output.test.ts`（scalar 配列描画）。
- フルゲート: `npm run lint && npm run typecheck && npm test && npm run test:e2e` = 155 scenarios / 872 unit すべて緑。

## スコープ境界 / follow-up

- 本 PR は `types` コマンドと `formatTable` の scalar 配列修正に限定。
- follow-up 候補: `/attributes` discovery コマンド新設（`AttributeList` unwrap 込み。issue 本文も「将来足す際に」と明記）。

Closes #172


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * `types list` に `--details` オプションを追加し、型情報の詳細を表示できるようになりました。
  * 型一覧レスポンスを用途に応じた形式で表示できるようになりました。

* **バグ修正**
  * スカラー値の配列をテーブル表示する際、各要素が個別の行に表示されるよう修正しました。

* **ドキュメント**
  * `types list` の使用方法と詳細表示の例を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->