### PR TITLE
fix(context): 読み取り時に JSON-LD @context を渡せるようにする (closes #177)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,14 @@
 ## [Unreleased]
 
 ### 2026-08-06
-- **Fix**: 読み取り時に JSON-LD `@context` を渡せるようにした (closes #177, 本体 geonicdb#1733 / #1785 対応)。本体が ETSI GS CIM 009 clause 5.5.5 / 5.5.7 に準拠し「応答の compaction はそのリクエストが渡した `@context` だけで行う」ようになったため、`@context` を渡す手段が無い CLI では独自語彙の型名・属性名が完全修飾 URI (FQN) でしか読めなくなっていた。グローバルオプション `--context <uri>` を追加 (繰り返し指定・カンマ区切りの両方に対応)。
+- **Fix**: 読み取り時に JSON-LD `@context` を渡せるようにした (closes #177, 本体 geonicdb#1733 / #1785 対応)。本体が ETSI GS CIM 009 clause 5.5.5 / 5.5.7 に準拠し「応答の compaction はそのリクエストが渡した `@context` だけで行う」ようになったため、`@context` を渡す手段が無い CLI では独自語彙の型名・属性名が完全修飾 URI (FQN) でしか読めなくなっていた。グローバルオプション `--context <uri>` を追加 (繰り返し指定・カンマ区切りの両方に対応)。(#178)
   - **読み取り**: `Link: <uri>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"` を NGSI-LD の全リクエスト (`entities` / `attrs` / `types` / `temporal` / `batch` / `subscriptions` / `registrations` / `snapshots`) に付与する。GET には Link 以外に `@context` を運ぶ経路が無い。admin / auth 等の非 NGSI-LD パスには付けない
   - **書き込み**: `application/ld+json` では本体が **body の `@context` を読み Link ヘッダーを無視する** (`extractContextRef`) ため、エンティティ書き込みボディにも注入する。対象は `/entities` (オブジェクトボディ) と `entityOperations` の `create`/`upsert`/`update`/`merge` (配列の各要素)。`entityOperations/delete` (ID 文字列の配列) と `query` (Query オブジェクト) には注入しない。利用者が明示した `@context` は非上書き。`--context` 未指定時の挙動は従来どおり (#168 の core context 注入)
   - **既定値**: `geonic config set context <uri[,uri...]>` でプロファイルごとの既定 `@context` を保存できる。`--context` は既定値を*置換*する (マージしない)
-  - **検証**: `--context` は絶対 http/https URL のみ受理し、`<` `>` `"` / 空白 / 制御文字を含む値を拒否する (Link ヘッダーへのヘッダーインジェクション防止)。`config set context` も保存時に同じ検証を通す
+  - **検証**: `--context` は絶対 http/https URL のみ受理し、`<` `>` `"` / 空白 / 制御文字を含む値を拒否する (Link ヘッダーへのヘッダーインジェクション防止)。`config set context` も保存時に同じ検証を通し、手編集された `config.json` の値も使用時に同じ検証を通す (検証を迂回して `Link` ヘッダーへ到達させない)
   - **既知の本体側ギャップ**: 本体は Link ヘッダーの link-value を 1 個目しか読まない (geonicdb#1818 として起票)。複数指定時は stderr で警告し、黙って落とさない
   - `config set` の値検証エラー (`url` / `context`) が未処理例外のスタックトレースではなく通常のエラー + exit 1 になるよう修正
-  - E2E `tests/e2e/features/context.feature` を追加 (13 シナリオ)。Link ヘッダー除去の変異で 8 シナリオ、body 注入除去の変異で 2 シナリオが赤くなることを確認済み。geonicdb 依存を #1733 / #1775 を含む origin/main へ更新 (#178)
+  - E2E `tests/e2e/features/context.feature` を追加 (13 シナリオ)。Link ヘッダー除去の変異で 8 シナリオ、body 注入除去の変異で 2 シナリオが赤くなることを確認済み。geonicdb 依存を #1733 / #1775 を含む origin/main へ更新
 
 ## [0.23.0] - 2026-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@
 
 ## [Unreleased]
 
+### 2026-08-06
+- **Fix**: 読み取り時に JSON-LD `@context` を渡せるようにした (closes #177, 本体 geonicdb#1733 / #1785 対応)。本体が ETSI GS CIM 009 clause 5.5.5 / 5.5.7 に準拠し「応答の compaction はそのリクエストが渡した `@context` だけで行う」ようになったため、`@context` を渡す手段が無い CLI では独自語彙の型名・属性名が完全修飾 URI (FQN) でしか読めなくなっていた。グローバルオプション `--context <uri>` を追加 (繰り返し指定・カンマ区切りの両方に対応)。
+  - **読み取り**: `Link: <uri>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"` を NGSI-LD の全リクエスト (`entities` / `attrs` / `types` / `temporal` / `batch` / `subscriptions` / `registrations` / `snapshots`) に付与する。GET には Link 以外に `@context` を運ぶ経路が無い。admin / auth 等の非 NGSI-LD パスには付けない
+  - **書き込み**: `application/ld+json` では本体が **body の `@context` を読み Link ヘッダーを無視する** (`extractContextRef`) ため、エンティティ書き込みボディにも注入する。対象は `/entities` (オブジェクトボディ) と `entityOperations` の `create`/`upsert`/`update`/`merge` (配列の各要素)。`entityOperations/delete` (ID 文字列の配列) と `query` (Query オブジェクト) には注入しない。利用者が明示した `@context` は非上書き。`--context` 未指定時の挙動は従来どおり (#168 の core context 注入)
+  - **既定値**: `geonic config set context <uri[,uri...]>` でプロファイルごとの既定 `@context` を保存できる。`--context` は既定値を*置換*する (マージしない)
+  - **検証**: `--context` は絶対 http/https URL のみ受理し、`<` `>` `"` / 空白 / 制御文字を含む値を拒否する (Link ヘッダーへのヘッダーインジェクション防止)。`config set context` も保存時に同じ検証を通す
+  - **既知の本体側ギャップ**: 本体は Link ヘッダーの link-value を 1 個目しか読まない (geonicdb#1818 として起票)。複数指定時は stderr で警告し、黙って落とさない
+  - `config set` の値検証エラー (`url` / `context`) が未処理例外のスタックトレースではなく通常のエラー + exit 1 になるよう修正
+  - E2E `tests/e2e/features/context.feature` を追加 (13 シナリオ)。Link ヘッダー除去の変異で 8 シナリオ、body 注入除去の変異で 2 シナリオが赤くなることを確認済み。geonicdb 依存を #1733 / #1775 を含む origin/main へ更新 (#178)
+
 ## [0.23.0] - 2026-08-04
 
 ### 2026-08-04

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ geonic entities list --help
 | `--token <token>` | Authentication token |
 | `-p, --profile <name>` | Use a named profile |
 | `--api-key <key>` | API key for authentication |
+| `--context <uri>` | JSON-LD `@context` URI for NGSI-LD requests (repeatable, or comma-separated) |
 | `-f, --format <fmt>` | Output format: `json`, `table`, `geojson` |
 | `--no-color` | Disable color output |
 | `-v, --verbose` | Verbose output |
@@ -735,6 +736,46 @@ Specify the output format with `--format` or `geonic config set format <fmt>`.
 
 Use `--key-values` on `entities list` and `entities get` to request simplified key-value format from the API.
 
+## JSON-LD @context
+
+GeonicDB compacts a response using **only the `@context` that the request itself supplied**, and renders anything it cannot map as a fully qualified URI (ETSI GS CIM 009 [clause 5.5.5 / 5.5.7](https://cim.etsi.org/NGSI-LD/official/clause-5.html)). Read an entity written with a custom vocabulary and you get absolute URIs back:
+
+```bash
+$ geonic entities get urn:ngsi-ld:Building:v1
+{
+  "id": "urn:ngsi-ld:Building:v1",
+  "type": "https://example-vocab/ns#Building",
+  "https://example-vocab/ns#name": { "type": "Property", "value": "HQ" }
+}
+```
+
+Pass `--context` to get the short terms back:
+
+```bash
+$ geonic entities get urn:ngsi-ld:Building:v1 --context https://example.org/building.jsonld
+{
+  "id": "urn:ngsi-ld:Building:v1",
+  "type": "Building",
+  "name": { "type": "Property", "value": "HQ" }
+}
+```
+
+- Works on every NGSI-LD command — `entities`, `attrs`, `types`, `temporal`, `batch`, `subscriptions`, `registrations`, `snapshots`.
+- On reads it is sent as a `Link` header; on entity and batch writes it is placed in the request body, so the same flag also lets you **write** with a custom vocabulary.
+- Repeat the flag or separate values with commas for a context array:
+  `--context https://a.example/1.jsonld --context https://b.example/2.jsonld`.
+  Note that GeonicDB currently applies only the first one ([geolonia/geonicdb#1818](https://github.com/geolonia/geonicdb/issues/1818)); the CLI warns on stderr when you pass more.
+- Save a per-profile default so you do not have to repeat it:
+
+```bash
+geonic config set context https://example.org/building.jsonld
+geonic entities get urn:ngsi-ld:Building:v1        # uses the saved context
+```
+
+`--context` on a command **replaces** the saved default for that invocation rather than adding to it.
+
+The URI must be an absolute `http`/`https` URL that the server can resolve — either publicly reachable or registered with the tenant via `POST /ngsi-ld/v1/jsonldContexts`. An unresolvable context makes the server return `504 LdContextNotAvailable` instead of quietly falling back.
+
 ## Dry Run
 
 Use `--dry-run` on any command to print the equivalent `curl` command instead of executing the request. The output can be copied and run directly in a terminal.
@@ -775,6 +816,9 @@ geonic config set url http://localhost:3000
 
 # Set default output format
 geonic config set format table
+
+# Set a default JSON-LD @context for NGSI-LD requests (comma-separate for several)
+geonic config set context https://example.org/building.jsonld
 
 # View all settings
 geonic config list

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@types/node": "^22.13.0",
         "@vitest/coverage-v8": "^4.1.8",
         "eslint": "^10.8.0",
-        "geonicdb": "github:geolonia/geonicdb#19ee77a428e3f2288ef51c3665d78d104d6ec82a",
+        "geonicdb": "github:geolonia/geonicdb#475a758969976cdcf97d9015063617cd69c6c2f5",
         "mongodb": "^7.1.0",
         "mongodb-memory-server": "^11.0.1",
         "prettier": "^3.4.2",
@@ -66,18 +66,18 @@
       }
     },
     "node_modules/@aws-sdk/client-apigatewaymanagementapi": {
-      "version": "3.1095.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-apigatewaymanagementapi/-/client-apigatewaymanagementapi-3.1095.0.tgz",
-      "integrity": "sha512-tPLLSUa2huKWlNLLorWNSNLzxp5uiQbEQ/bOKrGeslu5W2fyDdHdKc09DIYFFbrsL2LoXLqAG85+XllJwytTCg==",
+      "version": "3.1103.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-apigatewaymanagementapi/-/client-apigatewaymanagementapi-3.1103.0.tgz",
+      "integrity": "sha512-dkFlzGKsn11rfdnbKPdWGqt99GD6kUF/BCOeyTHtPufVieKKy9QyjXhMVbl4ozo+qNxYPLQ7U391ag39z/OtcA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
-        "@aws-sdk/credential-provider-node": "^3.972.72",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/credential-provider-node": "^3.972.78",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
-        "@smithy/fetch-http-handler": "^5.6.10",
-        "@smithy/node-http-handler": "^4.9.10",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -86,18 +86,18 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudtrail": {
-      "version": "3.1095.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudtrail/-/client-cloudtrail-3.1095.0.tgz",
-      "integrity": "sha512-ijm4PrjosarWN0Eg9q0dUlBP9YU4dNzHgQtqhyTgNlI5allbnmWrA2G9NR4BeHewoqvR+s7ib9fO+Qsrw66YYA==",
+      "version": "3.1103.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudtrail/-/client-cloudtrail-3.1103.0.tgz",
+      "integrity": "sha512-s6w3uHT8EZ9c+URSh1YYRQvm2Cv/ZRyjlOuyjzZfStYQxfS6lk9FMpdXRXR4kRVsv/VwNZrFV4aR/ZnNMX7hJw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
-        "@aws-sdk/credential-provider-node": "^3.972.72",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/credential-provider-node": "^3.972.78",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
-        "@smithy/fetch-http-handler": "^5.6.10",
-        "@smithy/node-http-handler": "^4.9.10",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -106,20 +106,20 @@
       }
     },
     "node_modules/@aws-sdk/client-dynamodb": {
-      "version": "3.1095.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1095.0.tgz",
-      "integrity": "sha512-b1Y9NW5U1mOpkmLMnjZeUCo5FchTYfE3ththqXX6MA0beHpDwPydm5UPCJ0gcyHGvlPEYCU7NwANZwGHy+zCzA==",
+      "version": "3.1103.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1103.0.tgz",
+      "integrity": "sha512-9qN3H5DJYA1TA7vI5RGI6v2yLWpxcWyJQZuAK1LyVH8HaZoVLVof0MHZL/3PfjIW/KFaHHu8EC5kxT7EVjHooQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
-        "@aws-sdk/credential-provider-node": "^3.972.72",
-        "@aws-sdk/dynamodb-codec": "^3.973.35",
-        "@aws-sdk/middleware-endpoint-discovery": "^3.972.26",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/credential-provider-node": "^3.972.78",
+        "@aws-sdk/dynamodb-codec": "^3.973.41",
+        "@aws-sdk/middleware-endpoint-discovery": "^3.972.27",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
-        "@smithy/fetch-http-handler": "^5.6.10",
-        "@smithy/node-http-handler": "^4.9.10",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -128,19 +128,19 @@
       }
     },
     "node_modules/@aws-sdk/client-eventbridge": {
-      "version": "3.1095.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-eventbridge/-/client-eventbridge-3.1095.0.tgz",
-      "integrity": "sha512-qZ3G3aD9C5EP4wYSSRXvaUsI1jPkTKarUYRgXkg93gUF58Rmdp/ijJY3slFdH8uoJ7V0vop91G78Z41Rim+X5Q==",
+      "version": "3.1103.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-eventbridge/-/client-eventbridge-3.1103.0.tgz",
+      "integrity": "sha512-65yVqtIrJxnW6Lr/9UFsOheTBHlsnvE7xqrEZsVI5JI7T3jo+/8t1r28C23wVmTO+URX0tvWBaMzMiwbk2RGnA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
-        "@aws-sdk/credential-provider-node": "^3.972.72",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.42",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/credential-provider-node": "^3.972.78",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.43",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
-        "@smithy/fetch-http-handler": "^5.6.10",
-        "@smithy/node-http-handler": "^4.9.10",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -149,18 +149,18 @@
       }
     },
     "node_modules/@aws-sdk/client-kms": {
-      "version": "3.1095.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.1095.0.tgz",
-      "integrity": "sha512-inNKi30hcvb/pQtS6Of4vDbWE4qWjTQx00G8H70ID565762qpBm9HZk6OVB13WCUvnORUnLqgPSad+ebrEVb5Q==",
+      "version": "3.1103.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.1103.0.tgz",
+      "integrity": "sha512-gYdlyiASPS3Zu9a9jpJlKfEw3FGD4CB8lnuvUTpio1xmboltQjbnaTZ7JR12raiPcv51ODFfES1sUT+QXu3+Fw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
-        "@aws-sdk/credential-provider-node": "^3.972.72",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/credential-provider-node": "^3.972.78",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
-        "@smithy/fetch-http-handler": "^5.6.10",
-        "@smithy/node-http-handler": "^4.9.10",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -169,18 +169,18 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.1095.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1095.0.tgz",
-      "integrity": "sha512-CiBryu8nC+8PVx72ybrxIPLOMoGLW0hGMWMvgqBWm8ZYOeE+w+c7HcLsuLhEiPzKMON8Xng0lPKCIm1ANWsv+Q==",
+      "version": "3.1103.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1103.0.tgz",
+      "integrity": "sha512-LHX7O/50macEHNZdN776FfuU83BlP0fhRrB2TzzoLaJKVSuuFLnY3dUBPQmhejJDzG5vY9hXqoSVZUWDs6eydA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
-        "@aws-sdk/credential-provider-node": "^3.972.72",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/credential-provider-node": "^3.972.78",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
-        "@smithy/fetch-http-handler": "^5.6.10",
-        "@smithy/node-http-handler": "^4.9.10",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -189,18 +189,18 @@
       }
     },
     "node_modules/@aws-sdk/client-sns": {
-      "version": "3.1095.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sns/-/client-sns-3.1095.0.tgz",
-      "integrity": "sha512-B97JUxfcu/bTyqti3FZipDdIlH4g+YZ90CdpXT99+h6hww9dK6JMwNBHfJVHvmrYTy+NtflQf7HNQweXowIysg==",
+      "version": "3.1103.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sns/-/client-sns-3.1103.0.tgz",
+      "integrity": "sha512-PAgNJwJWkZmcuPU4l1LqVBP7ZpFQmFLRNvKjIpaxsNV/orT2Qq6ehofRK64psvQbvaTwp1K8L1fi10wBSXbF8A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
-        "@aws-sdk/credential-provider-node": "^3.972.72",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/credential-provider-node": "^3.972.78",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
-        "@smithy/fetch-http-handler": "^5.6.10",
-        "@smithy/node-http-handler": "^4.9.10",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -209,19 +209,19 @@
       }
     },
     "node_modules/@aws-sdk/client-sqs": {
-      "version": "3.1095.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.1095.0.tgz",
-      "integrity": "sha512-E9kLDfzlBxwnu5GaV+zyUQP88EwbTMyKca6MatmIJAaxhl12Yml7uDQaFxtSMLxNVEWP4oqFrByR8PZQJGTUKw==",
+      "version": "3.1103.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.1103.0.tgz",
+      "integrity": "sha512-KuVv3mY/X1uQsHoCpd7vrRFFvucrMn2KfLmsQ4w61ayafLIt2UoRd5cokfnJvleJRo7fG7GjKYBhgF5bTKQkrQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
-        "@aws-sdk/credential-provider-node": "^3.972.72",
-        "@aws-sdk/middleware-sdk-sqs": "^3.972.38",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/credential-provider-node": "^3.972.78",
+        "@aws-sdk/middleware-sdk-sqs": "^3.972.39",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
-        "@smithy/fetch-http-handler": "^5.6.10",
-        "@smithy/node-http-handler": "^4.9.10",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -230,17 +230,17 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.977.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.1.tgz",
-      "integrity": "sha512-KVtQRtc00ES/y+Sc3vYXeP6pCIcNlBJCZOwvqSy8ZpVGmbM5+IG+AfhuTKQ2oXmIVqZJewaGMMpzPkywC6xg0w==",
+      "version": "3.977.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.6.tgz",
+      "integrity": "sha512-QiaJV4/zDrB4ZY2mfeSXSzSTc36W16sZXcGz+SPFk0CJ26gziO0cS+4LjJUMAbdeeBOvS0k0Aq1cZpfGdUXxSw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.974.2",
         "@aws-sdk/xml-builder": "^3.972.37",
         "@aws/lambda-invoke-store": "^0.3.0",
-        "@smithy/core": "^3.29.8",
-        "@smithy/signature-v4": "^5.6.9",
+        "@smithy/core": "^3.31.1",
+        "@smithy/signature-v4": "^5.6.12",
         "@smithy/types": "^4.16.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
@@ -250,15 +250,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.61",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.61.tgz",
-      "integrity": "sha512-qihs2ekMb89Nxd2JenCgVFhjbkb3EIo7HEBCBzyZACKVJdrLUZBLOmAE3xr0Sayml8n/jZSzwO/IufIiIzO7PQ==",
+      "version": "3.972.67",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.67.tgz",
+      "integrity": "sha512-rcIpk5kxUqDaaNa6Xk23pQ6ViY7jlqzmfFWCahQcBT97ddXaXYYwzCen9Tz1Jvo6aJft6wDl5bN44/Jw5B4oLA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/core": "^3.977.6",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -267,17 +267,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.63",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.63.tgz",
-      "integrity": "sha512-yfozsS8wkWZEi/n6IsrodcFKBWZ0iNAezhJbTReMNc0z1Px17qdeAeuL1/wziCAmCZyXiW7QzP75ggJkBQv8jQ==",
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.69.tgz",
+      "integrity": "sha512-nggwJtZ4eeNsUw5IeWBMXsi1ryct5idi0K+/SCRF3kybLubOMaNTb3XCihXpWMiVpyzyPeIrl0zTkzhBH9porA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/core": "^3.977.6",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
-        "@smithy/fetch-http-handler": "^5.6.10",
-        "@smithy/node-http-handler": "^4.9.10",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -286,23 +286,23 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.973.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.6.tgz",
-      "integrity": "sha512-jGLTW1bj148GL/6/IMlfY2fMYS9FtHOG+NahkFD4y0qkzYudNUahelxryY68/HGMslYuHClk1XaS/3b3eJzEkg==",
+      "version": "3.973.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.12.tgz",
+      "integrity": "sha512-pNEf/OeyN5X3VmLKlgSO6TqaWmW10CvI3TfwL1XhsuhYjSLT2VDaxFnCPHnOeQXSaFisMX4jNhpETriqN8DOmg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
-        "@aws-sdk/credential-provider-env": "^3.972.61",
-        "@aws-sdk/credential-provider-http": "^3.972.63",
-        "@aws-sdk/credential-provider-login": "^3.972.68",
-        "@aws-sdk/credential-provider-process": "^3.972.61",
-        "@aws-sdk/credential-provider-sso": "^3.973.5",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.67",
-        "@aws-sdk/nested-clients": "^3.997.35",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/credential-provider-env": "^3.972.67",
+        "@aws-sdk/credential-provider-http": "^3.972.69",
+        "@aws-sdk/credential-provider-login": "^3.972.74",
+        "@aws-sdk/credential-provider-process": "^3.972.67",
+        "@aws-sdk/credential-provider-sso": "^3.973.11",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.73",
+        "@aws-sdk/nested-clients": "^3.997.41",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
-        "@smithy/credential-provider-imds": "^4.4.13",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -311,16 +311,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.68",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.68.tgz",
-      "integrity": "sha512-w6tNci6g7RqFpLhj1f5xseBvaNojb4Pkgp5Jp5apl9hrJtaf2AA+rX9+qlhlWUK6kcyAFYPA7emO+55zj+S98Q==",
+      "version": "3.972.74",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.74.tgz",
+      "integrity": "sha512-0AQfDcf99TNmqVKv0owHrw/TQs6i4ZE5t9qmz6NvO53bE/sA/tpXhXL9AAcEP1qHc6Zzjd1UMb69+/9zdhvY3g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
-        "@aws-sdk/nested-clients": "^3.997.35",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -329,21 +329,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.72",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.72.tgz",
-      "integrity": "sha512-blQ7F5QGzylnzeh5549zQLoCAiMHkXFLjFovEMaVy4b2X8JhUu+u9NXro1hyK95YHdVFNmBHKs2hIHtZchxKlQ==",
+      "version": "3.972.78",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.78.tgz",
+      "integrity": "sha512-OgPAnfvbGAMWac6yvxJ1ihslrvDpPVwR68D2csospdNCCyPvHk9JLzYKwz48SNiS1T2znDwHauywRKRFfpyYng==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.61",
-        "@aws-sdk/credential-provider-http": "^3.972.63",
-        "@aws-sdk/credential-provider-ini": "^3.973.6",
-        "@aws-sdk/credential-provider-process": "^3.972.61",
-        "@aws-sdk/credential-provider-sso": "^3.973.5",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.67",
+        "@aws-sdk/credential-provider-env": "^3.972.67",
+        "@aws-sdk/credential-provider-http": "^3.972.69",
+        "@aws-sdk/credential-provider-ini": "^3.973.12",
+        "@aws-sdk/credential-provider-process": "^3.972.67",
+        "@aws-sdk/credential-provider-sso": "^3.973.11",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.73",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
-        "@smithy/credential-provider-imds": "^4.4.13",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -352,15 +352,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.61",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.61.tgz",
-      "integrity": "sha512-xzRuj+fUVO4nkafKQJVKAF97kGpeQbfjuwmRrtGZNf42/1dkmcz6o7dswBy7alY0htQn5sCL1GWQYEykviWZkA==",
+      "version": "3.972.67",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.67.tgz",
+      "integrity": "sha512-IlUEejorGTWKb4/Dm7K5Yw4QxUmXLThLhrvBmzVBqZFTbW72cv9LTcITmo1dsnYriALE4h68mOq4LB99x6sQ7Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/core": "^3.977.6",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -369,17 +369,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.973.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.5.tgz",
-      "integrity": "sha512-fZRjjWhLFelsDoOYjqShQTrIGYC3Pf9Mx9Czf+1ikfQDgktxjze33dVo1q1/ZQ+T0qbtejVoHNHrfD5aJVpv/w==",
+      "version": "3.973.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.11.tgz",
+      "integrity": "sha512-gAQBkBZxUB84d71+pPcI9L+jh2ujhuAVxc/4FgGiWFDjkPBlMKxzd5XDtkSXTFX8Ro7ansnT88+XadasxMeCRw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
-        "@aws-sdk/nested-clients": "^3.997.35",
-        "@aws-sdk/token-providers": "3.1095.0",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
+        "@aws-sdk/token-providers": "3.1103.0",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -388,16 +388,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.67",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.67.tgz",
-      "integrity": "sha512-FTNZ05gkPBA6CKbU3N4zPgybV+stdazwMOya75CmGdcJL7p8Fw/BdHP8WVxJd0mvzyPK2cg/C3gli58Ir4HgCw==",
+      "version": "3.972.73",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.73.tgz",
+      "integrity": "sha512-SnlEmQa6SjOgs6iOPLUQl1Eyq4AKiAdPQlkOhFhqNfDtDCwibMGvL6QlkSmf3o6vAUSImzdPCxowT5dfQUZP1A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
-        "@aws-sdk/nested-clients": "^3.997.35",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -406,14 +406,14 @@
       }
     },
     "node_modules/@aws-sdk/dynamodb-codec": {
-      "version": "3.973.35",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.35.tgz",
-      "integrity": "sha512-h4l4YbioeEW2vM4OkelGkQ+pboFnTEaRAt8uH/b6oklm0p3NhISHXdbTk8x3/UOvLUNW+5ItU+B5JHTP9QfJBw==",
+      "version": "3.973.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.41.tgz",
+      "integrity": "sha512-N4go/LzYFd6KJ+r7qqAjzmsw85PFN99RnDYZvw22FzU3VZgL5+umvncfu0M7hlzeIUKHSLL65HTJIXiLY7RJFg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
-        "@smithy/core": "^3.29.8",
+        "@aws-sdk/core": "^3.977.6",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -436,15 +436,15 @@
       }
     },
     "node_modules/@aws-sdk/lib-dynamodb": {
-      "version": "3.1095.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.1095.0.tgz",
-      "integrity": "sha512-Lx/d3Ou5KL/JttC1JSWA9fkvkVvFYwiVLnvvXCaHaW3AeUkgMcF8K3dCRWtbM9xW40hXdD3catwisgYXEfmbxQ==",
+      "version": "3.1103.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.1103.0.tgz",
+      "integrity": "sha512-PKjLHIbm5LTeltTPNqSQZOEm9kGq2IMG6hej2TSblYH6S5gbNhceRyJajkPln8kMKjzCfmf4i4fupn1WCjwOlQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/core": "^3.977.6",
         "@aws-sdk/util-dynamodb": "^3.996.7",
-        "@smithy/core": "^3.29.8",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -452,19 +452,19 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-dynamodb": "^3.1095.0"
+        "@aws-sdk/client-dynamodb": "^3.1103.0"
       }
     },
     "node_modules/@aws-sdk/middleware-endpoint-discovery": {
-      "version": "3.972.26",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.26.tgz",
-      "integrity": "sha512-suOMAYAM43aSyC3cLBvvJIuNyg96nUsPvYQUrq4G+8Prt2qTpFETgaiXX7JP1gIcK5FF0Z2IdyEsPXseZATOPw==",
+      "version": "3.972.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.27.tgz",
+      "integrity": "sha512-5AJlxrsg27IGGiQauWOdVyqK55EN0EMIwXndkVHhBiPT4CtdSaz89/sAENSw+GP4KF+BOWcgycZFNjkOLmfo1A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/endpoint-cache": "^3.972.9",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -473,14 +473,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-sqs": {
-      "version": "3.972.38",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.972.38.tgz",
-      "integrity": "sha512-izM6iWpd/s50WMcYOjLJfWm7McNiJKeit/NNUQ4JQIU0rBmNPMvf7AsJN7tk28N+afPYbpPIUSE3BNWZwtwf8w==",
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.972.39.tgz",
+      "integrity": "sha512-dlKLmJg1dLQVfFXUPS+f+SqXrRGHDVumY4gjM8sCLGao+zkDXEu8TObTyiaheKjT20ruok9Xs8oLocNItKQ0fw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -489,18 +489,18 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.35",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.35.tgz",
-      "integrity": "sha512-2MJfseVG/aXvIyOIBlYA/Oaf6qFDdsu4D8RKsEUdOQpVuLaor0BdxIBBtJLBNQQEe6Ku3YMvLljwb1MwVUpzRw==",
+      "version": "3.997.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.41.tgz",
+      "integrity": "sha512-RDHqPGQWlF6tatA/Tp3rg6oIwtgN9IVderxE+9av2Y93Dfyu+mO1hZ5Bu2jpfZg2rwdNbsssnwM+sLafIczMlQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.42",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.43",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
-        "@smithy/fetch-http-handler": "^5.6.10",
-        "@smithy/node-http-handler": "^4.9.10",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -509,14 +509,14 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.42",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.42.tgz",
-      "integrity": "sha512-DBV4naZP6HYBlAvPpoQzOP12Wvfou/5rN8yJPXjBTBylU5qwCbh/tXr2MddHoIjgoRkEl/eS+IljiUqvmwey1Q==",
+      "version": "3.996.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.43.tgz",
+      "integrity": "sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/signature-v4": "^5.6.9",
+        "@smithy/signature-v4": "^5.6.12",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -525,16 +525,16 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1095.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1095.0.tgz",
-      "integrity": "sha512-65SudS6y4nzaYHybtqcpm3sHe5jLhdMn68HRKS1nUx690BtQeaAQOoujQ+dpOjBATIVGVgKKjEP8tR+U06QJQA==",
+      "version": "3.1103.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1103.0.tgz",
+      "integrity": "sha512-N4wy26MNn31ItGVHYHPrEuCIFY4MBBjC+C5v1lJKqIUSA7OZBdhleCY53zCCrXn27hsk7YNOaTuhQu807S4AfQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
-        "@aws-sdk/nested-clients": "^3.997.35",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -1604,9 +1604,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.11.tgz",
-      "integrity": "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
+      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1732,13 +1732,13 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -1773,9 +1773,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1836,9 +1836,9 @@
       }
     },
     "node_modules/@opentelemetry/api-logs": {
-      "version": "0.220.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.220.0.tgz",
-      "integrity": "sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==",
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.221.0.tgz",
+      "integrity": "sha512-OlanaW1vv7ufTqQ3/fPLI4arGt5ZoM+P8abOMki6uEYnpRazepSWDwDnnw+la7kE26SHVC18//SMccrDvLKOXQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2099,13 +2099,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation": {
-      "version": "0.220.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.220.0.tgz",
-      "integrity": "sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==",
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.221.0.tgz",
+      "integrity": "sha512-cCk80Z/iRDf/5gfsKMB4f74LqVA5yKETB/9ojPzVW/6/f70iu89nJvGxsFCxx4XfSohaOofkU19kiYm84AiAlw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.220.0",
+        "@opentelemetry/api-logs": "0.221.0",
         "import-in-the-middle": "^3.0.0",
         "require-in-the-middle": "^8.0.0"
       },
@@ -2134,37 +2134,6 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/instrumentation-aws-sdk/node_modules/@opentelemetry/api-logs": {
-      "version": "0.221.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.221.0.tgz",
-      "integrity": "sha512-OlanaW1vv7ufTqQ3/fPLI4arGt5ZoM+P8abOMki6uEYnpRazepSWDwDnnw+la7kE26SHVC18//SMccrDvLKOXQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-aws-sdk/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.221.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.221.0.tgz",
-      "integrity": "sha512-cCk80Z/iRDf/5gfsKMB4f74LqVA5yKETB/9ojPzVW/6/f70iu89nJvGxsFCxx4XfSohaOofkU19kiYm84AiAlw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.221.0",
-        "import-in-the-middle": "^3.0.0",
-        "require-in-the-middle": "^8.0.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
     "node_modules/@opentelemetry/instrumentation-http": {
       "version": "0.221.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.221.0.tgz",
@@ -2184,45 +2153,14 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/api-logs": {
-      "version": "0.221.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.221.0.tgz",
-      "integrity": "sha512-OlanaW1vv7ufTqQ3/fPLI4arGt5ZoM+P8abOMki6uEYnpRazepSWDwDnnw+la7kE26SHVC18//SMccrDvLKOXQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.221.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.221.0.tgz",
-      "integrity": "sha512-cCk80Z/iRDf/5gfsKMB4f74LqVA5yKETB/9ojPzVW/6/f70iu89nJvGxsFCxx4XfSohaOofkU19kiYm84AiAlw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.221.0",
-        "import-in-the-middle": "^3.0.0",
-        "require-in-the-middle": "^8.0.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
     "node_modules/@opentelemetry/instrumentation-mongodb": {
-      "version": "0.73.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.73.0.tgz",
-      "integrity": "sha512-M61+VpaXaLj7euluV+jARBo62tBWrpubSUPIZMpUnjOM90nqCQCj8gpyhDP1rVgzQt2LoTIzcdWnKq/DEkzMog==",
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.74.0.tgz",
+      "integrity": "sha512-GRnHu69YLQUYgguuYkKi6wpizMY4r7gLC08rSq8cg41p6t7+1YIy5nXoGC61NA7KCZUE9jbcDnzd45i32IblZg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.220.0",
+        "@opentelemetry/instrumentation": "^0.221.0",
         "@opentelemetry/semantic-conventions": "^1.33.0"
       },
       "engines": {
@@ -2233,14 +2171,14 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-undici": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.30.0.tgz",
-      "integrity": "sha512-VgxMzeR14uPEVqEC5b55m4KijEe+gQAgJ4jjWCE7h5i2Q76nS4y7OWDk8V+XkD4zK9bbJyWEK+a2DqtGP/fCuw==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.31.0.tgz",
+      "integrity": "sha512-qunCfgSFV+bjRdAYkWIjVX38jIN/Xj80CiERXXdzYAmdigCFvJPB3AY3j43bjJlkhgbJJSCGdbvQUSut8QIiyQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.220.0",
+        "@opentelemetry/core": "^2.9.0",
+        "@opentelemetry/instrumentation": "^0.221.0",
         "@opentelemetry/semantic-conventions": "^1.24.0"
       },
       "engines": {
@@ -2305,19 +2243,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/api-logs": {
-      "version": "0.221.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.221.0.tgz",
-      "integrity": "sha512-OlanaW1vv7ufTqQ3/fPLI4arGt5ZoM+P8abOMki6uEYnpRazepSWDwDnnw+la7kE26SHVC18//SMccrDvLKOXQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/@opentelemetry/propagator-b3": {
@@ -2388,19 +2313,6 @@
         "@opentelemetry/api": ">=1.4.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/api-logs": {
-      "version": "0.221.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.221.0.tgz",
-      "integrity": "sha512-OlanaW1vv7ufTqQ3/fPLI4arGt5ZoM+P8abOMki6uEYnpRazepSWDwDnnw+la7kE26SHVC18//SMccrDvLKOXQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/@opentelemetry/sdk-metrics": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.10.0.tgz",
@@ -2458,37 +2370,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/api-logs": {
-      "version": "0.221.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.221.0.tgz",
-      "integrity": "sha512-OlanaW1vv7ufTqQ3/fPLI4arGt5ZoM+P8abOMki6uEYnpRazepSWDwDnnw+la7kE26SHVC18//SMccrDvLKOXQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.221.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.221.0.tgz",
-      "integrity": "sha512-cCk80Z/iRDf/5gfsKMB4f74LqVA5yKETB/9ojPzVW/6/f70iu89nJvGxsFCxx4XfSohaOofkU19kiYm84AiAlw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.221.0",
-        "import-in-the-middle": "^3.0.0",
-        "require-in-the-middle": "^8.0.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/sdk-trace": {
@@ -3247,9 +3128,9 @@
       ]
     },
     "node_modules/@smithy/core": {
-      "version": "3.30.0",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.30.0.tgz",
-      "integrity": "sha512-dl2yRglDxfzH9uJ4fSo4zTaAHa0zH7+V7BZMRWy8hEYIKT1BiqMUK/CN6T3ADQ3kbA5N1tmUulroJ2UtONS7Kw==",
+      "version": "3.31.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.31.1.tgz",
+      "integrity": "sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3261,13 +3142,13 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.4.14",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.14.tgz",
-      "integrity": "sha512-QgbuahIb2qxQeZQvNK0sw3aF3JH5zwH8j2lLp5DUasVXexGGMWULAR+7z0omPXFolCP/m5wN9M5lm9EGdSviTQ==",
+      "version": "4.4.16",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.16.tgz",
+      "integrity": "sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.30.0",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -3276,13 +3157,13 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.6.11",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.11.tgz",
-      "integrity": "sha512-o0Zkj1nKqJAoq+a+BrkhU39tRftMNjLwpc/z06Frfl43wpbHrJMaSAVZE4vTqlxtVkNaGaT0bIDxOp7tkFTuQQ==",
+      "version": "5.6.13",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.13.tgz",
+      "integrity": "sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.30.0",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -3291,13 +3172,13 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.9.11",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.11.tgz",
-      "integrity": "sha512-slbzbz8taEOzoXv/9y34YNBoE+ZHmddLykCgjDAjvMAsu2nM5s2Gzwa5OGF721tD8s+CKeFUBds5lSj9lcbuDg==",
+      "version": "4.9.13",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.13.tgz",
+      "integrity": "sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.30.0",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -3306,13 +3187,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.6.10",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.10.tgz",
-      "integrity": "sha512-EXhWePm3SXJAX38npIy4TXL2Aex/OVgCClTjelN2QHw/U+8CQUH8C7AaxsVzQcYieYPseywn48s89DmvuGjiAg==",
+      "version": "5.6.12",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.12.tgz",
+      "integrity": "sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.30.0",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -3924,9 +3805,9 @@
       }
     },
     "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5072,9 +4953,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
-      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5136,12 +5017,13 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
-      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "debug": "^4.4.3",
         "ip-address": "^10.2.0"
       },
       "engines": {
@@ -5197,9 +5079,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -5447,31 +5329,31 @@
       }
     },
     "node_modules/geonicdb": {
-      "version": "0.15.0",
-      "resolved": "git+ssh://git@github.com/geolonia/geonicdb.git#19ee77a428e3f2288ef51c3665d78d104d6ec82a",
-      "integrity": "sha512-eDwvozoud3QKPsY69tNbleGuEF1SaJ/mNERf5ZNCMezoNLdPtr40ultqtav1q7eF1Dus3nGgdWudSckAg3fJNw==",
+      "version": "0.16.0",
+      "resolved": "git+ssh://git@github.com/geolonia/geonicdb.git#475a758969976cdcf97d9015063617cd69c6c2f5",
+      "integrity": "sha512-1KoU+JRGPHsv5j+z5EvJ1iS6CLV0zJ+mdTt5YJGs2eL1aoIz5oTNiTBroEpBn8x0K2tmEDnBKHjY5cDtHoePpQ==",
       "dev": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@a2a-js/sdk": "^0.3.14",
-        "@aws-sdk/client-apigatewaymanagementapi": "^3.1095.0",
-        "@aws-sdk/client-cloudtrail": "^3.1095.0",
-        "@aws-sdk/client-dynamodb": "^3.1095.0",
-        "@aws-sdk/client-eventbridge": "^3.1095.0",
-        "@aws-sdk/client-kms": "^3.1095.0",
-        "@aws-sdk/client-secrets-manager": "^3.1095.0",
-        "@aws-sdk/client-sns": "^3.1095.0",
-        "@aws-sdk/client-sqs": "^3.1095.0",
-        "@aws-sdk/lib-dynamodb": "^3.1095.0",
+        "@aws-sdk/client-apigatewaymanagementapi": "^3.1100.0",
+        "@aws-sdk/client-cloudtrail": "^3.1100.0",
+        "@aws-sdk/client-dynamodb": "^3.1100.0",
+        "@aws-sdk/client-eventbridge": "^3.1100.0",
+        "@aws-sdk/client-kms": "^3.1100.0",
+        "@aws-sdk/client-secrets-manager": "^3.1100.0",
+        "@aws-sdk/client-sns": "^3.1100.0",
+        "@aws-sdk/client-sqs": "^3.1100.0",
+        "@aws-sdk/lib-dynamodb": "^3.1100.0",
         "@marcbachmann/cel-js": "^7.6.1",
-        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/context-async-hooks": "^2.9.0",
         "@opentelemetry/exporter-trace-otlp-http": "^0.221.0",
         "@opentelemetry/instrumentation-aws-sdk": "^0.76.0",
         "@opentelemetry/instrumentation-http": "^0.221.0",
-        "@opentelemetry/instrumentation-mongodb": "^0.73.0",
-        "@opentelemetry/instrumentation-undici": "^0.30.0",
+        "@opentelemetry/instrumentation-mongodb": "^0.74.0",
+        "@opentelemetry/instrumentation-undici": "^0.31.0",
         "@opentelemetry/resources": "^2.9.0",
         "@opentelemetry/sdk-node": "^0.221.0",
         "@opentelemetry/sdk-trace-base": "^2.10.0",
@@ -5481,7 +5363,7 @@
         "js-yaml": "^5.2.3",
         "mongodb": "^7.5.0",
         "mqtt": "^5.15.1",
-        "proj4": "^2.20.9",
+        "proj4": "^2.21.0",
         "ws": "^8.21.1",
         "zod": "^4.4.3"
       },
@@ -5679,9 +5561,9 @@
       "license": "MIT"
     },
     "node_modules/hono": {
-      "version": "4.12.31",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
-      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
+      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6042,9 +5924,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
-      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
+      "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -7496,9 +7378,9 @@
       }
     },
     "node_modules/proj4": {
-      "version": "2.20.9",
-      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.20.9.tgz",
-      "integrity": "sha512-GLBGqXaTcdWnppre3o1sMmy4DcMGSGq/ng+9k2MTNddarRK6SveINqlqYzi3xEXuy06ljY1TTrC6H9C4f360IQ==",
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.21.0.tgz",
+      "integrity": "sha512-33HfDftqw8kY+Cl1dcL16SJuqTSzYxmz4re7Nmhk+fs1/N1fFrAkkF579msQTR/4fLeJVSNne8/gpoCz0fk1uw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9085,9 +8967,9 @@
       }
     },
     "node_modules/wkt-parser": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.5.5.tgz",
-      "integrity": "sha512-/zMYi94/7D7fxcOSlVmWn6vnOMj3Gq5d1xvVjaYOS9n6h0qOJ4I7YYVxBWYcH1vq9+suhqzXkn05Yx47zQNUIA==",
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.5.6.tgz",
+      "integrity": "sha512-cqHU3lzGt/gt2OqIORP0uVy5yeOX43WABmgFkmJsmcqH3HhQo9PiJG6ftytwGKmpQUbegeX7+pQc2BuNCRfcrw==",
       "dev": true,
       "license": "MIT",
       "funding": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@types/node": "^22.13.0",
     "@vitest/coverage-v8": "^4.1.8",
     "eslint": "^10.8.0",
-    "geonicdb": "github:geolonia/geonicdb#19ee77a428e3f2288ef51c3665d78d104d6ec82a",
+    "geonicdb": "github:geolonia/geonicdb#475a758969976cdcf97d9015063617cd69c6c2f5",
     "mongodb": "^7.1.0",
     "mongodb-memory-server": "^11.0.1",
     "prettier": "^3.4.2",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,7 @@ import { registerHealthCommand, registerVersionCommand } from "./commands/health
 import { enforceKnownCommandHelp, registerHelpCommand } from "./commands/help.js";
 import { registerCliCommand } from "./commands/cli.js";
 import { addAttrsSubcommands } from "./commands/attrs.js";
+import { collectContext } from "./context.js";
 
 export function createProgram(): Command {
   const require = createRequire(import.meta.url);
@@ -33,6 +34,11 @@ export function createProgram(): Command {
     .option("--token <token>", "Authentication token")
     .option("-p, --profile <name>", "Use a named profile")
     .option("--api-key <key>", "API key for authentication")
+    .option(
+      "--context <uri>",
+      "JSON-LD @context URI for NGSI-LD requests (repeatable, or comma-separated)",
+      collectContext,
+    )
     .option("-f, --format <fmt>", "Output format: json, table, geojson")
     .option("--no-color", "Disable color output")
     .option("-v, --verbose", "Verbose output")

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,6 +1,7 @@
 import type { ClientOptions, ClientResponse, NgsiError } from "./types.js";
 import { clientCredentialsGrant } from "./oauth.js";
 import { getTokenStatus } from "./token.js";
+import { buildContextLinkHeader, toBodyContext } from "./context.js";
 
 /**
  * NGSI-LD core @context. Injected into `application/ld+json` entity-write bodies
@@ -28,6 +29,7 @@ export class GdbClient {
   private onBeforeRefresh?: () => { token?: string; refreshToken?: string };
   private verbose: boolean;
   private dryRun: boolean;
+  private context?: string[];
   private refreshPromise?: Promise<boolean>;
 
   constructor(options: ClientOptions) {
@@ -42,14 +44,24 @@ export class GdbClient {
     this.onBeforeRefresh = options.onBeforeRefresh;
     this.verbose = options.verbose ?? false;
     this.dryRun = options.dryRun ?? false;
+    this.context = options.context && options.context.length > 0 ? options.context : undefined;
   }
 
-  private buildHeaders(extra?: Record<string, string>): Record<string, string> {
+  private buildHeaders(
+    extra?: Record<string, string>,
+    options?: { contextLink?: boolean },
+  ): Record<string, string> {
     const headers: Record<string, string> = {};
 
     headers["Content-Type"] = "application/ld+json";
     headers["Accept"] = "application/ld+json";
     if (this.service) headers["NGSILD-Tenant"] = this.service;
+    // #177: reads carry the JSON-LD @context in a Link header — it is the only
+    // channel a GET has, and the server compacts the response using exactly the
+    // context the request supplied (ETSI GS CIM 009 clause 5.5.7).
+    if (options?.contextLink && this.context) {
+      headers["Link"] = buildContextLinkHeader(this.context);
+    }
 
     if (this.token) {
       headers["Authorization"] = `Bearer ${this.token}`;
@@ -299,6 +311,61 @@ export class GdbClient {
     return { ...(body as Record<string, unknown>), "@context": NGSI_LD_CORE_CONTEXT };
   }
 
+  /**
+   * Batch endpoints whose body is an array of entity objects. Their `@context`
+   * lives on each element, not on the request: the server reads it per entity
+   * (`attachContextRef` in geonicdb's batch controller). `entityOperations/delete`
+   * is excluded because its array holds ID strings, and `entityOperations/query`
+   * because its body is a Query object — the Link header carries the context there.
+   */
+  private static readonly ENTITY_ARRAY_WRITE_PATHS = [
+    "/entityOperations/create",
+    "/entityOperations/upsert",
+    "/entityOperations/update",
+    "/entityOperations/merge",
+  ];
+
+  /**
+   * #177: apply a user-supplied `--context` to entity-write bodies.
+   *
+   * Under `application/ld+json` — which this CLI always sends — the server takes
+   * the `@context` from the **body** and ignores the Link header
+   * (`extractContextRef`, ETSI GS CIM 009 clause 6.3.5). Without this, `--context`
+   * would be accepted on a write and then silently do nothing, which is the same
+   * class of quiet failure this flag exists to remove.
+   *
+   * Scope mirrors where the server actually reads a body `@context` for entity
+   * writes: `/entities...` (object body) and the batch endpoints listed above
+   * (per-element). A caller-supplied `@context` always wins — an explicit
+   * `@context` in the payload is a deliberate choice.
+   */
+  private applyContextToBody(resourcePath: string, body: unknown): unknown {
+    if (!this.context) return body;
+    const relative = resourcePath.slice(this.getBasePath().length);
+    const injected = toBodyContext(this.context);
+
+    if (relative.startsWith("/entities")) {
+      return GdbClient.withContext(body, injected);
+    }
+    if (GdbClient.ENTITY_ARRAY_WRITE_PATHS.includes(relative) && Array.isArray(body)) {
+      return body.map((entry) => GdbClient.withContext(entry, injected));
+    }
+    return body;
+  }
+
+  /** Add `@context` to a plain-object payload, leaving anything else untouched. */
+  private static withContext(body: unknown, context: string | string[]): unknown {
+    if (
+      body === null ||
+      typeof body !== "object" ||
+      Array.isArray(body) ||
+      "@context" in (body as Record<string, unknown>)
+    ) {
+      return body;
+    }
+    return { ...(body as Record<string, unknown>), "@context": context };
+  }
+
   private async executeRequest<T>(
     method: string,
     path: string,
@@ -309,10 +376,15 @@ export class GdbClient {
       signal?: AbortSignal;
     },
   ): Promise<ClientResponse<T>> {
-    const url = this.buildUrl(`${this.getBasePath()}${path}`, options?.params);
-    const headers = this.buildHeaders(options?.headers);
+    const resourcePath = `${this.getBasePath()}${path}`;
+    const url = this.buildUrl(resourcePath, options?.params);
+    // #177: NGSI-LD requests carry the @context; raw admin/auth paths never do.
+    const headers = this.buildHeaders(options?.headers, { contextLink: true });
     const injectedBody = options?.body
-      ? this.maybeInjectCoreContext(`${this.getBasePath()}${path}`, options.body)
+      ? this.maybeInjectCoreContext(
+          resourcePath,
+          this.applyContextToBody(resourcePath, options.body),
+        )
       : undefined;
     const body = injectedBody ? JSON.stringify(injectedBody) : undefined;
 

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -7,7 +7,8 @@ import {
   getConfigPath,
 } from "../config.js";
 import { printOutput, printSuccess, printInfo } from "../output.js";
-import { addExamples } from "./help.js";
+import { withErrorHandler } from "../helpers.js";
+import { addExamples, addNotes } from "./help.js";
 
 const SENSITIVE_CONFIG_KEYS = new Set(["token", "refreshToken", "apiKey"]);
 
@@ -21,18 +22,22 @@ export function registerConfigCommand(program: Command): void {
     .description("Save a config value")
     .argument(
       "<key>",
-      "Configuration key (url, service, token, refreshToken, format, apiKey)",
+      "Configuration key (url, service, token, refreshToken, format, apiKey, context)",
     )
     .argument("<value>", "Configuration value")
-    .action((...args: unknown[]) => {
-      const cmd = args[args.length - 1] as Command;
-      const key = args[0] as string;
-      const value = args[1] as string;
-      const profile = (cmd.optsWithGlobals() as { profile?: string }).profile;
-      setConfigValue(key, value, profile);
-      const display = SENSITIVE_CONFIG_KEYS.has(key) ? "***" : value;
-      printSuccess(`Set ${key} = ${display}`);
-    });
+    .action(
+      // Values are validated on save (url, context), so a rejection must surface
+      // as a clean error + exit 1 rather than an unhandled rejection stack trace.
+      withErrorHandler(async (...args: unknown[]) => {
+        const cmd = args[args.length - 1] as Command;
+        const key = args[0] as string;
+        const value = args[1] as string;
+        const profile = (cmd.optsWithGlobals() as { profile?: string }).profile;
+        setConfigValue(key, value, profile);
+        const display = SENSITIVE_CONFIG_KEYS.has(key) ? "***" : value;
+        printSuccess(`Set ${key} = ${display}`);
+      }),
+    );
 
   addExamples(set, [
     {
@@ -56,10 +61,26 @@ export function registerConfigCommand(program: Command): void {
       command: "geonic config set format table",
     },
     {
+      description: "Set a default JSON-LD @context for NGSI-LD requests",
+      command: "geonic config set context https://example.org/building.jsonld",
+    },
+    {
+      description: "Set several default @context URIs (comma-separated)",
+      command:
+        "geonic config set context https://example.org/a.jsonld,https://example.org/b.jsonld",
+    },
+    {
       description: "Set config for a specific profile",
       command:
         "geonic config set url https://staging.example.com --profile staging",
     },
+  ]);
+
+  addNotes(set, [
+    "context: default JSON-LD @context sent with NGSI-LD requests (stored as a list).",
+    "  Without it, responses are compacted with the NGSI-LD core context only, so",
+    "  custom vocabulary comes back as fully qualified URIs (ETSI GS CIM 009 5.5.7).",
+    "  `--context` on a command replaces this default for that invocation.",
   ]);
 
   const get = config

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,7 @@
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
+import { splitContextValues } from "./context.js";
 import type { GdbConfig, GdbConfigFile } from "./types.js";
 
 export function getConfigDir(): string {
@@ -121,6 +122,13 @@ export function setConfigValue(key: string, value: string, profileName?: string)
   const config = loadConfig(profileName);
   if (key === "url") {
     value = validateUrl(value);
+  }
+  // #177: `context` is a list, so store it as one. Validating here means a bad
+  // URI is rejected when it is saved instead of failing on every later request.
+  if (key === "context") {
+    (config as Record<string, unknown>)[key] = splitContextValues(value);
+    saveConfig(config, profileName);
+    return;
   }
   (config as Record<string, unknown>)[key] = value;
   saveConfig(config, profileName);

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,0 +1,120 @@
+import { InvalidArgumentError } from "commander";
+
+/**
+ * JSON-LD `@context` handling for NGSI-LD requests (#177).
+ *
+ * GeonicDB compacts a response using **only the `@context` that the request
+ * itself supplied** (ETSI GS CIM 009 clause 5.5.5 / 5.5.7, geolonia/geonicdb#1733).
+ * Terms that the supplied context does not map are rendered as Fully Qualified
+ * Names. A read that sends no context therefore gets core-context compaction
+ * only, so any custom vocabulary comes back as absolute URIs — which is exactly
+ * what `--context` exists to fix.
+ *
+ * https://cim.etsi.org/NGSI-LD/official/clause-5.html
+ */
+
+/** `rel` value that marks a Link header entry as a JSON-LD context (JSON-LD 1.1 6.1). */
+const JSON_LD_CONTEXT_REL = "http://www.w3.org/ns/json-ld#context";
+
+/**
+ * Characters that must never reach a Link header value. `<` / `>` / `"` would
+ * terminate the link-value or its parameters early, and CR/LF would split the
+ * request into forged headers. `new URL()` alone does not reject them (it
+ * percent-encodes some and preserves others), so screen the raw input instead
+ * of trusting normalization.
+ */
+// eslint-disable-next-line no-control-regex
+const FORBIDDEN_URI_CHARS = /[\u0000-\u0020\u007F<>"]/;
+
+/**
+ * Validate a single `--context` value and return it unchanged (trimmed).
+ *
+ * The string is deliberately NOT normalized through `new URL().toString()`:
+ * servers and clients compare `@context` URLs by exact string, and
+ * normalization silently rewrites values (e.g. `https://example.org` becomes
+ * `https://example.org/`), which would make the round-trip lie about what the
+ * user asked for.
+ */
+export function validateContextUri(value: string): string {
+  const uri = value.trim();
+  if (!uri) {
+    throw new InvalidArgumentError("@context URI must not be empty.");
+  }
+  if (FORBIDDEN_URI_CHARS.test(uri)) {
+    throw new InvalidArgumentError(
+      `Invalid @context URI: "${uri}". It must not contain whitespace, control characters, '<', '>' or '"'.`,
+    );
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(uri);
+  } catch {
+    throw new InvalidArgumentError(
+      `Invalid @context URI: "${uri}". It must be an absolute URL (e.g. https://example.org/ctx.jsonld).`,
+    );
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new InvalidArgumentError(
+      `Invalid @context URI: "${uri}". Only http:// and https:// URLs are supported — the server dereferences it.`,
+    );
+  }
+  return uri;
+}
+
+/**
+ * Split one raw `--context` occurrence into validated URIs.
+ * Commas separate entries so a single flag can carry a context array, matching
+ * how Link headers list multiple link-values (RFC 8288 3).
+ */
+export function splitContextValues(raw: string): string[] {
+  const parts = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  if (parts.length === 0) {
+    throw new InvalidArgumentError("@context URI must not be empty.");
+  }
+  return parts.map(validateContextUri);
+}
+
+/**
+ * Commander option parser for a repeatable `--context` flag.
+ * Accumulates across repeats and expands comma-separated values, so
+ * `--context a --context b` and `--context a,b` are equivalent.
+ */
+export function collectContext(raw: string, previous?: string[]): string[] {
+  return [...(previous ?? []), ...splitContextValues(raw)];
+}
+
+/**
+ * Coerce a persisted config value into a context list.
+ * Accepts an array (canonical) or a comma-separated string (hand-edited
+ * config files). Anything else is ignored rather than sent as garbage.
+ */
+export function normalizeContextConfigValue(value: unknown): string[] | undefined {
+  const raw = Array.isArray(value)
+    ? value.filter((v): v is string => typeof v === "string")
+    : typeof value === "string"
+      ? value.split(",")
+      : [];
+  const uris = raw.map((s) => s.trim()).filter((s) => s.length > 0);
+  return uris.length > 0 ? uris : undefined;
+}
+
+/**
+ * Build the `Link` header value carrying the JSON-LD contexts.
+ * Multiple contexts become multiple link-values in one header (RFC 8288 3).
+ */
+export function buildContextLinkHeader(contexts: string[]): string {
+  return contexts
+    .map((uri) => `<${uri}>; rel="${JSON_LD_CONTEXT_REL}"; type="application/ld+json"`)
+    .join(", ");
+}
+
+/**
+ * Shape the contexts for an `application/ld+json` request body: a bare string
+ * for one entry, an array for several — the two forms NGSI-LD accepts.
+ */
+export function toBodyContext(contexts: string[]): string | string[] {
+  return contexts.length === 1 ? contexts[0] : [...contexts];
+}

--- a/src/context.ts
+++ b/src/context.ts
@@ -90,6 +90,13 @@ export function collectContext(raw: string, previous?: string[]): string[] {
  * Coerce a persisted config value into a context list.
  * Accepts an array (canonical) or a comma-separated string (hand-edited
  * config files). Anything else is ignored rather than sent as garbage.
+ *
+ * Every entry is re-validated: `config set context` checks on the way in, but
+ * `config.json` is a plain file anyone can edit, and the value ends up verbatim
+ * in a `Link` header. Trusting it would leave the header-injection guard
+ * bypassable by editing a file. Failing loudly beats dropping the entry — a
+ * silently ignored context reads as "the server did not compact my terms".
+ * `geonic config delete context` still works, since it does not resolve options.
  */
 export function normalizeContextConfigValue(value: unknown): string[] | undefined {
   const raw = Array.isArray(value)
@@ -98,7 +105,19 @@ export function normalizeContextConfigValue(value: unknown): string[] | undefine
       ? value.split(",")
       : [];
   const uris = raw.map((s) => s.trim()).filter((s) => s.length > 0);
-  return uris.length > 0 ? uris : undefined;
+  if (uris.length === 0) {
+    return undefined;
+  }
+  return uris.map((uri) => {
+    try {
+      return validateContextUri(uri);
+    } catch (err) {
+      throw new Error(
+        `Invalid "context" in the saved config: ${err instanceof Error ? err.message : String(err)} ` +
+          `Fix it with \`geonic config set context <uri>\` or remove it with \`geonic config delete context\`.`,
+      );
+    }
+  });
 }
 
 /**

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -2,6 +2,7 @@ import { Command, InvalidArgumentError } from "commander";
 import { loadConfig, saveConfig, validateUrl } from "./config.js";
 import { DryRunSignal, GdbClient, GdbClientError } from "./client.js";
 import { printError, printOutput, printCount, printWarning } from "./output.js";
+import { normalizeContextConfigValue } from "./context.js";
 import type { ClientResponse, GlobalOptions, OutputFormat } from "./types.js";
 
 /**
@@ -20,6 +21,10 @@ export function resolveOptions(cmd: Command): GlobalOptions {
     profile: opts.profile,
     apiKey: opts.apiKey ?? process.env.GDB_API_KEY ?? config.apiKey,
     dryRun: opts.dryRun,
+    // #177: `--context` overrides the profile default outright rather than
+    // merging — a caller naming a vocabulary means "use this one", and silently
+    // appending the saved default would change how the response is compacted.
+    context: opts.context ?? normalizeContextConfigValue(config.context),
   };
 }
 
@@ -33,6 +38,16 @@ export function createClient(cmd: Command): GdbClient {
     process.exit(1);
   }
   opts.url = validateUrl(opts.url);
+  // #177: the CLI sends every --context as its own link-value (RFC 8288 §3), but
+  // GeonicDB only reads the first one (geolonia/geonicdb#1818). Say so rather than
+  // let the extra vocabularies vanish into a response full of absolute URIs —
+  // that silent drop is the exact failure this flag exists to remove.
+  if (opts.context && opts.context.length > 1) {
+    printWarning(
+      `Sending ${opts.context.length} @context URIs, but GeonicDB currently applies only the first ` +
+        `(geolonia/geonicdb#1818). Terms defined only in the others will be returned as full URIs.`,
+    );
+  }
   const cliOpts = cmd.optsWithGlobals() as GlobalOptions;
   const usingCliToken = !!cliOpts.token;
   const config = loadConfig(opts.profile);
@@ -60,6 +75,7 @@ export function createClient(cmd: Command): GdbClient {
         },
     verbose: opts.verbose,
     dryRun: opts.dryRun,
+    context: opts.context,
   });
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,8 @@ export interface GdbConfig {
   apiKey?: string;
   clientId?: string;
   clientSecret?: string;
+  /** Default JSON-LD `@context` URIs sent with every NGSI-LD request (#177). */
+  context?: string[];
 }
 
 export interface GdbConfigFile {
@@ -35,6 +37,8 @@ export interface GlobalOptions {
   profile?: string;
   apiKey?: string;
   dryRun?: boolean;
+  /** JSON-LD `@context` URIs from `--context` (repeatable / comma-separated, #177). */
+  context?: string[];
 }
 
 export interface ClientOptions {
@@ -49,6 +53,8 @@ export interface ClientOptions {
   onBeforeRefresh?: () => { token?: string; refreshToken?: string };
   verbose?: boolean;
   dryRun?: boolean;
+  /** JSON-LD `@context` URIs to attach to NGSI-LD requests (#177). */
+  context?: string[];
 }
 
 export interface ClientResponse<T = unknown> {

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -168,6 +168,185 @@ describe("GdbClient", () => {
     expect(sentBody).toEqual(body);
   });
 
+  // #177: --context must reach the server. Reads have only the Link header;
+  // ld+json writes are read from the body (the server ignores Link there).
+  describe("@context propagation (#177)", () => {
+    const CTX = "https://example.org/building.jsonld";
+    const CTX2 = "https://example.org/extra.jsonld";
+    const LINK_ONE = `<${CTX}>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"`;
+
+    function mockOk(status = 200, body: unknown = {}): void {
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(body), {
+          status,
+          headers: { "Content-Type": "application/ld+json" },
+        }),
+      );
+    }
+
+    function sentHeaders(): Record<string, string> {
+      return (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].headers as Record<
+        string,
+        string
+      >;
+    }
+
+    function sentBody(): unknown {
+      return JSON.parse((fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body as string);
+    }
+
+    it("sends a Link header on reads", async () => {
+      const client = new GdbClient({ baseUrl: "http://localhost:3000", context: [CTX] });
+      mockOk(200, []);
+
+      await client.get("/entities", { type: "Building" });
+
+      expect(sentHeaders().Link).toBe(LINK_ONE);
+    });
+
+    it("sends a Link header on every NGSI-LD read path, not just entities", async () => {
+      for (const path of ["/types", "/temporal/entities", "/subscriptions", "/snapshots"]) {
+        vi.restoreAllMocks();
+        const client = new GdbClient({ baseUrl: "http://localhost:3000", context: [CTX] });
+        mockOk(200, []);
+        await client.get(path);
+        expect(sentHeaders().Link, `missing Link on ${path}`).toBe(LINK_ONE);
+      }
+    });
+
+    it("sends every context as its own link-value", async () => {
+      const client = new GdbClient({ baseUrl: "http://localhost:3000", context: [CTX, CTX2] });
+      mockOk(200, []);
+
+      await client.get("/entities");
+
+      expect(sentHeaders().Link).toBe(
+        `${LINK_ONE}, <${CTX2}>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"`,
+      );
+    });
+
+    it("omits the Link header when no context is configured", async () => {
+      const client = new GdbClient({ baseUrl: "http://localhost:3000" });
+      mockOk(200, []);
+
+      await client.get("/entities");
+
+      expect("Link" in sentHeaders()).toBe(false);
+    });
+
+    it("treats an empty context list as unset", async () => {
+      const client = new GdbClient({ baseUrl: "http://localhost:3000", context: [] });
+      mockOk(200, []);
+
+      await client.get("/entities");
+
+      expect("Link" in sentHeaders()).toBe(false);
+    });
+
+    it("does not send a Link header on raw admin/auth paths", async () => {
+      const client = new GdbClient({ baseUrl: "http://localhost:3000", context: [CTX] });
+      mockOk(200, []);
+
+      await client.rawRequest("GET", "/admin/tenants");
+
+      expect("Link" in sentHeaders()).toBe(false);
+    });
+
+    it("injects the context into an entity-write body instead of the core context", async () => {
+      const client = new GdbClient({ baseUrl: "http://localhost:3000", context: [CTX] });
+      mockOk(201);
+
+      await client.post("/entities", { id: "urn:ngsi-ld:Building:1", type: "Building" });
+
+      expect((sentBody() as Record<string, unknown>)["@context"]).toBe(CTX);
+    });
+
+    it("injects an array when several contexts are given", async () => {
+      const client = new GdbClient({ baseUrl: "http://localhost:3000", context: [CTX, CTX2] });
+      mockOk(201);
+
+      await client.post("/entities", { id: "urn:ngsi-ld:Building:1", type: "Building" });
+
+      expect((sentBody() as Record<string, unknown>)["@context"]).toEqual([CTX, CTX2]);
+    });
+
+    it("never overrides a caller-supplied @context", async () => {
+      const client = new GdbClient({ baseUrl: "http://localhost:3000", context: [CTX] });
+      mockOk(201);
+
+      await client.post("/entities", {
+        id: "urn:ngsi-ld:Building:1",
+        type: "Building",
+        "@context": "https://explicit.example/ctx.jsonld",
+      });
+
+      expect((sentBody() as Record<string, unknown>)["@context"]).toBe(
+        "https://explicit.example/ctx.jsonld",
+      );
+    });
+
+    it("injects the context into each entity of a batch write body", async () => {
+      const client = new GdbClient({ baseUrl: "http://localhost:3000", context: [CTX] });
+      mockOk(201);
+
+      await client.post("/entityOperations/upsert", [
+        { id: "urn:ngsi-ld:Building:1", type: "Building" },
+        { id: "urn:ngsi-ld:Building:2", type: "Building" },
+      ]);
+
+      const body = sentBody() as Record<string, unknown>[];
+      expect(body.map((e) => e["@context"])).toEqual([CTX, CTX]);
+    });
+
+    // entityOperations/delete carries an array of ID strings — injecting into it
+    // would corrupt the payload.
+    it("leaves a batch delete body of ID strings untouched", async () => {
+      const client = new GdbClient({ baseUrl: "http://localhost:3000", context: [CTX] });
+      mockOk(200);
+
+      const ids = ["urn:ngsi-ld:Building:1", "urn:ngsi-ld:Building:2"];
+      await client.post("/entityOperations/delete", ids);
+
+      expect(sentBody()).toEqual(ids);
+    });
+
+    // The Query body is not an entity; the server reads the Link header for it.
+    it("leaves a batch query body untouched but still sends the Link header", async () => {
+      const client = new GdbClient({ baseUrl: "http://localhost:3000", context: [CTX] });
+      mockOk(200, []);
+
+      const query = { type: "Building" };
+      await client.post("/entityOperations/query", query);
+
+      expect(sentBody()).toEqual(query);
+      expect(sentHeaders().Link).toBe(LINK_ONE);
+    });
+
+    it("does not inject a context into non-entity resources", async () => {
+      const client = new GdbClient({ baseUrl: "http://localhost:3000", context: [CTX] });
+      mockOk(201);
+
+      const sub = { type: "Subscription", description: "sub" };
+      await client.post("/subscriptions", sub);
+
+      expect(sentBody()).toEqual(sub);
+    });
+
+    it("shows the Link header in --dry-run output", async () => {
+      const logs: string[] = [];
+      vi.spyOn(console, "log").mockImplementation((msg: string) => void logs.push(msg));
+      const client = new GdbClient({
+        baseUrl: "http://localhost:3000",
+        context: [CTX],
+        dryRun: true,
+      });
+
+      await expect(client.get("/entities")).rejects.toBeInstanceOf(DryRunSignal);
+
+      expect(logs.join("\n")).toContain(`-H 'Link: ${LINK_ONE}'`);
+    });
+  });
+
   it("appends query params to URL", async () => {
     const client = new GdbClient({ baseUrl: "http://localhost:3000" });
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -86,6 +86,31 @@ describe("config", () => {
     expect(getConfigValue("url")).toBeUndefined();
   });
 
+  // #177: `context` is a list, and validating on save means a bad URI fails once
+  // here instead of on every later request.
+  it("stores context as a list", () => {
+    setConfigValue("context", "https://example.org/ctx.jsonld");
+    expect(getConfigValue("context")).toEqual(["https://example.org/ctx.jsonld"]);
+  });
+
+  it("splits a comma-separated context into a list", () => {
+    setConfigValue("context", "https://a.example/1.jsonld, https://b.example/2.jsonld");
+    expect(getConfigValue("context")).toEqual([
+      "https://a.example/1.jsonld",
+      "https://b.example/2.jsonld",
+    ]);
+  });
+
+  it("rejects an invalid context URI without writing it", () => {
+    expect(() => setConfigValue("context", "not-a-url")).toThrow(/absolute URL/);
+    expect(getConfigValue("context")).toBeUndefined();
+  });
+
+  it("rejects a context URI that would break the Link header", () => {
+    expect(() => setConfigValue("context", "https://example.org/a\r\nX-Injected: 1")).toThrow();
+    expect(getConfigValue("context")).toBeUndefined();
+  });
+
   it("writes valid v2 JSON to disk", () => {
     setConfigValue("service", "myTenant");
     const configPath = join(tempDir, "geonic", "config.json");

--- a/tests/context.test.ts
+++ b/tests/context.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from "vitest";
+import { InvalidArgumentError } from "commander";
+import {
+  validateContextUri,
+  splitContextValues,
+  collectContext,
+  normalizeContextConfigValue,
+  buildContextLinkHeader,
+  toBodyContext,
+} from "../src/context.js";
+
+describe("validateContextUri", () => {
+  it("accepts an absolute https URL unchanged", () => {
+    expect(validateContextUri("https://example.org/ctx.jsonld")).toBe(
+      "https://example.org/ctx.jsonld",
+    );
+  });
+
+  it("accepts http and trims surrounding whitespace", () => {
+    expect(validateContextUri("  http://example.org/ctx.jsonld  ")).toBe(
+      "http://example.org/ctx.jsonld",
+    );
+  });
+
+  it("preserves the exact string instead of normalizing it", () => {
+    // `new URL(...).toString()` would rewrite this to `https://example.org/`.
+    // @context URLs are compared by exact string, so normalization must not happen.
+    expect(validateContextUri("https://example.org")).toBe("https://example.org");
+  });
+
+  it("rejects an empty value", () => {
+    expect(() => validateContextUri("   ")).toThrow(InvalidArgumentError);
+  });
+
+  it("rejects a relative or non-absolute value", () => {
+    expect(() => validateContextUri("./ctx.jsonld")).toThrow(/absolute URL/);
+  });
+
+  it("rejects non-http(s) schemes the server cannot dereference", () => {
+    expect(() => validateContextUri("file:///etc/passwd")).toThrow(/http:\/\/ and https:\/\//);
+    expect(() => validateContextUri("ftp://example.org/ctx.jsonld")).toThrow(
+      /http:\/\/ and https:\/\//,
+    );
+  });
+
+  // Header-injection guard: these characters would terminate the link-value or
+  // split the request into forged headers.
+  it.each([
+    ["CR", "https://example.org/a\r.jsonld"],
+    ["LF", "https://example.org/a\n.jsonld"],
+    ["CRLF + forged header", "https://example.org/a\r\nX-Injected: 1"],
+    ["angle bracket", "https://example.org/a>.jsonld"],
+    ["double quote", 'https://example.org/a".jsonld'],
+    ["NUL", "https://example.org/a\u0000.jsonld"],
+    ["space", "https://example.org/a b.jsonld"],
+  ])("rejects a URI containing %s", (_label, uri) => {
+    expect(() => validateContextUri(uri)).toThrow(InvalidArgumentError);
+  });
+});
+
+describe("splitContextValues", () => {
+  it("splits comma-separated URIs", () => {
+    expect(splitContextValues("https://a.example/1.jsonld,https://b.example/2.jsonld")).toEqual([
+      "https://a.example/1.jsonld",
+      "https://b.example/2.jsonld",
+    ]);
+  });
+
+  it("ignores empty segments from sloppy input", () => {
+    expect(splitContextValues("https://a.example/1.jsonld, ,")).toEqual([
+      "https://a.example/1.jsonld",
+    ]);
+  });
+
+  it("rejects input with no usable URI", () => {
+    expect(() => splitContextValues(" , ")).toThrow(InvalidArgumentError);
+  });
+
+  it("rejects the whole flag when one entry is invalid", () => {
+    expect(() => splitContextValues("https://a.example/1.jsonld,not-a-url")).toThrow(
+      InvalidArgumentError,
+    );
+  });
+});
+
+describe("collectContext", () => {
+  it("accumulates repeated flags", () => {
+    const first = collectContext("https://a.example/1.jsonld", undefined);
+    const second = collectContext("https://b.example/2.jsonld", first);
+    expect(second).toEqual(["https://a.example/1.jsonld", "https://b.example/2.jsonld"]);
+  });
+
+  it("treats repeats and comma-separated values as equivalent", () => {
+    const repeated = collectContext(
+      "https://b.example/2.jsonld",
+      collectContext("https://a.example/1.jsonld", undefined),
+    );
+    const commas = collectContext(
+      "https://a.example/1.jsonld,https://b.example/2.jsonld",
+      undefined,
+    );
+    expect(commas).toEqual(repeated);
+  });
+
+  it("does not mutate the accumulated array in place", () => {
+    const first = collectContext("https://a.example/1.jsonld", undefined);
+    collectContext("https://b.example/2.jsonld", first);
+    expect(first).toEqual(["https://a.example/1.jsonld"]);
+  });
+});
+
+describe("normalizeContextConfigValue", () => {
+  it("passes an array through", () => {
+    expect(normalizeContextConfigValue(["https://a.example/1.jsonld"])).toEqual([
+      "https://a.example/1.jsonld",
+    ]);
+  });
+
+  it("accepts a comma-separated string from a hand-edited config", () => {
+    expect(
+      normalizeContextConfigValue("https://a.example/1.jsonld, https://b.example/2.jsonld"),
+    ).toEqual(["https://a.example/1.jsonld", "https://b.example/2.jsonld"]);
+  });
+
+  it("drops non-string array members", () => {
+    expect(normalizeContextConfigValue(["https://a.example/1.jsonld", 42, null])).toEqual([
+      "https://a.example/1.jsonld",
+    ]);
+  });
+
+  it.each([
+    ["undefined", undefined],
+    ["empty array", []],
+    ["empty string", "  "],
+    ["a number", 42],
+    ["an object", { url: "https://a.example/1.jsonld" }],
+  ])("returns undefined for %s", (_label, value) => {
+    expect(normalizeContextConfigValue(value)).toBeUndefined();
+  });
+});
+
+describe("buildContextLinkHeader", () => {
+  it("builds a JSON-LD context link-value", () => {
+    expect(buildContextLinkHeader(["https://example.org/ctx.jsonld"])).toBe(
+      '<https://example.org/ctx.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"',
+    );
+  });
+
+  it("joins several contexts as comma-separated link-values (RFC 8288)", () => {
+    const header = buildContextLinkHeader([
+      "https://a.example/1.jsonld",
+      "https://b.example/2.jsonld",
+    ]);
+    expect(header).toBe(
+      '<https://a.example/1.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json", ' +
+        '<https://b.example/2.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"',
+    );
+  });
+});
+
+describe("toBodyContext", () => {
+  it("uses a bare string for a single context", () => {
+    expect(toBodyContext(["https://example.org/ctx.jsonld"])).toBe(
+      "https://example.org/ctx.jsonld",
+    );
+  });
+
+  it("uses an array for several contexts", () => {
+    expect(toBodyContext(["https://a.example/1.jsonld", "https://b.example/2.jsonld"])).toEqual([
+      "https://a.example/1.jsonld",
+      "https://b.example/2.jsonld",
+    ]);
+  });
+
+  it("copies the array so later mutation cannot leak into a request body", () => {
+    const source = ["https://a.example/1.jsonld", "https://b.example/2.jsonld"];
+    const body = toBodyContext(source) as string[];
+    source.push("https://c.example/3.jsonld");
+    expect(body).toHaveLength(2);
+  });
+});

--- a/tests/context.test.ts
+++ b/tests/context.test.ts
@@ -137,6 +137,27 @@ describe("normalizeContextConfigValue", () => {
   ])("returns undefined for %s", (_label, value) => {
     expect(normalizeContextConfigValue(value)).toBeUndefined();
   });
+
+  // config.json is a plain file: `config set` validation must not be the only gate,
+  // or editing the file by hand would bypass the Link-header injection guard.
+  it.each([
+    ["a relative URI", "./ctx.jsonld"],
+    ["a non-http scheme", "file:///etc/passwd"],
+    ["a CRLF injection attempt", "https://example.org/a\r\nX-Injected: 1"],
+    ["an angle bracket", "https://example.org/a>.jsonld"],
+  ])("rejects %s stored as a string", (_label, value) => {
+    expect(() => normalizeContextConfigValue(value)).toThrow(/saved config/);
+  });
+
+  it("rejects an invalid entry inside a stored array", () => {
+    expect(() =>
+      normalizeContextConfigValue(["https://a.example/1.jsonld", "not-a-url"]),
+    ).toThrow(/saved config/);
+  });
+
+  it("points at the commands that fix the saved value", () => {
+    expect(() => normalizeContextConfigValue("not-a-url")).toThrow(/config delete context/);
+  });
 });
 
 describe("buildContextLinkHeader", () => {

--- a/tests/e2e/features/context.feature
+++ b/tests/e2e/features/context.feature
@@ -1,0 +1,131 @@
+Feature: JSON-LD @context on NGSI-LD requests
+  As a CLI user working with a custom vocabulary
+  I want to send a JSON-LD @context with my requests
+  So that responses come back with short terms instead of fully qualified URIs
+
+  # GeonicDB compacts a response using only the @context that the request itself
+  # supplied; unmapped terms are rendered as Fully Qualified Names.
+  # ETSI GS CIM 009 clause 5.5.5 / 5.5.7 — https://cim.etsi.org/NGSI-LD/official/clause-5.html
+  # Regression guard for geolonia/geonicdb-cli#177 (server side: geolonia/geonicdb#1733).
+
+  Background:
+    Given I am logged in
+    And a JSON-LD context "https://example.org/e2e-vocab.jsonld" is registered with:
+      """
+      {
+        "Vehicle": "https://example-vocab/ns#Vehicle",
+        "plateNumber": "https://example-vocab/ns#plateNumber"
+      }
+      """
+
+  # Reproduces the issue: data written elsewhere with a custom vocabulary is
+  # unreadable in short form because the CLI could not send a @context.
+  Scenario: Reading without a context yields fully qualified names
+    Given an entity "urn:ngsi-ld:Vehicle:e2e1" exists using the custom vocabulary
+    When I run `geonic entities get urn:ngsi-ld:Vehicle:e2e1`
+    Then the exit code should be 0
+    And stdout should be valid JSON
+    And the JSON output key "type" should be "https://example-vocab/ns#Vehicle"
+    And the JSON output should have key "https://example-vocab/ns#plateNumber"
+
+  Scenario: --context restores the short terms on a single-entity read
+    Given an entity "urn:ngsi-ld:Vehicle:e2e2" exists using the custom vocabulary
+    When I run `geonic entities get urn:ngsi-ld:Vehicle:e2e2 --context https://example.org/e2e-vocab.jsonld`
+    Then the exit code should be 0
+    And the JSON output key "type" should be "Vehicle"
+    And the JSON output should have key "plateNumber"
+    And the output should not contain "example-vocab/ns#plateNumber"
+
+  Scenario: --context applies to list reads and to the type filter
+    Given an entity "urn:ngsi-ld:Vehicle:e2e3" exists using the custom vocabulary
+    When I run `geonic entities list --type Vehicle --context https://example.org/e2e-vocab.jsonld`
+    Then the exit code should be 0
+    And the JSON array length should be 1
+    And the output should contain "plateNumber"
+    And the output should not contain "example-vocab/ns#plateNumber"
+
+  Scenario: --context applies to temporal reads
+    Given a temporal entity "urn:ngsi-ld:Vehicle:e2e4" exists using the custom vocabulary
+    When I run `geonic temporal entities get urn:ngsi-ld:Vehicle:e2e4 --context https://example.org/e2e-vocab.jsonld`
+    Then the exit code should be 0
+    And the output should not contain "example-vocab/ns#plateNumber"
+
+  Scenario: --context applies to batch query reads
+    Given an entity "urn:ngsi-ld:Vehicle:e2e5" exists using the custom vocabulary
+    When I run `geonic batch query '{"type":"Vehicle"}' --context https://example.org/e2e-vocab.jsonld`
+    Then the exit code should be 0
+    And the JSON array length should be 1
+    And the output should not contain "example-vocab/ns#plateNumber"
+
+  # A profile default means the vocabulary does not have to be typed every time.
+  Scenario: A configured default @context is used without the flag
+    Given an entity "urn:ngsi-ld:Vehicle:e2e6" exists using the custom vocabulary
+    And I run `geonic config set context https://example.org/e2e-vocab.jsonld`
+    When I run `geonic entities get urn:ngsi-ld:Vehicle:e2e6`
+    Then the exit code should be 0
+    And the JSON output key "type" should be "Vehicle"
+
+  Scenario: --context overrides the configured default
+    Given an entity "urn:ngsi-ld:Vehicle:e2e7" exists using the custom vocabulary
+    And a JSON-LD context "https://example.org/e2e-other.jsonld" is registered with:
+      """
+      { "Unrelated": "https://example-vocab/ns#Unrelated" }
+      """
+    And I run `geonic config set context https://example.org/e2e-other.jsonld`
+    When I run `geonic entities get urn:ngsi-ld:Vehicle:e2e7 --context https://example.org/e2e-vocab.jsonld`
+    Then the exit code should be 0
+    And the JSON output key "type" should be "Vehicle"
+
+  # Writes take the @context from the body under application/ld+json, so the same
+  # flag has to reach the payload — otherwise it would be accepted and do nothing.
+  Scenario: --context lets the CLI write with a custom vocabulary
+    When I run `geonic entities create '{"id":"urn:ngsi-ld:Vehicle:e2e8","type":"Vehicle","plateNumber":{"type":"Property","value":"XYZ-999"}}' --context https://example.org/e2e-vocab.jsonld`
+    Then the exit code should be 0
+    When I run `geonic entities get urn:ngsi-ld:Vehicle:e2e8`
+    Then the exit code should be 0
+    And the JSON output key "type" should be "https://example-vocab/ns#Vehicle"
+    When I run `geonic entities get urn:ngsi-ld:Vehicle:e2e8 --context https://example.org/e2e-vocab.jsonld`
+    Then the exit code should be 0
+    And the JSON output key "type" should be "Vehicle"
+    And the JSON output should have key "plateNumber"
+
+  Scenario: --context lets the CLI write a batch with a custom vocabulary
+    When I run `geonic batch create '[{"id":"urn:ngsi-ld:Vehicle:e2e9","type":"Vehicle","plateNumber":{"type":"Property","value":"AAA-111"}}]' --context https://example.org/e2e-vocab.jsonld`
+    Then the exit code should be 0
+    # Reading back without the context proves the batch entity really was stored
+    # under the custom vocabulary — with the core context the type would stay the
+    # bare string "Vehicle" and the round-trip below would pass for the wrong reason.
+    When I run `geonic entities get urn:ngsi-ld:Vehicle:e2e9`
+    Then the exit code should be 0
+    And the JSON output key "type" should be "https://example-vocab/ns#Vehicle"
+    When I run `geonic entities get urn:ngsi-ld:Vehicle:e2e9 --context https://example.org/e2e-vocab.jsonld`
+    Then the exit code should be 0
+    And the JSON output key "type" should be "Vehicle"
+
+  Scenario: An invalid @context URI is rejected before any request is made
+    When I run `geonic entities list --context not-a-url`
+    Then the exit code should be 1
+    And stderr should contain "absolute URL"
+
+  Scenario: A @context URI that would forge a header is rejected
+    When I run `geonic entities list --context "https://example.org/a.jsonld extra"`
+    Then the exit code should be 1
+    And stderr should contain "must not contain"
+
+  # geolonia/geonicdb#1818: the server reads only the first link-value, so the
+  # dropped vocabularies must be announced rather than silently lost.
+  Scenario: Supplying several contexts warns that only the first is applied
+    Given an entity "urn:ngsi-ld:Vehicle:e2e10" exists using the custom vocabulary
+    And a JSON-LD context "https://example.org/e2e-second.jsonld" is registered with:
+      """
+      { "Unrelated": "https://example-vocab/ns#Unrelated" }
+      """
+    When I run `geonic entities get urn:ngsi-ld:Vehicle:e2e10 --context https://example.org/e2e-vocab.jsonld --context https://example.org/e2e-second.jsonld`
+    Then the exit code should be 0
+    And stderr should contain "geonicdb#1818"
+    And the JSON output key "type" should be "Vehicle"
+
+  Scenario: config set rejects an invalid @context instead of saving it
+    When I run `geonic config set context not-a-url`
+    Then the exit code should be 1
+    And the config should not have key "context"

--- a/tests/e2e/step_definitions/context.steps.ts
+++ b/tests/e2e/step_definitions/context.steps.ts
@@ -1,0 +1,97 @@
+import { Given } from "@cucumber/cucumber";
+import { strict as assert } from "node:assert";
+import type { GdbWorld } from "../support/world.js";
+
+/**
+ * Steps for the JSON-LD @context feature (#177).
+ *
+ * The fixtures are written over plain HTTP rather than through the CLI on
+ * purpose: the bug only shows up for data authored elsewhere with a custom
+ * vocabulary, since anything the CLI writes on its own carries the core context.
+ */
+
+const CUSTOM_VOCAB = {
+  Vehicle: "https://example-vocab/ns#Vehicle",
+  plateNumber: "https://example-vocab/ns#plateNumber",
+} as const;
+
+function authToken(world: GdbWorld): string {
+  const token = world.readProfileConfig().token;
+  assert.ok(typeof token === "string" && token, "Not logged in — no token in the CLI config.");
+  return token;
+}
+
+async function apiRequest(
+  world: GdbWorld,
+  method: string,
+  path: string,
+  body: unknown,
+): Promise<{ status: number; text: string }> {
+  const res = await fetch(new URL(path, world.serverUrl).toString(), {
+    method,
+    headers: {
+      "Content-Type": "application/ld+json",
+      Authorization: `Bearer ${authToken(world)}`,
+    },
+    body: JSON.stringify(body),
+  });
+  return { status: res.status, text: await res.text() };
+}
+
+/**
+ * Register a context in the tenant so the server resolves it locally. Its SSRF
+ * hardening blocks loopback URLs, so a context served from the test process
+ * could never be fetched — a registered document is the only workable fixture.
+ */
+Given(
+  /^a JSON-LD context "([^"]+)" is registered with:$/,
+  async function (this: GdbWorld, url: string, docString: string) {
+    const { status, text } = await apiRequest(this, "POST", "/ngsi-ld/v1/jsonldContexts", {
+      url,
+      kind: "cached",
+      body: { "@context": JSON.parse(docString) },
+    });
+    assert.equal(status, 201, `Registering ${url} failed: HTTP ${status} ${text}`);
+  },
+);
+
+/**
+ * Temporal history is not derived from a plain entity create here, so the
+ * temporal representation is written directly — with the same custom vocabulary.
+ */
+Given(
+  /^a temporal entity "([^"]+)" exists using the custom vocabulary$/,
+  async function (this: GdbWorld, entityId: string) {
+    const { status, text } = await apiRequest(this, "POST", "/ngsi-ld/v1/temporal/entities", {
+      "@context": [
+        CUSTOM_VOCAB,
+        "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
+      ],
+      id: entityId,
+      type: "Vehicle",
+      plateNumber: [
+        { type: "Property", value: "ABC-123", observedAt: "2026-01-01T00:00:00.000Z" },
+      ],
+    });
+    assert.ok(
+      status === 201 || status === 204,
+      `Creating temporal ${entityId} failed: HTTP ${status} ${text}`,
+    );
+  },
+);
+
+Given(
+  /^an entity "([^"]+)" exists using the custom vocabulary$/,
+  async function (this: GdbWorld, entityId: string) {
+    const { status, text } = await apiRequest(this, "POST", "/ngsi-ld/v1/entities", {
+      "@context": [
+        CUSTOM_VOCAB,
+        "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
+      ],
+      id: entityId,
+      type: "Vehicle",
+      plateNumber: { type: "Property", value: "ABC-123" },
+    });
+    assert.equal(status, 201, `Creating ${entityId} failed: HTTP ${status} ${text}`);
+  },
+);

--- a/tests/helpers.test.ts
+++ b/tests/helpers.test.ts
@@ -108,6 +108,34 @@ describe("helpers", () => {
       const opts = resolveOptions(fakeCmd());
       expect(opts.dryRun).toBeUndefined();
     });
+
+    // #177
+    it("uses the profile's default @context when --context is absent", () => {
+      saveConfig({ url: "http://localhost:3000", context: ["https://a.example/1.jsonld"] });
+      expect(resolveOptions(fakeCmd()).context).toEqual(["https://a.example/1.jsonld"]);
+    });
+
+    it("--context replaces the profile default rather than merging with it", () => {
+      saveConfig({ url: "http://localhost:3000", context: ["https://saved.example/1.jsonld"] });
+      const opts = resolveOptions(fakeCmd({ context: ["https://flag.example/2.jsonld"] }));
+      expect(opts.context).toEqual(["https://flag.example/2.jsonld"]);
+    });
+
+    it("tolerates a comma-separated context in a hand-edited config", () => {
+      saveConfig({
+        url: "http://localhost:3000",
+        context: "https://a.example/1.jsonld,https://b.example/2.jsonld" as unknown as string[],
+      });
+      expect(resolveOptions(fakeCmd()).context).toEqual([
+        "https://a.example/1.jsonld",
+        "https://b.example/2.jsonld",
+      ]);
+    });
+
+    it("leaves context undefined when neither flag nor config sets it", () => {
+      saveConfig({ url: "http://localhost:3000" });
+      expect(resolveOptions(fakeCmd()).context).toBeUndefined();
+    });
   });
 
   describe("createClient", () => {
@@ -156,6 +184,22 @@ describe("helpers", () => {
       // Verify dryRun is set by triggering a request — it should throw DryRunSignal
       await expect(client.get("/entities")).rejects.toThrow(DryRunSignal);
       logSpy.mockRestore();
+    });
+
+    // #177: geonicdb only honours the first link-value (geolonia/geonicdb#1818),
+    // so extra contexts must be announced rather than silently dropped.
+    it("warns when more than one @context is supplied", () => {
+      saveConfig({ url: "http://localhost:3000" });
+      createClient(
+        fakeCmd({ context: ["https://a.example/1.jsonld", "https://b.example/2.jsonld"] }),
+      );
+      expect(printWarning).toHaveBeenCalledWith(expect.stringContaining("geonicdb#1818"));
+    });
+
+    it("does not warn for a single @context", () => {
+      saveConfig({ url: "http://localhost:3000" });
+      createClient(fakeCmd({ context: ["https://a.example/1.jsonld"] }));
+      expect(printWarning).not.toHaveBeenCalled();
     });
 
     it("sets onTokenRefresh callback when token comes from config", () => {


### PR DESCRIPTION
## 概要

closes #177

本体が ETSI GS CIM 009 clause 5.5.5 / 5.5.7 に準拠し、**応答の compaction を「そのリクエストが渡した `@context`」だけで行う**ようになった (geolonia/geonicdb#1733 / #1785)。従来の「作成時の `@context` / 型からの推測」によるフォールバックが仕様違反として撤廃された結果、`@context` を渡す手段の無い CLI では**独自語彙の型名・属性名が完全修飾 URI (FQN) でしか読めない**状態になっていた。

グローバルオプション `--context <uri>` を追加してこれを解消する。

```console
$ geonic entities get urn:ngsi-ld:Vehicle:1
{ "id": "...", "type": "https://example-vocab/ns#Vehicle",
  "https://example-vocab/ns#plateNumber": { "type": "Property", "value": "ABC-123" } }

$ geonic entities get urn:ngsi-ld:Vehicle:1 --context https://example.org/vocab.jsonld
{ "id": "...", "type": "Vehicle",
  "plateNumber": { "type": "Property", "value": "ABC-123" } }
```

## 実装

| 経路 | 運び方 | 理由 |
|---|---|---|
| 読み取り (GET / POST query) | `Link: <uri>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"` | GET には `@context` を運ぶ経路が Link しか無い |
| エンティティ書き込み | リクエストボディの `@context` | `application/ld+json` では本体が **body を読み Link を無視する** (`extractContextRef`, clause 6.3.5) |

- **付与範囲 (読み)**: NGSI-LD ベースパス (`/ngsi-ld/v1/**`) の全リクエスト — `entities` / `attrs` / `types` / `temporal` / `batch` / `subscriptions` / `registrations` / `snapshots`。`admin` / `auth` 等の raw パスには付けない。
- **注入範囲 (書き)**: `/entities` (オブジェクトボディ) と `entityOperations` の `create`/`upsert`/`update`/`merge` (配列の各要素 — 本体は batch の `@context` を**エンティティ単位**で読む)。`entityOperations/delete` は ID 文字列の配列、`query` は Query オブジェクトなので注入しない。
  - **これを入れないと `--context` は書き込みで「受理されるが何もしない」** = この issue が潰そうとしている silent failure そのものになるため、読みだけで済ませていない。
- **利用者が明示した `@context` は常に優先** (非上書き)。`--context` 未指定時の挙動は従来どおり (#168 の core context 注入) で不変。
- **既定値**: `geonic config set context <uri[,uri...]>` でプロファイルごとに保存。`--context` は既定値を**置換**する (マージしない — 語彙を名指しした利用者の意図を尊重)。
- **入力検証**: 絶対 http/https URL のみ受理。`<` `>` `"` / 空白 / 制御文字を拒否する (**Link ヘッダーへのヘッダーインジェクション防止**。`new URL()` はこれらを弾かないため生入力を検査する)。URL は正規化せず**利用者の文字列をそのまま**送る (`@context` URL は完全一致で比較されるため)。`config set context` も保存時に同じ検証を通す。

## 本体側の既知ギャップ (silent drop を潰した)

実測で、**本体は Link ヘッダーの link-value を 1 個目しか読まない**ことを確認した (`parseContextLinkHeader` が非 global の `String.match`)。2 個渡すと 2 個目の語彙は黙って FQN のまま返る。

→ **geolonia/geonicdb#1818 として起票**。CLI は RFC 8288 準拠で全件を送りつつ、複数指定時に stderr で警告する (黙って落とさない)。本体修正後に警告を撤去する。

## 副次的な修正

`config set` の値検証エラー (`url` / `context`) が未処理例外のスタックトレースになっていたのを、通常のエラー表示 + exit 1 に修正 (`withErrorHandler` 適用)。

## テスト

- **E2E `tests/e2e/features/context.feature` を新規追加 (13 シナリオ)**。fixture は CLI ではなく素の HTTP で書く — バグは「CLI 以外で独自語彙を付けて書かれたデータを CLI で読む」ケースでしか出ないため。context は本体の SSRF 硬化が loopback を弾くので、テナントに登録した context (`POST /jsonldContexts`) で解決させている。
- **変異注入で実効性を確認**:
  - Link ヘッダー付与を無効化 → **13 中 8 シナリオが赤**
  - body への `@context` 注入を無効化 → **書き込み 2 シナリオが赤**
  - 初回はバッチ書き込みシナリオが hollow (core context でも `type` が `Vehicle` のまま通る) だったため、**`--context` 無しで読むと FQN になる**ことを併せて確認する判別可能な形に書き直した。
- ユニット: `tests/context.test.ts` を新規追加 (URI 検証 / ヘッダーインジェクション拒否 / Link 組み立て / config 値の正規化)。`client.test.ts` に `@context` 伝播の 15 ケース、`helpers.test.ts` / `config.test.ts` に既定値・警告・保存時検証を追加。

`geonicdb` devDependency を #1733 / #1775 を含む `origin/main` (`475a7589`) に更新した。更新のみの状態で既存 E2E 161 シナリオが全緑であることを先に確認済み (pin 上げが既存を壊していないことの切り分け)。

## 影響

`--context` 未指定時の挙動は完全に不変。追加は純粋にオプトイン。

## ✅ レビューチェックシート

### 自己レビュー / 外部レビュー
- [ ] `/code-review`（自己）— 未実施
- [ ] `/security-review`（自己）— 未実施
- [ ] Cursor — 未実施
- [ ] CodeRabbit — 未実施

### pre-push ゲート（ローカル）
- [x] `npm run lint`（0 errors）
- [x] `npm run typecheck`
- [x] `npx vitest run`（unit 940 passed）
- [x] `npm run test:e2e`（E2E 174 scenarios / 1008 steps passed）

### CI（GitHub Actions）
- [ ] 全チェック pass

### 残
- [ ] 承認レビュー（人間）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * NGSI-LD リクエストで JSON-LD `@context` URI を指定可能になりました。
  * `--context` の複数指定・カンマ区切りに対応しました。
  * 読み取り時の `Link` ヘッダー付与、書き込み時の本文反映に対応しました。
  * プロファイル設定でデフォルトのコンテキストを保存・利用できます。
  * 既存の本文内 `@context` は上書きされません。

* **改善**
  * URI 検証、不正設定の安全なエラー表示、複数指定時の警告に対応しました。

* **テスト**
  * 単体テストおよび E2E テストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->