### PR TITLE
release: v0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## [Unreleased]
 
+## [0.23.0] - 2026-08-04
+
 ### 2026-08-04
 - **Feat**: `types list` が本体 geonicdb#1706 (#1694) の破壊的変更に追従 (closes #172)。`GET /types` の `details` 未指定レスポンスが ETSI OpenAPI v1.8.1 準拠の `EntityTypeList` オブジェクト (`{id,type,typeList,@context}`) へ変わったため、`types list` は `typeList` (型名の配列) を unwrap して従来どおり型名一覧を表示する。応答が既に配列 (旧 backend) ならそのまま通す (shape-tolerant)。`--details` を追加し、指定時は `EntityType` オブジェクト配列をそのまま整形する。あわせて `output.formatTable` が scalar のみの配列を 1 行 1 要素で描画するよう修正 (従来はインデックス列で誤描画)。geonicdb 依存を #1706 を含む origin/main に更新。(#173)
 - **Feat**: NGSI-LD v1.9.1 の purge / orderBy に対応 (closes #171, 本体 geonicdb#1681)。`entities purge` を新設し `DELETE /entities` を叩く (selector: `--type/--id/--id-pattern/--query/--attrs/--georel/--geometry/--coords/--scope-q/--local`、mutation: `--keep`/`--drop` 相互排他)。破壊的コマンドのため確認を要求 (`--yes`/`-y` でスキップ、非TTY で `--yes` 無しはサーバ未呼び出しで exit 1、TTY は確認プロンプト)。さらにクライアント側で `type|attrs|query|georel` のいずれか必須の too-wide ガードを設け、無指定 purge がサーバへ飛ばないようにした (多層防御)。`--attrs` は purge ではセレクタ (list の射影とは別)。`temporal entities list` に `--order-by` を追加 (POST query は本体が読まないため非対応)。`--order-direction` は追加せず、方向は `name;desc` 文法内で表現。legacy `!attr` は互換受理だが deprecated。geonicdb 依存を #1681 を含む origin/main へ更新。(#174)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolonia/geonicdb-cli",
-  "version": "0.22.1",
+  "version": "0.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolonia/geonicdb-cli",
-      "version": "0.22.1",
+      "version": "0.23.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolonia/geonicdb-cli",
-  "version": "0.22.1",
+  "version": "0.23.0",
   "description": "A CLI client for the GeonicDB",
   "type": "module",
   "bin": {


### PR DESCRIPTION
v0.23.0 リリース。

## 含まれる変更
- **#174 (closes #171)**: NGSI-LD v1.9.1 の `entities purge` コマンド新設 + `temporal entities list --order-by`。
- **#173 (closes #172)**: `types list` の EntityTypeList unwrap + `--details` + formatTable scalar 配列描画修正。

## リリース手順
- package.json / package-lock.json を 0.23.0 に bump。
- CHANGELOG の `[Unreleased]` を `[0.23.0] - 2026-08-04` に確定。
- マージ後 `v0.23.0` タグ push で publish.yml が CI 検証のうえ npm 公開 (OIDC Trusted Publishing)。

MINOR bump: 新機能追加 (purge コマンド・--details) のため。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * バージョン0.23.0（2026年8月4日）のリリース情報を追加しました。
* **変更**
  * パッケージのバージョンを0.23.0に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->