### PR TITLE
feat(entities,temporal): NGSI-LD v1.9.1 purge コマンドと temporal orderBy に対応 (closes #171)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### 2026-08-04
 - **Feat**: `types list` が本体 geonicdb#1706 (#1694) の破壊的変更に追従 (closes #172)。`GET /types` の `details` 未指定レスポンスが ETSI OpenAPI v1.8.1 準拠の `EntityTypeList` オブジェクト (`{id,type,typeList,@context}`) へ変わったため、`types list` は `typeList` (型名の配列) を unwrap して従来どおり型名一覧を表示する。応答が既に配列 (旧 backend) ならそのまま通す (shape-tolerant)。`--details` を追加し、指定時は `EntityType` オブジェクト配列をそのまま整形する。あわせて `output.formatTable` が scalar のみの配列を 1 行 1 要素で描画するよう修正 (従来はインデックス列で誤描画)。geonicdb 依存を #1706 を含む origin/main に更新。(#173)
+- **Feat**: NGSI-LD v1.9.1 の purge / orderBy に対応 (closes #171, 本体 geonicdb#1681)。`entities purge` を新設し `DELETE /entities` を叩く (selector: `--type/--id/--id-pattern/--query/--attrs/--georel/--geometry/--coords/--scope-q/--local`、mutation: `--keep`/`--drop` 相互排他)。破壊的コマンドのため確認を要求 (`--yes`/`-y` でスキップ、非TTY で `--yes` 無しはサーバ未呼び出しで exit 1、TTY は確認プロンプト)。さらにクライアント側で `type|attrs|query|georel` のいずれか必須の too-wide ガードを設け、無指定 purge がサーバへ飛ばないようにした (多層防御)。`--attrs` は purge ではセレクタ (list の射影とは別)。`temporal entities list` に `--order-by` を追加 (POST query は本体が読まないため非対応)。`--order-direction` は追加せず、方向は `name;desc` 文法内で表現。legacy `!attr` は互換受理だが deprecated。geonicdb 依存を #1681 を含む origin/main へ更新。(#174)
 
 ## [0.22.1] - 2026-07-30
 

--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ geonic me oauth-clients update <client-id> --policy-id my-readonly
 
 `entities list` supports filtering options: `--type`, `--id-pattern`, `--query`, `--attrs`, `--georel`, `--geometry`, `--coords`, `--spatial-id`, `--limit`, `--offset`, `--order-by`, `--count`.
 
-`entities purge` supports selectors: `--type`, `--id`, `--id-pattern`, `--query`, `--attrs`, `--georel`, `--geometry`, `--coords`, `--scope-q`, `--local`, and mutation flags `--keep`, `--drop`. `--attrs` on purge is a selector ("entities having any listed attributes"), not an output projection.
+`entities purge` requires **at least one primary selector** — `--type`, `--attrs`, `--query`, or `--georel` (the latter together with `--geometry`/`--coords`). These can be narrowed with the refinement filters `--id`, `--id-pattern`, `--scope-q`, `--local`. A refinement filter **on its own is not sufficient**: `--id`/`--id-pattern`/`--scope-q` alone are rejected by both the CLI and the server — to remove a single entity use `entities delete <id>`. Mutation flags `--keep`/`--drop` (mutually exclusive) remove/retain attributes on matched entities instead of deleting the entities. `--attrs` on purge is a selector ("entities having any listed attributes"), not an output projection.
 
 For safety, `entities purge` requires confirmation. In non-interactive contexts (CI/pipes), it refuses to run unless `--yes` is provided.
 

--- a/README.md
+++ b/README.md
@@ -332,8 +332,15 @@ geonic me oauth-clients update <client-id> --policy-id my-readonly
 | `entities replace <id> [json]` | Replace all attributes (PUT) |
 | `entities upsert [json]` | Create or update entities |
 | `entities delete <id>` | Delete an entity by ID |
+| `entities purge <selectors> [--keep\|--drop] --yes` | Purge entities/attributes by selector (destructive) |
 
 `entities list` supports filtering options: `--type`, `--id-pattern`, `--query`, `--attrs`, `--georel`, `--geometry`, `--coords`, `--spatial-id`, `--limit`, `--offset`, `--order-by`, `--count`.
+
+`entities purge` supports selectors: `--type`, `--id`, `--id-pattern`, `--query`, `--attrs`, `--georel`, `--geometry`, `--coords`, `--scope-q`, `--local`, and mutation flags `--keep`, `--drop`. `--attrs` on purge is a selector ("entities having any listed attributes"), not an output projection.
+
+For safety, `entities purge` requires confirmation. In non-interactive contexts (CI/pipes), it refuses to run unless `--yes` is provided.
+
+`--order-by` uses NGSI-LD v1.9.1 inline direction grammar: `name`, `name;desc`, `type;asc,name;desc` (quote `;` in shell, e.g. `--order-by 'name;desc'`). There is no `--order-direction` flag. Legacy `!attr` (e.g. `--order-by '!temperature'`) is still accepted server-side but deprecated; prefer `attr;desc`.
 
 #### entities attrs — Manage entity attributes
 
@@ -445,7 +452,11 @@ Notes:
 | `temporal entities create [json]` | Create a temporal entity |
 | `temporal entities delete <id>` | Delete a temporal entity |
 
-Temporal entities list/get support: `--time-rel`, `--time-at`, `--end-time-at`, `--last-n`.
+Temporal entities list supports: `--time-rel`, `--time-at`, `--end-time-at`, `--last-n`, `--order-by`.
+
+Temporal entities get supports: `--time-rel`, `--time-at`, `--end-time-at`, `--last-n`.
+
+Temporal `--order-by` follows NGSI-LD v1.9.1 grammar (`name`, `name;desc`, composites like `a;asc,b;desc`). The server returns `400` for `dist-*`/`geo:distance`, nested paths like `a.b`, or when combined with `aggrMethods`.
 
 > **History truncation**: Without `--last-n`, the server caps the returned history to the **100 most recent instances per attribute** (default). When it does, the server returns an `NGSILD-Warning` header and the CLI echoes it as a `Warning:` line on **stderr** so truncation is never a silent drop. To retrieve more, set `--last-n` (**max 1000**) or narrow the window with `--time-at`/`--end-time-at` — with an explicit `--last-n` the server does not truncate, so no warning is emitted. The CLI surfaces whatever `NGSILD-Warning` the server sends, verbatim.
 
@@ -455,7 +466,7 @@ Temporal entities list/get support: `--time-rel`, `--time-at`, `--end-time-at`, 
 |---|---|
 | `temporal entityOperations query [json]` | Query temporal entities (POST) |
 
-Temporal entityOperations query supports: `--aggr-methods`, `--aggr-period`.
+Temporal entityOperations query supports: `--aggr-methods`, `--aggr-period`. `--order-by` is intentionally unsupported on this POST route.
 
 ### snapshots — Snapshot operations
 

--- a/src/commands/entities.ts
+++ b/src/commands/entities.ts
@@ -201,7 +201,10 @@ export function registerEntitiesCommand(program: Command): void {
         // requests (400 requires at least one of type|attrs|q|georel), but a
         // stray `purge --yes` (or a typo that parses to no selector) must never
         // even leave the CLI as an unbounded delete. Mirror the server's
-        // sufficient-selector set exactly.
+        // sufficient-selector set exactly: only type/attrs/query/georel qualify.
+        // --id/--id-pattern/--scope-q/--local are refinements, NOT sufficient on
+        // their own (the server rejects them alone too); a single-entity delete
+        // is `entities delete <id>`. See README "entities purge".
         if (!opts.type && !opts.attrs && !opts.query && !opts.georel) {
           throw new Error(
             "Refusing to purge: specify at least one selector (--type, --attrs, --query, or --georel).",

--- a/src/commands/entities.ts
+++ b/src/commands/entities.ts
@@ -7,6 +7,7 @@ import {
 } from "../helpers.js";
 import { parseJsonInput } from "../input.js";
 import { printCount, printSuccess } from "../output.js";
+import { isInteractive, promptConfirm } from "../prompt.js";
 import { registerAttrsSubcommand } from "./attrs.js";
 import { addExamples } from "./help.js";
 
@@ -149,6 +150,91 @@ export function registerEntitiesCommand(program: Command): void {
     {
       description: "Filter by scope (one level below)",
       command: "geonic entities list --scope-q '/Japan/+'",
+    },
+  ]);
+
+  // entities purge
+  const purge = entities
+    .command("purge")
+    .description(
+      "Purge entities or attributes by selector (destructive).\n\n" +
+        "Note: --attrs here selects target entities that have any of the listed attributes.\n" +
+        "This differs from `entities list --attrs`, which only selects returned fields.",
+    )
+    .option("--type <type>", "Filter target entities by type")
+    .option("--id <a,b>", "Comma-separated list of entity IDs to target")
+    .option("--id-pattern <pat>", "Filter by entity ID pattern (regex)")
+    .option("--query <q>", "NGSI query expression (q)")
+    .option("--attrs <a,b>", "Selector: target entities that have any listed attributes")
+    .option("--georel <rel>", "Geo-relationship selector")
+    .option("--geometry <geo>", "Geometry type for geo-selector (e.g. Point)")
+    .option("--coords <coords>", "Coordinates for geo-selector")
+    .option("--scope-q <expr>", "Filter by scope (scopeQ)")
+    .option("--local", "Restrict to local entities")
+    .option("--keep <a,b>", "Keep only these attributes on matched entities")
+    .option("--drop <a,b>", "Drop these attributes from matched entities")
+    .option("-y, --yes", "Skip confirmation prompt")
+    .action(
+      withErrorHandler(async (opts: Record<string, unknown>, cmd: Command) => {
+        const client = createClient(cmd);
+        const params: Record<string, string> = {};
+
+        if (opts.type) params.type = String(opts.type);
+        if (opts.id) params.id = String(opts.id);
+        if (opts.idPattern) params.idPattern = String(opts.idPattern);
+        if (opts.query) params.q = String(opts.query);
+        if (opts.attrs) params.attrs = String(opts.attrs);
+        if (opts.georel) params.georel = String(opts.georel);
+        if (opts.geometry) params.geometry = String(opts.geometry);
+        if (opts.coords) params.coordinates = String(opts.coords);
+        if (opts.scopeQ) params.scopeQ = String(opts.scopeQ);
+        if (opts.local) params.local = "true";
+        if (opts.keep) params.keep = String(opts.keep);
+        if (opts.drop) params.drop = String(opts.drop);
+
+        if (opts.keep && opts.drop) {
+          throw new Error("Cannot specify both --keep and --drop.");
+        }
+
+        // Defense-in-depth: refuse an under-specified purge on the client before
+        // any confirmation or server call. The server also rejects too-wide
+        // requests (400 requires at least one of type|attrs|q|georel), but a
+        // stray `purge --yes` (or a typo that parses to no selector) must never
+        // even leave the CLI as an unbounded delete. Mirror the server's
+        // sufficient-selector set exactly.
+        if (!opts.type && !opts.attrs && !opts.query && !opts.georel) {
+          throw new Error(
+            "Refusing to purge: specify at least one selector (--type, --attrs, --query, or --georel).",
+          );
+        }
+
+        if (!opts.yes) {
+          if (!isInteractive()) {
+            throw new Error("Refusing to purge without confirmation. Re-run with --yes.");
+          }
+          const confirmed = await promptConfirm(
+            "This operation can permanently delete entities or attributes. Continue?",
+          );
+          if (!confirmed) return;
+        }
+
+        await client.delete("/entities", params);
+        printSuccess("Purge completed.");
+      }),
+    );
+
+  addExamples(purge, [
+    {
+      description: "Purge all matching entities by type (requires explicit confirmation bypass)",
+      command: "geonic entities purge --type Sensor --yes",
+    },
+    {
+      description: "Drop selected attributes from matching entities",
+      command: "geonic entities purge --type Sensor --drop temperature,humidity --yes",
+    },
+    {
+      description: "Keep only selected attributes on matching entities",
+      command: "geonic entities purge --type Sensor --keep location,status --yes",
     },
   ]);
 

--- a/src/commands/temporal.ts
+++ b/src/commands/temporal.ts
@@ -29,6 +29,10 @@ function addTemporalListOptions(cmd: Command): Command {
     )
     .option("--limit <n>", "Maximum number of entities to return", parseInt)
     .option("--offset <n>", "Skip first N entities", parseInt)
+    .option(
+      "--order-by <spec>",
+      "Order by NGSI-LD v1.9.1 grammar (e.g. observedAt;desc). Server rejects dist-*/geo:distance, nested paths, aggrMethods combos.",
+    )
     .option("--count", "Include total count in response");
 }
 
@@ -52,6 +56,7 @@ function createListAction() {
     if (cmdOpts.lastN !== undefined) params["lastN"] = String(cmdOpts.lastN);
     if (cmdOpts.limit !== undefined) params["limit"] = String(cmdOpts.limit);
     if (cmdOpts.offset !== undefined) params["offset"] = String(cmdOpts.offset);
+    if (cmdOpts.orderBy) params["orderBy"] = cmdOpts.orderBy;
     if (cmdOpts.count) params["count"] = "true";
 
     const response = await client.get("/temporal/entities", params);
@@ -178,6 +183,10 @@ export function registerTemporalCommand(program: Command): void {
       description: "Filter by time (after a point)",
       command:
         "geonic temporal entities list --time-rel after --time-at 2025-06-01T00:00:00Z",
+    },
+    {
+      description: "Order temporal entities (NGSI-LD v1.9.1 grammar)",
+      command: "geonic temporal entities list --type Sensor --order-by 'observedAt;desc'",
     },
   ]);
 

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -16,6 +16,16 @@ export async function promptEmail(): Promise<string> {
   }
 }
 
+export async function promptConfirm(message: string): Promise<boolean> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = (await rl.question(`${message} [y/N]: `)).trim().toLowerCase();
+    return answer === "y" || answer === "yes";
+  } finally {
+    rl.close();
+  }
+}
+
 export async function promptTenantSelection(
   tenants: TenantInfo[],
 ): Promise<TenantInfo> {

--- a/tests/completions.test.ts
+++ b/tests/completions.test.ts
@@ -66,6 +66,7 @@ describe("completions", () => {
       expect(result).toContain("create");
       expect(result).toContain("update");
       expect(result).toContain("delete");
+      expect(result).toContain("purge");
       expect(result).toContain("attrs");
     });
 

--- a/tests/e2e/features/entities.feature
+++ b/tests/e2e/features/entities.feature
@@ -227,3 +227,50 @@ Feature: Entity management
       """
     Then the exit code should be 0
     And the output should contain "Entity created."
+
+  @issue-171
+  Scenario: Purge entities by type selector
+    Given I am logged in
+    And I run `geonic entities create '{"id":"urn:ngsi-ld:Room:P171-1","type":"Room"}'`
+    And I run `geonic entities create '{"id":"urn:ngsi-ld:Car:P171-1","type":"Car"}'`
+    When I run `geonic entities purge --type Room --yes`
+    Then the exit code should be 0
+    And the output should contain "Purge completed."
+    And I run `geonic entities list`
+    Then the exit code should be 0
+    And the output should not contain "Room:P171-1"
+    And the output should contain "Car:P171-1"
+
+  @issue-171
+  Scenario: Purge refuses to run without confirmation in non-TTY mode
+    Given I am logged in
+    And I run `geonic entities create '{"id":"urn:ngsi-ld:Room:P171-2","type":"Room"}'`
+    When I run `geonic entities purge --type Room`
+    Then the exit code should be 1
+    And the output should contain "Refusing to purge without confirmation. Re-run with --yes."
+    And I run `geonic entities list --type Room`
+    Then the exit code should be 0
+    And the output should contain "Room:P171-2"
+
+  @issue-171
+  Scenario: Purge drop removes only selected attributes
+    Given I am logged in
+    And I run `geonic entities create '{"id":"urn:ngsi-ld:Room:P171-3","type":"Room","attrA":{"type":"Property","value":1},"attrB":{"type":"Property","value":2}}'`
+    When I run `geonic entities purge --type Room --drop attrA --yes`
+    Then the exit code should be 0
+    And the output should contain "Purge completed."
+    And I run `geonic entities get urn:ngsi-ld:Room:P171-3`
+    Then the exit code should be 0
+    And the output should contain "attrB"
+    And the output should not contain "attrA"
+
+  @issue-171
+  Scenario: Purge refuses an under-specified selector on the client (no delete)
+    Given I am logged in
+    And I run `geonic entities create '{"id":"urn:ngsi-ld:Room:P171-4","type":"Room"}'`
+    When I run `geonic entities purge --id-pattern '.*' --yes`
+    Then the exit code should be 1
+    And the output should contain "specify at least one selector"
+    And I run `geonic entities list --type Room`
+    Then the exit code should be 0
+    And the output should contain "Room:P171-4"

--- a/tests/e2e/features/temporal.feature
+++ b/tests/e2e/features/temporal.feature
@@ -62,8 +62,8 @@ Feature: Temporal entity management
     And stdout should be valid JSON
 
   @issue-171
-  Scenario: Temporal entities list actually transmits orderBy (not silently dropped)
+  Scenario: Temporal entities list actually transmits orderBy incl. direction (not silently dropped)
     Given I am logged in
     When I run `geonic temporal entities list --type Room --order-by observedAt;desc --dry-run`
     Then the exit code should be 0
-    And the output should contain "orderBy=observedAt"
+    And the output should contain "orderBy=observedAt%3Bdesc"

--- a/tests/e2e/features/temporal.feature
+++ b/tests/e2e/features/temporal.feature
@@ -51,3 +51,19 @@ Feature: Temporal entity management
     When I run `geonic temporal entityOperations query '{"entities":[{"type":"Room"}]}'`
     Then the exit code should be 0
     And stdout should be valid JSON
+
+  @issue-171
+  Scenario: Temporal entities list accepts NGSI-LD v1.9.1 orderBy grammar
+    Given I am logged in
+    And I run `geonic temporal entities create '{"id":"urn:ngsi-ld:Room:T171-1","type":"Room","temperature":[{"type":"Property","value":21,"observedAt":"2025-01-01T00:00:00Z"}]}'`
+    And I run `geonic temporal entities create '{"id":"urn:ngsi-ld:Room:T171-2","type":"Room","temperature":[{"type":"Property","value":24,"observedAt":"2025-01-02T00:00:00Z"}]}'`
+    When I run `geonic temporal entities list --type Room --order-by observedAt;desc`
+    Then the exit code should be 0
+    And stdout should be valid JSON
+
+  @issue-171
+  Scenario: Temporal entities list actually transmits orderBy (not silently dropped)
+    Given I am logged in
+    When I run `geonic temporal entities list --type Room --order-by observedAt;desc --dry-run`
+    Then the exit code should be 0
+    And the output should contain "orderBy=observedAt"

--- a/tests/entities.test.ts
+++ b/tests/entities.test.ts
@@ -31,9 +31,15 @@ vi.mock("../src/commands/attrs.js", () => ({
   registerAttrsSubcommand: vi.fn(),
 }));
 
+vi.mock("../src/prompt.js", () => ({
+  isInteractive: vi.fn(),
+  promptConfirm: vi.fn(),
+}));
+
 import { createClient, getFormat, outputResponse } from "../src/helpers.js";
 import { parseJsonInput } from "../src/input.js";
 import { printCount, printSuccess } from "../src/output.js";
+import { isInteractive, promptConfirm } from "../src/prompt.js";
 import { registerEntitiesCommand } from "../src/commands/entities.js";
 
 describe("entities command", () => {
@@ -45,6 +51,8 @@ describe("entities command", () => {
     mockClient = createMockClient();
     vi.mocked(createClient).mockReturnValue(mockClient as never);
     vi.mocked(getFormat).mockReturnValue("json");
+    vi.mocked(isInteractive).mockReturnValue(false);
+    vi.mocked(promptConfirm).mockResolvedValue(false);
     program = createTestProgram(registerEntitiesCommand);
   });
 
@@ -298,6 +306,94 @@ describe("entities command", () => {
         `/entities/${encodeURIComponent("urn:ngsi-ld:Sensor:001")}`,
       );
       expect(printSuccess).toHaveBeenCalledWith("Entity deleted.");
+    });
+  });
+
+  describe("purge", () => {
+    it("deletes with assembled selector and mutation params", async () => {
+      mockClient.delete.mockResolvedValue(mockResponse(undefined, 204));
+
+      await runCommand(program, [
+        "entities", "purge",
+        "--type", "Room",
+        "--id", "urn:1,urn:2",
+        "--id-pattern", "urn:.*",
+        "--query", "temperature>30",
+        "--attrs", "temperature,humidity",
+        "--georel", "near;maxDistance==1000",
+        "--geometry", "Point",
+        "--coords", "[139.7,35.6]",
+        "--scope-q", "/Japan/#",
+        "--local",
+        "--drop", "temperature",
+        "--yes",
+      ]);
+
+      expect(mockClient.delete).toHaveBeenCalledWith("/entities", {
+        type: "Room",
+        id: "urn:1,urn:2",
+        idPattern: "urn:.*",
+        q: "temperature>30",
+        attrs: "temperature,humidity",
+        georel: "near;maxDistance==1000",
+        geometry: "Point",
+        coordinates: "[139.7,35.6]",
+        scopeQ: "/Japan/#",
+        local: "true",
+        drop: "temperature",
+      });
+      expect(printSuccess).toHaveBeenCalledWith("Purge completed.");
+      expect(promptConfirm).not.toHaveBeenCalled();
+    });
+
+    it("refuses without --yes in non-interactive mode", async () => {
+      vi.mocked(isInteractive).mockReturnValue(false);
+
+      await expect(
+        runCommand(program, ["entities", "purge", "--type", "Room"]),
+      ).rejects.toThrow("Refusing to purge without confirmation. Re-run with --yes.");
+
+      expect(mockClient.delete).not.toHaveBeenCalled();
+      expect(promptConfirm).not.toHaveBeenCalled();
+    });
+
+    it("asks for confirmation in interactive mode and aborts when declined", async () => {
+      vi.mocked(isInteractive).mockReturnValue(true);
+      vi.mocked(promptConfirm).mockResolvedValue(false);
+
+      await runCommand(program, ["entities", "purge", "--type", "Room"]);
+
+      expect(promptConfirm).toHaveBeenCalledWith(
+        "This operation can permanently delete entities or attributes. Continue?",
+      );
+      expect(mockClient.delete).not.toHaveBeenCalled();
+    });
+
+    it("proceeds after confirmation in interactive mode", async () => {
+      mockClient.delete.mockResolvedValue(mockResponse(undefined, 204));
+      vi.mocked(isInteractive).mockReturnValue(true);
+      vi.mocked(promptConfirm).mockResolvedValue(true);
+
+      await runCommand(program, ["entities", "purge", "--type", "Room"]);
+
+      expect(mockClient.delete).toHaveBeenCalledWith("/entities", { type: "Room" });
+      expect(printSuccess).toHaveBeenCalledWith("Purge completed.");
+    });
+
+    it("rejects mutually exclusive keep and drop options", async () => {
+      await expect(
+        runCommand(program, ["entities", "purge", "--type", "Room", "--keep", "a", "--drop", "b", "--yes"]),
+      ).rejects.toThrow("Cannot specify both --keep and --drop.");
+
+      expect(mockClient.delete).not.toHaveBeenCalled();
+    });
+
+    it("refuses an under-specified purge (no type/attrs/query/georel) before any server call", async () => {
+      await expect(
+        runCommand(program, ["entities", "purge", "--id-pattern", ".*", "--yes"]),
+      ).rejects.toThrow("specify at least one selector");
+
+      expect(mockClient.delete).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/help.test.ts
+++ b/tests/help.test.ts
@@ -153,6 +153,7 @@ describe("help", () => {
       expect(output).toContain("create");
       expect(output).toContain("update");
       expect(output).toContain("delete");
+      expect(output).toContain("purge");
     });
 
     it("does not include OPTIONS section", () => {

--- a/tests/prompt.test.ts
+++ b/tests/prompt.test.ts
@@ -11,7 +11,7 @@ vi.mock("node:readline/promises", () => ({
   })),
 }));
 
-import { isInteractive, promptEmail, promptPassword, promptTenantSelection } from "../src/prompt.js";
+import { isInteractive, promptConfirm, promptEmail, promptPassword, promptTenantSelection } from "../src/prompt.js";
 
 describe("prompt", () => {
   const originalStdinIsTTY = process.stdin.isTTY;
@@ -66,6 +66,31 @@ describe("prompt", () => {
       mockQuestion.mockRejectedValue(new Error("readline error"));
 
       await expect(promptEmail()).rejects.toThrow("readline error");
+      expect(mockClose).toHaveBeenCalled();
+    });
+  });
+
+  describe("promptConfirm", () => {
+    it("returns true for y/yes answers", async () => {
+      mockQuestion.mockResolvedValueOnce("y");
+      await expect(promptConfirm("Proceed?")).resolves.toBe(true);
+
+      mockQuestion.mockResolvedValueOnce("YES");
+      await expect(promptConfirm("Proceed?")).resolves.toBe(true);
+      expect(mockQuestion).toHaveBeenCalledWith("Proceed? [y/N]: ");
+    });
+
+    it("returns false for empty or non-yes answers", async () => {
+      mockQuestion.mockResolvedValueOnce("");
+      await expect(promptConfirm("Proceed?")).resolves.toBe(false);
+
+      mockQuestion.mockResolvedValueOnce("no");
+      await expect(promptConfirm("Proceed?")).resolves.toBe(false);
+    });
+
+    it("always closes readline", async () => {
+      mockQuestion.mockRejectedValueOnce(new Error("readline failed"));
+      await expect(promptConfirm("Proceed?")).rejects.toThrow("readline failed");
       expect(mockClose).toHaveBeenCalled();
     });
   });

--- a/tests/temporal.test.ts
+++ b/tests/temporal.test.ts
@@ -96,6 +96,7 @@ describe("temporal commands", () => {
         "--last-n", "5",
         "--limit", "10",
         "--offset", "20",
+        "--order-by", "observedAt;desc",
         "--count",
       ]);
 
@@ -112,6 +113,7 @@ describe("temporal commands", () => {
         lastN: "5",
         limit: "10",
         offset: "20",
+        orderBy: "observedAt;desc",
         count: "true",
       });
       expect(outputResponse).toHaveBeenCalledWith(expect.anything(), "json", true);
@@ -241,8 +243,11 @@ describe("temporal commands", () => {
     it("temporal list works as alias for temporal entities list", async () => {
       client.get.mockResolvedValue(mockResponse([]));
       const program = makeProgram();
-      await runCommand(program, ["temporal", "list", "--type", "Sensor"]);
-      expect(client.get).toHaveBeenCalledWith("/temporal/entities", { type: "Sensor" });
+      await runCommand(program, ["temporal", "list", "--type", "Sensor", "--order-by", "observedAt;desc"]);
+      expect(client.get).toHaveBeenCalledWith("/temporal/entities", {
+        type: "Sensor",
+        orderBy: "observedAt;desc",
+      });
     });
 
     it("temporal get works as alias for temporal entities get", async () => {


### PR DESCRIPTION
## 背景

本体 geonicdb #1681 で NGSI-LD v1.9.1 対応が入り、以下が使えるようになった。
- `DELETE /ngsi-ld/v1/entities`（selector + `keep`/`drop` + too-wide guard + unknown param 400）
- `orderBy` の v1.9.1 文法（`name;desc`、複合 `type;asc,name;desc`）、temporal query の orderBy

本 PR は CLI をこれに追従させる。

## 修正内容

### 1. `entities purge`（破壊的・新設）
`DELETE /entities` を叩く。
- **selector**: `--type` `--id`（CSV）`--id-pattern` `--query`(q) `--attrs` `--georel` `--geometry` `--coords`(coordinates) `--scope-q`(scopeQ) `--local`
- **mutation**: `--keep` `--drop`（相互排他。両指定でクライアントエラー）
- **`--attrs` の意味差**: purge では「いずれかの属性を持つ」**セレクタ**（`entities list --attrs` の射影とは別物）。help/README に明記。
- **安全ガード**（多層防御）:
  - `--yes`/`-y` で確認スキップ。
  - 非 TTY（CI/パイプ）で `--yes` 無し → **サーバを呼ばず** exit 1（`Refusing to purge without confirmation. Re-run with --yes.`）。
  - TTY で `--yes` 無し → `promptConfirm()` で y/N 確認。
  - **クライアント側 too-wide ガード**（gemini レビュー指摘 / PLAN 準拠）: `type|attrs|query|georel` のいずれも無ければ、確認・送信前に拒否（`specify at least one selector`）。無指定 `purge --yes` がサーバへ飛ぶ導線を断つ。サーバも too-wide を 400 で拒否するが、クライアントでも塞ぐ。
- 既存 global `--dry-run` で送信前に curl 確認可能。

### 2. temporal orderBy
- `temporal entities list`（GET /temporal/entities）と hidden alias `temporal list` に `--order-by` を追加し `orderBy` へ透過。
- **`temporal entityOperations query`（POST）には追加しない** — 本体 `batchQueryTemporalEntities` が body/params どちらからも orderBy を読まないため、足すと silent-ignore の罠になる（インストール済み backend 実装で確認）。
- 制約（`dist-*`/`geo:distance`・ネストパス・`aggrMethods` 併用で 400）は help に明記。

### 3. orderBy legacy 互換
- CLI は元々 `--order-direction` を持たず、本 PR でも追加しない（方向は `name;desc` の文法内で表現）。
- legacy `!attr` 接頭辞（例 `--order-by '!temperature'`）はサーバ側で互換受理されるが **deprecated** と README に明記。`entities list --order-by` は元々 verbatim 透過なので新文法はそのまま動く（docs のみ更新）。

### 4. deps
- `geonicdb` を #1681 を含む origin/main (`19ee77a4`) へ bump。E2E ハーネスがこの本体で `createServer` 起動 → purge/orderBy を実挙動で再現。

## reproduction 証跡（red → green → 変異 → 復元）

reproduction-first。dep bump 後に既存 E2E 緑を確認 → `@issue-171` を追加し実装前の赤を実測 → 実装で緑 → 変異注入で再赤 → 復元で緑。

```
# 依存 bump 後・実装前ベースライン（既存 E2E 緑）: 152 scenarios passed
# @issue-171 実装前: 5 scenarios failed（unknown command 'purge' / unknown option '--order-by'）
# 実装後: 全緑
# 変異(purge の type param キー破壊): 2 scenarios failed（type セレクタ依存の purge/drop）→ 復元で緑
```

**gemini レビュー指摘への追加対応**も独立に変異検証（Claude が自分の手で実測）:
- クライアント too-wide ガード: 無効化すると「under-specified purge 拒否」シナリオが赤（id-pattern 単独がサーバへ飛び別メッセージに）→ 復元で緑。
- temporal orderBy 透過: 無効化すると `--dry-run` で `orderBy=observedAt` が消え「silently dropped でない」シナリオが赤 → 復元で緑。

## テスト

- E2E `@issue-171`（`entities.feature` / `temporal.feature`）: type purge の選択性（対象型のみ削除・他型残存）、非TTY 拒否で削除が起きない、drop で対象属性のみ消える、under-specified 拒否で削除が起きない、orderBy が実際に送信される（`--dry-run`）。
- Unit: `entities.test.ts`（purge param 組み立て・keep/drop 排他・under-specified 拒否・非TTY 拒否）、`temporal.test.ts`、`prompt.test.ts`。
- フルゲート: `npm run lint && npm run typecheck && npm test && npm run test:e2e` = 158 scenarios / 877 unit すべて緑。

## スコープ境界 / follow-up

- 本 PR は purge・temporal orderBy・docs・dep bump に限定。
- follow-up 候補: (1) purge 前の件数プレビュー（`--attrs` セレクタ意味論が count と異なり要設計）、(2) `--geoproperty`/`csf`/`localOnly` フラグ露出、(3) 非 temporal batch query の `--order-by` 便宜フラグ。

Closes #171


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 条件を指定してエンティティまたは属性を削除する `entities purge` を追加しました。
  - 対話確認、`--yes`、保持・削除属性の指定に対応しました。
  - Temporal エンティティ一覧で `--order-by` による並び替えに対応しました。
- **ドキュメント**
  - `purge` の確認要件、セレクター、利用可能な並び替え形式を追記しました。
- **互換性**
  - 既存の `!attr` 指定を引き続き利用できます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->