### PR TITLE
fix(client): clause 6.3.5 の @context 供給元規則へ全面的に揃える (closes #186, closes #189, closes #187)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@
 
 ## [Unreleased]
 
+### 2026-08-13
+- **Fix**: ETSI GS CIM 009 clause 6.3.5 の `@context` 供給元規則へ全面的に揃えた (closes #186, closes #189, closes #187, 本体 geolonia/geonicdb#1924 / #2065 対応) (#191)
+  - **書き込み (POST/PATCH/PUT) では JSON-LD `Link` ヘッダーを送らない** — `application/ld+json` との併用は本体がリクエスト単位の 400 で拒否する ("No mixes")。`Link` は読み取り (GET/DELETE) 専用のチャネルにした。`--context` 付きの書き込みが全て 400 になっていた #186 の修正
+  - **core `@context` / `--context` の本文注入を NGSI-LD 全書き込み経路へ拡張** — 対象は object ボディ (entities / subscriptions / registrations / temporal / query / snapshots) と配列ボディの各 object 要素。`entityOperations/delete` の ID 文字列のような非 object 要素は**要素の形**で除外し (本体の判定と同じ軸)、`/jsonldContexts` は完全一致で除外。優先順は payload 明示 > `--context` > core context。`--context` 無しの batch / subscriptions / registrations / temporal 書き込みが 400/207 になっていた #189 の修正
+  - **`snapshots create` はボディ `{}` を明示送信する** — 本体はボディ必須で、従来は local server のボディ捏造 (geolonia/geonicdb#2118、修正済み) で偶然通っていた
+  - **複数 `--context` の「1 個目しか適用されない」警告を削除** — 本体 geolonia/geonicdb#1818 は解消済みで、全 link-value がマージされる (README も追従)
+  - devDependency の geonicdb を `1e6c983d` (clause 6.3.5 全経路 enforcement + #2118 修正込み) へ更新し、週次互換性チェック #187 を解消
+
 ### 2026-08-06
 - **Fix**: #178 / #179 のマージ後レビュー (Cursor CLI の別系統 2 モデル) で検出した 5 件を修正 (closes #183) (#184)
   - **非 ASCII の `--context` が実行時 TypeError になっていた**。`Link` ヘッダーは ByteString 制約があるため、`https://example.org/日本語.jsonld` のような URI は fetch の深部で `Cannot convert argument to a ByteString...` を投げていた。検証境界で拒否し、percent-encoded / punycode 形式を案内する。`@context` URL は完全一致で比較されるため、正規化して送るのではなく拒否する (#178 の設計を維持)

--- a/README.md
+++ b/README.md
@@ -803,7 +803,7 @@ $ geonic entities get urn:ngsi-ld:Building:v1 --context https://example.org/buil
 ```
 
 - Works on every NGSI-LD command — `entities`, `attrs`, `types`, `temporal`, `batch`, `subscriptions`, `registrations`, `snapshots`.
-- On reads it is sent as a `Link` header; on entity and batch writes it is placed in the request body, so the same flag also lets you **write** with a custom vocabulary.
+- On reads (`GET`/`DELETE`) it is sent as a `Link` header; on writes (`POST`/`PATCH`/`PUT`) it is placed in the request body (per element for batch arrays), so the same flag also lets you **write** with a custom vocabulary. Writes never carry a `Link` header — combining one with `Content-Type: application/ld+json` is rejected by the server (ETSI GS CIM 009 [clause 6.3.5](https://cim.etsi.org/NGSI-LD/official/clause-6.html), "no mixes").
 - Repeat the flag or separate values with commas for a context array:
   `--context https://a.example/1.jsonld --context https://b.example/2.jsonld`.
   Note that GeonicDB currently applies only the first one ([geolonia/geonicdb#1818](https://github.com/geolonia/geonicdb/issues/1818)); the CLI warns on stderr when you pass more.
@@ -843,10 +843,14 @@ curl \
   'http://localhost:3000/ngsi-ld/v1/entities'
 ```
 
-> Entity writes are sent as `application/ld+json`, which requires an inline JSON-LD
-> `@context`. When your payload omits `@context`, the CLI injects the NGSI-LD core
-> context automatically (a `@context` you provide is preserved). Batch
-> (`entityOperations`) and other resources are not affected.
+> All NGSI-LD writes are sent as `application/ld+json`, which requires an inline
+> JSON-LD `@context` in the body (ETSI GS CIM 009 clause 6.3.5). When your payload
+> omits `@context`, the CLI injects the NGSI-LD core context automatically — into
+> object bodies (entities, subscriptions, registrations, temporal, query bodies)
+> and into each object element of batch arrays. A `@context` you provide is
+> preserved, and `--context` takes precedence over the core context. ID-string
+> arrays (`entityOperations/delete`) and `/jsonldContexts` registrations are left
+> untouched.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -806,7 +806,7 @@ $ geonic entities get urn:ngsi-ld:Building:v1 --context https://example.org/buil
 - On reads (`GET`/`DELETE`) it is sent as a `Link` header; on writes (`POST`/`PATCH`/`PUT`) it is placed in the request body (per element for batch arrays), so the same flag also lets you **write** with a custom vocabulary. Writes never carry a `Link` header — combining one with `Content-Type: application/ld+json` is rejected by the server (ETSI GS CIM 009 [clause 6.3.5](https://cim.etsi.org/NGSI-LD/official/clause-6.html), "no mixes").
 - Repeat the flag or separate values with commas for a context array:
   `--context https://a.example/1.jsonld --context https://b.example/2.jsonld`.
-  Note that GeonicDB currently applies only the first one ([geolonia/geonicdb#1818](https://github.com/geolonia/geonicdb/issues/1818)); the CLI warns on stderr when you pass more.
+  Every supplied context is applied — the server merges them all.
 - Save a per-profile default so you do not have to repeat it:
 
 ```bash
@@ -846,8 +846,8 @@ curl \
 > All NGSI-LD writes are sent as `application/ld+json`, which requires an inline
 > JSON-LD `@context` in the body (ETSI GS CIM 009 clause 6.3.5). When your payload
 > omits `@context`, the CLI injects the NGSI-LD core context automatically — into
-> object bodies (entities, subscriptions, registrations, temporal, query bodies)
-> and into each object element of batch arrays. A `@context` you provide is
+> object bodies (entities, subscriptions, registrations, temporal, snapshots,
+> query bodies) and into each object element of batch arrays. A `@context` you provide is
 > preserved, and `--context` takes precedence over the core context. ID-string
 > arrays (`entityOperations/delete`) and `/jsonldContexts` registrations are left
 > untouched.

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@types/node": "^22.13.0",
         "@vitest/coverage-v8": "^4.1.8",
         "eslint": "^10.8.0",
-        "geonicdb": "github:geolonia/geonicdb#475a758969976cdcf97d9015063617cd69c6c2f5",
+        "geonicdb": "github:geolonia/geonicdb#e219739f0b10e241faf5f39bd4d1fff4b736add1",
         "mongodb": "^7.1.0",
         "mongodb-memory-server": "^11.0.1",
         "prettier": "^3.4.2",
@@ -66,15 +66,15 @@
       }
     },
     "node_modules/@aws-sdk/client-apigatewaymanagementapi": {
-      "version": "3.1103.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-apigatewaymanagementapi/-/client-apigatewaymanagementapi-3.1103.0.tgz",
-      "integrity": "sha512-dkFlzGKsn11rfdnbKPdWGqt99GD6kUF/BCOeyTHtPufVieKKy9QyjXhMVbl4ozo+qNxYPLQ7U391ag39z/OtcA==",
+      "version": "3.1108.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-apigatewaymanagementapi/-/client-apigatewaymanagementapi-3.1108.0.tgz",
+      "integrity": "sha512-kPue1gSnNTLhSEuA3xSghK0k7owr+aVavYdPqBqmZ8l7Q9yRHUxgHcgSQh4IlazQy9swd2kCxLk9naZmEMHkJw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/credential-provider-node": "^3.972.78",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/credential-provider-node": "^3.972.79",
+        "@aws-sdk/types": "^3.974.3",
         "@smithy/core": "^3.31.1",
         "@smithy/fetch-http-handler": "^5.6.13",
         "@smithy/node-http-handler": "^4.9.13",
@@ -86,15 +86,15 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudtrail": {
-      "version": "3.1103.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudtrail/-/client-cloudtrail-3.1103.0.tgz",
-      "integrity": "sha512-s6w3uHT8EZ9c+URSh1YYRQvm2Cv/ZRyjlOuyjzZfStYQxfS6lk9FMpdXRXR4kRVsv/VwNZrFV4aR/ZnNMX7hJw==",
+      "version": "3.1108.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudtrail/-/client-cloudtrail-3.1108.0.tgz",
+      "integrity": "sha512-e6/oyT9+1DR8exOcEzlKgOepd83UM6XghIo2Gm9PsoshnMsNwx0s6/VR7kCdIb7cuPG2A4GiJQ9LXaEplHu56g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/credential-provider-node": "^3.972.78",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/credential-provider-node": "^3.972.79",
+        "@aws-sdk/types": "^3.974.3",
         "@smithy/core": "^3.31.1",
         "@smithy/fetch-http-handler": "^5.6.13",
         "@smithy/node-http-handler": "^4.9.13",
@@ -106,17 +106,17 @@
       }
     },
     "node_modules/@aws-sdk/client-dynamodb": {
-      "version": "3.1103.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1103.0.tgz",
-      "integrity": "sha512-9qN3H5DJYA1TA7vI5RGI6v2yLWpxcWyJQZuAK1LyVH8HaZoVLVof0MHZL/3PfjIW/KFaHHu8EC5kxT7EVjHooQ==",
+      "version": "3.1108.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1108.0.tgz",
+      "integrity": "sha512-fJPQJFZeLdjlktT/AxnsBUkDVeZeCB4kuU1UEPOD5/JFr8wCDAVdLKNO6pks/0ALnn7ELLfEJb/YfRoc/a7k6g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/credential-provider-node": "^3.972.78",
-        "@aws-sdk/dynamodb-codec": "^3.973.41",
-        "@aws-sdk/middleware-endpoint-discovery": "^3.972.27",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/credential-provider-node": "^3.972.79",
+        "@aws-sdk/dynamodb-codec": "^3.973.42",
+        "@aws-sdk/middleware-endpoint-discovery": "^3.972.28",
+        "@aws-sdk/types": "^3.974.3",
         "@smithy/core": "^3.31.1",
         "@smithy/fetch-http-handler": "^5.6.13",
         "@smithy/node-http-handler": "^4.9.13",
@@ -128,16 +128,16 @@
       }
     },
     "node_modules/@aws-sdk/client-eventbridge": {
-      "version": "3.1103.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-eventbridge/-/client-eventbridge-3.1103.0.tgz",
-      "integrity": "sha512-65yVqtIrJxnW6Lr/9UFsOheTBHlsnvE7xqrEZsVI5JI7T3jo+/8t1r28C23wVmTO+URX0tvWBaMzMiwbk2RGnA==",
+      "version": "3.1108.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-eventbridge/-/client-eventbridge-3.1108.0.tgz",
+      "integrity": "sha512-pLCt3Z5jYa8mWsxV/bK2T671ixlnFMX1kXhPaSGOfQb/sFaCgT/WCYeiPbPnd4xJEpLBA/GKFYPZso7UPLArXw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/credential-provider-node": "^3.972.78",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.43",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/credential-provider-node": "^3.972.79",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.44",
+        "@aws-sdk/types": "^3.974.3",
         "@smithy/core": "^3.31.1",
         "@smithy/fetch-http-handler": "^5.6.13",
         "@smithy/node-http-handler": "^4.9.13",
@@ -149,15 +149,15 @@
       }
     },
     "node_modules/@aws-sdk/client-kms": {
-      "version": "3.1103.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.1103.0.tgz",
-      "integrity": "sha512-gYdlyiASPS3Zu9a9jpJlKfEw3FGD4CB8lnuvUTpio1xmboltQjbnaTZ7JR12raiPcv51ODFfES1sUT+QXu3+Fw==",
+      "version": "3.1108.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.1108.0.tgz",
+      "integrity": "sha512-MQrpjiQUVkpPyR9b2LwUJVdnwvdRvLnGxPNIk1BOF+2ICw8CMU7Uva0KeBRts1QEIca7rU4fgDHp2TmusjTaYg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/credential-provider-node": "^3.972.78",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/credential-provider-node": "^3.972.79",
+        "@aws-sdk/types": "^3.974.3",
         "@smithy/core": "^3.31.1",
         "@smithy/fetch-http-handler": "^5.6.13",
         "@smithy/node-http-handler": "^4.9.13",
@@ -169,15 +169,15 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.1103.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1103.0.tgz",
-      "integrity": "sha512-LHX7O/50macEHNZdN776FfuU83BlP0fhRrB2TzzoLaJKVSuuFLnY3dUBPQmhejJDzG5vY9hXqoSVZUWDs6eydA==",
+      "version": "3.1108.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1108.0.tgz",
+      "integrity": "sha512-pZtoHWD+WorgM9xK1ikNcKLbtEMIS6wFtELuCX5AOo9v3ZajV8wOEmXz/7JnBHbsLmyBnyv3NCf7whyV++joiw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/credential-provider-node": "^3.972.78",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/credential-provider-node": "^3.972.79",
+        "@aws-sdk/types": "^3.974.3",
         "@smithy/core": "^3.31.1",
         "@smithy/fetch-http-handler": "^5.6.13",
         "@smithy/node-http-handler": "^4.9.13",
@@ -189,15 +189,15 @@
       }
     },
     "node_modules/@aws-sdk/client-sns": {
-      "version": "3.1103.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sns/-/client-sns-3.1103.0.tgz",
-      "integrity": "sha512-PAgNJwJWkZmcuPU4l1LqVBP7ZpFQmFLRNvKjIpaxsNV/orT2Qq6ehofRK64psvQbvaTwp1K8L1fi10wBSXbF8A==",
+      "version": "3.1108.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sns/-/client-sns-3.1108.0.tgz",
+      "integrity": "sha512-8JTFg2IQxxsleQ1f+H6IwPdt5ZYp4n5TygcSr4uvB6GYO4CKvM9R2Xp48H7RcHleqGoN4aaCBuq195jbxdMF4Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/credential-provider-node": "^3.972.78",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/credential-provider-node": "^3.972.79",
+        "@aws-sdk/types": "^3.974.3",
         "@smithy/core": "^3.31.1",
         "@smithy/fetch-http-handler": "^5.6.13",
         "@smithy/node-http-handler": "^4.9.13",
@@ -209,16 +209,16 @@
       }
     },
     "node_modules/@aws-sdk/client-sqs": {
-      "version": "3.1103.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.1103.0.tgz",
-      "integrity": "sha512-KuVv3mY/X1uQsHoCpd7vrRFFvucrMn2KfLmsQ4w61ayafLIt2UoRd5cokfnJvleJRo7fG7GjKYBhgF5bTKQkrQ==",
+      "version": "3.1108.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.1108.0.tgz",
+      "integrity": "sha512-Zv+txQxuHUteCyI1kv3WIteoZ3j+Uucrp8cVeqeJhCFdBtGjKLL4NfBOwzwwSVamxssRhQrpdNnMTw6iMkeuXQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/credential-provider-node": "^3.972.78",
-        "@aws-sdk/middleware-sdk-sqs": "^3.972.39",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/credential-provider-node": "^3.972.79",
+        "@aws-sdk/middleware-sdk-sqs": "^3.972.40",
+        "@aws-sdk/types": "^3.974.3",
         "@smithy/core": "^3.31.1",
         "@smithy/fetch-http-handler": "^5.6.13",
         "@smithy/node-http-handler": "^4.9.13",
@@ -230,14 +230,14 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.977.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.6.tgz",
-      "integrity": "sha512-QiaJV4/zDrB4ZY2mfeSXSzSTc36W16sZXcGz+SPFk0CJ26gziO0cS+4LjJUMAbdeeBOvS0k0Aq1cZpfGdUXxSw==",
+      "version": "3.977.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.7.tgz",
+      "integrity": "sha512-I88Iov89NVmjSmJLKSv7Cn9M2J+a2942OkA8nZCbz+sl4ZeY4zEOcoLOrbt1GRfQ8zEQKnjAJdXixA3J/p1fDQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.2",
-        "@aws-sdk/xml-builder": "^3.972.37",
+        "@aws-sdk/types": "^3.974.3",
+        "@aws-sdk/xml-builder": "^3.972.38",
         "@aws/lambda-invoke-store": "^0.3.0",
         "@smithy/core": "^3.31.1",
         "@smithy/signature-v4": "^5.6.12",
@@ -250,14 +250,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.67",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.67.tgz",
-      "integrity": "sha512-rcIpk5kxUqDaaNa6Xk23pQ6ViY7jlqzmfFWCahQcBT97ddXaXYYwzCen9Tz1Jvo6aJft6wDl5bN44/Jw5B4oLA==",
+      "version": "3.972.68",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.68.tgz",
+      "integrity": "sha512-2a20A/IdNOwUvaDq91iqqS7BA0XlNMfW3iLGZGZLJv0EbUqhSxB0PIx4rQQqssvWj1uXImb3/UCCdHz/+1dOiA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/types": "^3.974.3",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -267,14 +267,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.69",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.69.tgz",
-      "integrity": "sha512-nggwJtZ4eeNsUw5IeWBMXsi1ryct5idi0K+/SCRF3kybLubOMaNTb3XCihXpWMiVpyzyPeIrl0zTkzhBH9porA==",
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.70.tgz",
+      "integrity": "sha512-0yRem2Fs52r/Nn6UAqIlpjexfaYj8ziEozOe9tamtAVT/5bzFLKx8O2r7MaRqgS3hGKHIa1Jij9nKHSsNnb04A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/types": "^3.974.3",
         "@smithy/core": "^3.31.1",
         "@smithy/fetch-http-handler": "^5.6.13",
         "@smithy/node-http-handler": "^4.9.13",
@@ -286,21 +286,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.973.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.12.tgz",
-      "integrity": "sha512-pNEf/OeyN5X3VmLKlgSO6TqaWmW10CvI3TfwL1XhsuhYjSLT2VDaxFnCPHnOeQXSaFisMX4jNhpETriqN8DOmg==",
+      "version": "3.973.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.13.tgz",
+      "integrity": "sha512-2M39DE02XpYYaSWYk/4AsImXYUU/1L2xmTMLUpMMWq7DfLv191/vCRy3baKtdr45AkJQyVgSjmuVOLm15SwrRQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/credential-provider-env": "^3.972.67",
-        "@aws-sdk/credential-provider-http": "^3.972.69",
-        "@aws-sdk/credential-provider-login": "^3.972.74",
-        "@aws-sdk/credential-provider-process": "^3.972.67",
-        "@aws-sdk/credential-provider-sso": "^3.973.11",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.73",
-        "@aws-sdk/nested-clients": "^3.997.41",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/credential-provider-env": "^3.972.68",
+        "@aws-sdk/credential-provider-http": "^3.972.70",
+        "@aws-sdk/credential-provider-login": "^3.972.75",
+        "@aws-sdk/credential-provider-process": "^3.972.68",
+        "@aws-sdk/credential-provider-sso": "^3.973.12",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.74",
+        "@aws-sdk/nested-clients": "^3.997.42",
+        "@aws-sdk/types": "^3.974.3",
         "@smithy/core": "^3.31.1",
         "@smithy/credential-provider-imds": "^4.4.16",
         "@smithy/types": "^4.16.1",
@@ -311,15 +311,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.74",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.74.tgz",
-      "integrity": "sha512-0AQfDcf99TNmqVKv0owHrw/TQs6i4ZE5t9qmz6NvO53bE/sA/tpXhXL9AAcEP1qHc6Zzjd1UMb69+/9zdhvY3g==",
+      "version": "3.972.75",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.75.tgz",
+      "integrity": "sha512-jaTESuJlQsoUZ44f/i2puyPt8VlF/dMMJ9HM3cStYtk7eKX4N9UWi83OLixUkoOJH3BwWlPLCq9YIK9nfWhVBg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/nested-clients": "^3.997.41",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/nested-clients": "^3.997.42",
+        "@aws-sdk/types": "^3.974.3",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -329,19 +329,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.78",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.78.tgz",
-      "integrity": "sha512-OgPAnfvbGAMWac6yvxJ1ihslrvDpPVwR68D2csospdNCCyPvHk9JLzYKwz48SNiS1T2znDwHauywRKRFfpyYng==",
+      "version": "3.972.79",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.79.tgz",
+      "integrity": "sha512-RIw5dof1EHkWubrZzPC941CDtnFG1iAXsxbFgLkhdYZXHc4icU13c/uxSMI0J5eUx9bxa7LjfpdjfClBB1QsDA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.67",
-        "@aws-sdk/credential-provider-http": "^3.972.69",
-        "@aws-sdk/credential-provider-ini": "^3.973.12",
-        "@aws-sdk/credential-provider-process": "^3.972.67",
-        "@aws-sdk/credential-provider-sso": "^3.973.11",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.73",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/credential-provider-env": "^3.972.68",
+        "@aws-sdk/credential-provider-http": "^3.972.70",
+        "@aws-sdk/credential-provider-ini": "^3.973.13",
+        "@aws-sdk/credential-provider-process": "^3.972.68",
+        "@aws-sdk/credential-provider-sso": "^3.973.12",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.74",
+        "@aws-sdk/types": "^3.974.3",
         "@smithy/core": "^3.31.1",
         "@smithy/credential-provider-imds": "^4.4.16",
         "@smithy/types": "^4.16.1",
@@ -352,14 +352,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.67",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.67.tgz",
-      "integrity": "sha512-IlUEejorGTWKb4/Dm7K5Yw4QxUmXLThLhrvBmzVBqZFTbW72cv9LTcITmo1dsnYriALE4h68mOq4LB99x6sQ7Q==",
+      "version": "3.972.68",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.68.tgz",
+      "integrity": "sha512-nLP3Pda2MQTFJ25hKBMmUuB9Uv+bTZQNlufbeCwklP549Vwnkd8bRLJoCKp5k6xjmdyptrPrOfGOhN0mKuca8A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/types": "^3.974.3",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -369,16 +369,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.973.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.11.tgz",
-      "integrity": "sha512-gAQBkBZxUB84d71+pPcI9L+jh2ujhuAVxc/4FgGiWFDjkPBlMKxzd5XDtkSXTFX8Ro7ansnT88+XadasxMeCRw==",
+      "version": "3.973.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.12.tgz",
+      "integrity": "sha512-EmgyyHn+f9WCcelp3L/vci+LGbX8GigWaVphRArjVo5Pktkr9YnLy/mQ6VDkDyBD72dtfRNTgHmD2ts4rTDXKQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/nested-clients": "^3.997.41",
-        "@aws-sdk/token-providers": "3.1103.0",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/nested-clients": "^3.997.42",
+        "@aws-sdk/token-providers": "3.1108.0",
+        "@aws-sdk/types": "^3.974.3",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -388,15 +388,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.73",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.73.tgz",
-      "integrity": "sha512-SnlEmQa6SjOgs6iOPLUQl1Eyq4AKiAdPQlkOhFhqNfDtDCwibMGvL6QlkSmf3o6vAUSImzdPCxowT5dfQUZP1A==",
+      "version": "3.972.74",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.74.tgz",
+      "integrity": "sha512-0YfczxGXF3RjGj8z7QG/Ho2HnLGKDHfPSHiTs47UU1U/+mmwISDN+rvGKt2zh+3FX8NdT4xd95LGBGyhQw2dgQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/nested-clients": "^3.997.41",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/nested-clients": "^3.997.42",
+        "@aws-sdk/types": "^3.974.3",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -406,13 +406,13 @@
       }
     },
     "node_modules/@aws-sdk/dynamodb-codec": {
-      "version": "3.973.41",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.41.tgz",
-      "integrity": "sha512-N4go/LzYFd6KJ+r7qqAjzmsw85PFN99RnDYZvw22FzU3VZgL5+umvncfu0M7hlzeIUKHSLL65HTJIXiLY7RJFg==",
+      "version": "3.973.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.42.tgz",
+      "integrity": "sha512-EJjm82YDsWjN991merbDHEprA1s8OYPRtPYaMD57MvilZeCJ4lMAld/gZGFpVN6d1dmYoh4DKTFlWJVfmfMhcg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/core": "^3.977.7",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -422,9 +422,9 @@
       }
     },
     "node_modules/@aws-sdk/endpoint-cache": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.972.9.tgz",
-      "integrity": "sha512-LFvdgq8SriaskUcjpBMDE7J2c9RmuT5v3gU36/znV71EU5DKUis4FmGFjCMelKCCViFeVrQADBAlIiOYRhEx6Q==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.972.10.tgz",
+      "integrity": "sha512-xL5sogJajtyGU8p/pA2e8P6dQqs0P6wj2FtBNcZ5VxyBovpoxghKi9hPEkjx+THZijgGW9fOP9EsHDcraSxF8A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -436,14 +436,14 @@
       }
     },
     "node_modules/@aws-sdk/lib-dynamodb": {
-      "version": "3.1103.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.1103.0.tgz",
-      "integrity": "sha512-PKjLHIbm5LTeltTPNqSQZOEm9kGq2IMG6hej2TSblYH6S5gbNhceRyJajkPln8kMKjzCfmf4i4fupn1WCjwOlQ==",
+      "version": "3.1108.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.1108.0.tgz",
+      "integrity": "sha512-MV5JMY4Etst7YiqOp4Mg3z0KLVlwIUAZ5amiazqOEnlWE3Pvja7kWOiQlJ5Qdwid6bygSPWEJp5GCfxbi7cInA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/util-dynamodb": "^3.996.7",
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/util-dynamodb": "^3.996.8",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -452,18 +452,18 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-dynamodb": "^3.1103.0"
+        "@aws-sdk/client-dynamodb": "^3.1108.0"
       }
     },
     "node_modules/@aws-sdk/middleware-endpoint-discovery": {
-      "version": "3.972.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.27.tgz",
-      "integrity": "sha512-5AJlxrsg27IGGiQauWOdVyqK55EN0EMIwXndkVHhBiPT4CtdSaz89/sAENSw+GP4KF+BOWcgycZFNjkOLmfo1A==",
+      "version": "3.972.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.28.tgz",
+      "integrity": "sha512-T4F2dZRK80PyigacWVH2Garx6x3oH24tfOZxsv8zLqha+0K0zBS4GvbnFTgHTVjAdJGAYisxQHD/TNDJh+Up/w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/endpoint-cache": "^3.972.9",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/endpoint-cache": "^3.972.10",
+        "@aws-sdk/types": "^3.974.3",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -473,13 +473,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-sqs": {
-      "version": "3.972.39",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.972.39.tgz",
-      "integrity": "sha512-dlKLmJg1dLQVfFXUPS+f+SqXrRGHDVumY4gjM8sCLGao+zkDXEu8TObTyiaheKjT20ruok9Xs8oLocNItKQ0fw==",
+      "version": "3.972.40",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.972.40.tgz",
+      "integrity": "sha512-inMaGeVemJEIp9Bc5Wlw0aVgVgUr/OwGqg5CLwO8TbMi6m1xFd+BG0fO/nJKVS/rkb9FSRxU/l0njDBz8OQvHQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/types": "^3.974.3",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -489,15 +489,15 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.41",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.41.tgz",
-      "integrity": "sha512-RDHqPGQWlF6tatA/Tp3rg6oIwtgN9IVderxE+9av2Y93Dfyu+mO1hZ5Bu2jpfZg2rwdNbsssnwM+sLafIczMlQ==",
+      "version": "3.997.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.42.tgz",
+      "integrity": "sha512-XWRyon2MTHXD/zMoo0Mbge6Vwf+iE0qQaM/RyGO6NfZ9WukCFiQL27nQVZjYy2JwSIg+iXZxKOX95OBXqlSM4w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.43",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.44",
+        "@aws-sdk/types": "^3.974.3",
         "@smithy/core": "^3.31.1",
         "@smithy/fetch-http-handler": "^5.6.13",
         "@smithy/node-http-handler": "^4.9.13",
@@ -509,13 +509,13 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.43",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.43.tgz",
-      "integrity": "sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==",
+      "version": "3.996.44",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.44.tgz",
+      "integrity": "sha512-ZSfQ35Qn4MhSY+A0Whyr+KBx+wJKZUyBsOrjB2pSHOafRzbFe47T8XcXM8hZqUAC69qnqIy0C9ArxTuud0CC2w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/types": "^3.974.3",
         "@smithy/signature-v4": "^5.6.12",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -525,15 +525,15 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1103.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1103.0.tgz",
-      "integrity": "sha512-N4wy26MNn31ItGVHYHPrEuCIFY4MBBjC+C5v1lJKqIUSA7OZBdhleCY53zCCrXn27hsk7YNOaTuhQu807S4AfQ==",
+      "version": "3.1108.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1108.0.tgz",
+      "integrity": "sha512-rI80zxDxGJ6904eC/YbjkdjY6JdaZvQ01kOmrMvw7cFQGIHo27fhnIVbMSVDS4T6foQImjxYSRoOu/uSJscXDw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/nested-clients": "^3.997.41",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/nested-clients": "^3.997.42",
+        "@aws-sdk/types": "^3.974.3",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -543,9 +543,9 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.974.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
-      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
+      "version": "3.974.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.3.tgz",
+      "integrity": "sha512-ECAqfpNsef+7MO8qtR0h9KcFIBAygaE7Cm6UOiQl+ft+uVap+1G7bNEjs4mdJE2OnA4m6k7i8peH8uGIAsOMGw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -557,9 +557,9 @@
       }
     },
     "node_modules/@aws-sdk/util-dynamodb": {
-      "version": "3.996.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.996.7.tgz",
-      "integrity": "sha512-v+WJASG9yaW8qNM7pNSgH1PBYz5mVTf7gzKPi0NqGjLlaCtPdk6EjM1lmv03egA07iXUw6OToGYfW2w8D3kBrg==",
+      "version": "3.996.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.996.8.tgz",
+      "integrity": "sha512-zg9Scj7J5MCQS4XeEkvKwPN6Crw3oYjFBICxfPpcrIurEKhckL1o/Co8cNKC2WxsYwKmaywFTB8cxpmJqSUx5Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -569,13 +569,13 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-dynamodb": "^3.1088.0"
+        "@aws-sdk/client-dynamodb": "^3.1108.0"
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.37",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz",
-      "integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.38.tgz",
+      "integrity": "sha512-grf7mzfVxBS5AlsuTvBN7uDpzqohFww9fRPCO+EBSUdvtsYMcPSKdz54h/7XiscqNcUM1Ae1MF7JLHmiYYuzbQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -648,9 +648,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1719,9 +1719,9 @@
       }
     },
     "node_modules/@marcbachmann/cel-js": {
-      "version": "7.6.1",
-      "resolved": "https://registry.npmjs.org/@marcbachmann/cel-js/-/cel-js-7.6.1.tgz",
-      "integrity": "sha512-YyY8yiDU07ByKb2rJUoNgMAkYeeDvkdrONBREV2MP9siAW7yNft0KfbIoonWTIMY0fGtv8og0EhzKx3Xsi1Nmg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@marcbachmann/cel-js/-/cel-js-8.0.0.tgz",
+      "integrity": "sha512-oaTrAziGr3zDLFiMt/yLU3nZuRMawyWQB5X1a0I7s9eGy3JYzX9l8ZXXHyMd64nzbeVFZTewuUShwsZQdK6UCA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3128,13 +3128,13 @@
       ]
     },
     "node_modules/@smithy/core": {
-      "version": "3.31.1",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.31.1.tgz",
-      "integrity": "sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==",
+      "version": "3.32.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.32.0.tgz",
+      "integrity": "sha512-NAiCSC78fzbNIEWoheoF74Ob5ZorLijCHpMY26Fqvqg/+9LuyIqMfHDg2p8Yk1rqOyowtiL3y7WX0AW+teL6zw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.16.1",
+        "@smithy/types": "^4.17.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3142,14 +3142,14 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.4.16",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.16.tgz",
-      "integrity": "sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.0.tgz",
+      "integrity": "sha512-2jsPi+7Zv2hSzD9IXR9D7DTqSn7mv4XalzRm+bESh53jiaUS3NKEUbpQFTJP0HhQy9qzZvluxQ3yS24zdRrqsA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
+        "@smithy/core": "^3.32.0",
+        "@smithy/types": "^4.17.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3157,14 +3157,14 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.6.13",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.13.tgz",
-      "integrity": "sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.7.0.tgz",
+      "integrity": "sha512-W/exA8T0LEzCQtJ02w4IzaEQPIspgarqZprb7W8FwnYiDowgCrjl2fTQ6FvuSSUnJORuepBF81abmBJwqh+0XQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
+        "@smithy/core": "^3.32.0",
+        "@smithy/types": "^4.17.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3172,14 +3172,14 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.9.13",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.13.tgz",
-      "integrity": "sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.10.0.tgz",
+      "integrity": "sha512-nrh7VxqzPQS/ip1hS293aI/OAWDWARQvjUxCfuKhyrfHa2gTdk28066RNeWLI1uuoHXaKAkOF8IcSAHuOp0+SA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
+        "@smithy/core": "^3.32.0",
+        "@smithy/types": "^4.17.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3187,14 +3187,14 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.6.12",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.12.tgz",
-      "integrity": "sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.0.tgz",
+      "integrity": "sha512-hCynhm22wMJ8wTF9crcwu8mxggtUrSLLJgDcGUvYFBqpofxycYJCGKOMYg4xtPPFtgNiDJSYmhsWLTrcU/g59Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
+        "@smithy/core": "^3.32.0",
+        "@smithy/types": "^4.17.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3202,9 +3202,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
-      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.17.0.tgz",
+      "integrity": "sha512-Aw4joiM0ZdErpo39lCj8phT2lxoiKZV+KZzBxnnQhWVtU2Is/WffQSL04uUWRcXUse9Ln8vXZK6V/FwqRVnQpg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3299,9 +3299,9 @@
       "license": "MIT"
     },
     "node_modules/@types/readable-stream": {
-      "version": "4.0.23",
-      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.23.tgz",
-      "integrity": "sha512-wwXrtQvbMHxCbBgjHaMGEmImFTQxxpfMOR/ZoQnXxB1woqkUbdLGFDgauo00Py9IudiaqSeiBiulSV9i6XIPig==",
+      "version": "4.0.24",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.24.tgz",
+      "integrity": "sha512-NRvUNC/JFGPJvqdAfEve8oginbM6V08u5NzLWpG8MwA2kTPOLnqk+wpwuPT+mp3aUsxyuT6m2gnrPuHYCruzEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4114,16 +4114,16 @@
       }
     },
     "node_modules/broker-factory": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/broker-factory/-/broker-factory-3.1.14.tgz",
-      "integrity": "sha512-L45k5HMbPIrMid0nTOZ/UPXG/c0aRuQKVrSDFIb1zOkvfiyHgYmIjc3cSiN1KwQIvRDOtKE0tfb3I9EZ3CmpQQ==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/broker-factory/-/broker-factory-3.1.15.tgz",
+      "integrity": "sha512-ko+aWvgNuP49meGrdjUu7rC+Y+Wai3cCPxP3xWwHsHfehFjOh5ZQM2yC4gEB2UddeZ/YXhm0K1eG/L6fxym2Og==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.29.2",
+        "@babel/runtime": "^7.29.7",
         "fast-unique-numbers": "^9.0.27",
         "tslib": "^2.8.1",
-        "worker-factory": "^7.0.49"
+        "worker-factory": "^7.0.50"
       }
     },
     "node_modules/bson": {
@@ -5330,22 +5330,22 @@
     },
     "node_modules/geonicdb": {
       "version": "0.16.0",
-      "resolved": "git+ssh://git@github.com/geolonia/geonicdb.git#475a758969976cdcf97d9015063617cd69c6c2f5",
-      "integrity": "sha512-1KoU+JRGPHsv5j+z5EvJ1iS6CLV0zJ+mdTt5YJGs2eL1aoIz5oTNiTBroEpBn8x0K2tmEDnBKHjY5cDtHoePpQ==",
+      "resolved": "git+ssh://git@github.com/geolonia/geonicdb.git#e219739f0b10e241faf5f39bd4d1fff4b736add1",
+      "integrity": "sha512-ca22yfyZEyE/bn71QjIYY7BKoSp2NUM7+/pe0Qm/NFhddDjb+vbHamASyeRg0Hdc2/Nw90a84tsiD1S/CLcXWw==",
       "dev": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@a2a-js/sdk": "^0.3.14",
-        "@aws-sdk/client-apigatewaymanagementapi": "^3.1100.0",
-        "@aws-sdk/client-cloudtrail": "^3.1100.0",
-        "@aws-sdk/client-dynamodb": "^3.1100.0",
-        "@aws-sdk/client-eventbridge": "^3.1100.0",
-        "@aws-sdk/client-kms": "^3.1100.0",
-        "@aws-sdk/client-secrets-manager": "^3.1100.0",
-        "@aws-sdk/client-sns": "^3.1100.0",
-        "@aws-sdk/client-sqs": "^3.1100.0",
-        "@aws-sdk/lib-dynamodb": "^3.1100.0",
-        "@marcbachmann/cel-js": "^7.6.1",
+        "@aws-sdk/client-apigatewaymanagementapi": "^3.1105.0",
+        "@aws-sdk/client-cloudtrail": "^3.1105.0",
+        "@aws-sdk/client-dynamodb": "^3.1105.0",
+        "@aws-sdk/client-eventbridge": "^3.1105.0",
+        "@aws-sdk/client-kms": "^3.1105.0",
+        "@aws-sdk/client-secrets-manager": "^3.1105.0",
+        "@aws-sdk/client-sns": "^3.1105.0",
+        "@aws-sdk/client-sqs": "^3.1105.0",
+        "@aws-sdk/lib-dynamodb": "^3.1105.0",
+        "@marcbachmann/cel-js": "^8.0.0",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/context-async-hooks": "^2.9.0",
@@ -5362,9 +5362,9 @@
         "fresh": "^2.0.0",
         "js-yaml": "^5.2.3",
         "mongodb": "^7.5.0",
-        "mqtt": "^5.15.1",
+        "mqtt": "^5.15.2",
         "proj4": "^2.21.0",
-        "ws": "^8.21.1",
+        "ws": "^8.21.2",
         "zod": "^4.4.3"
       },
       "bin": {
@@ -6745,9 +6745,9 @@
       }
     },
     "node_modules/mqtt": {
-      "version": "5.15.1",
-      "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-5.15.1.tgz",
-      "integrity": "sha512-V1WnkGuJh3ec9QXzy5Iylw8OOBK+Xu1WhxcQ9mMpLThG+/JZIMV1PgLNRgIiqXhZnvnVLsuyxHl5A/3bHHbcAA==",
+      "version": "5.15.2",
+      "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-5.15.2.tgz",
+      "integrity": "sha512-VWZU2CSUY3U3oN0PSBRDE5SNsFi4zqqNeQ/uv3pZWqY3CrBXD/dhd0ZLjlsk5YnebGlrapi4lRVNJPUNQ5aZ3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8987,54 +8987,54 @@
       }
     },
     "node_modules/worker-factory": {
-      "version": "7.0.49",
-      "resolved": "https://registry.npmjs.org/worker-factory/-/worker-factory-7.0.49.tgz",
-      "integrity": "sha512-lW7tpgy6aUv2dFsQhv1yv+XFzdkCf/leoKRTGMPVK5/die6RrUjqgJHJf556qO+ZfytNG6wPXc17E8zzsOLUDw==",
+      "version": "7.0.50",
+      "resolved": "https://registry.npmjs.org/worker-factory/-/worker-factory-7.0.50.tgz",
+      "integrity": "sha512-hhwc0G+sFwM4qBuhJIUBn2p1Jf8v/FwmLUANBf/Q+Lt2uI8mfIZQhXaZQACodQD4R7Zp6cn/6702bIvNn2puJQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.29.2",
+        "@babel/runtime": "^7.29.7",
         "fast-unique-numbers": "^9.0.27",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/worker-timers": {
-      "version": "8.0.31",
-      "resolved": "https://registry.npmjs.org/worker-timers/-/worker-timers-8.0.31.tgz",
-      "integrity": "sha512-ngkq5S6JuZyztom8tDgBzorLo9byhBMko/sXfgiUD945AuzKGg1GCgDMCC3NaYkicLpGKXutONM36wEX8UbBCA==",
+      "version": "8.0.34",
+      "resolved": "https://registry.npmjs.org/worker-timers/-/worker-timers-8.0.34.tgz",
+      "integrity": "sha512-WXL+Dqsm0G6dnC66rQsvM3tPT2adhbqSirWUCZGglkALOr8ocS0KlpU0iuKbjflJOlu3ydZikMEVrYnHOM9suw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.29.2",
+        "@babel/runtime": "^7.29.7",
         "tslib": "^2.8.1",
-        "worker-timers-broker": "^8.0.16",
-        "worker-timers-worker": "^9.0.14"
+        "worker-timers-broker": "^8.0.18",
+        "worker-timers-worker": "^9.0.15"
       }
     },
     "node_modules/worker-timers-broker": {
-      "version": "8.0.16",
-      "resolved": "https://registry.npmjs.org/worker-timers-broker/-/worker-timers-broker-8.0.16.tgz",
-      "integrity": "sha512-JyP3AvUGyPGbBGW7XiUewm2+0pN/aYo1QpVf5kdXAfkDZcN3p7NbWrG6XnyDEpDIvfHk/+LCnOW/NsuiU9riYA==",
+      "version": "8.0.18",
+      "resolved": "https://registry.npmjs.org/worker-timers-broker/-/worker-timers-broker-8.0.18.tgz",
+      "integrity": "sha512-FrjzDVX1wKfZN0gRbCFqv8VHuTncG4sbI/WGEg4tSSQeIsnwqg4YBYWMAHYLJtUDEYYmiK65UKFrVMVk2irDSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.29.2",
-        "broker-factory": "^3.1.14",
+        "@babel/runtime": "^7.29.7",
+        "broker-factory": "^3.1.15",
         "fast-unique-numbers": "^9.0.27",
         "tslib": "^2.8.1",
-        "worker-timers-worker": "^9.0.14"
+        "worker-timers-worker": "^9.0.15"
       }
     },
     "node_modules/worker-timers-worker": {
-      "version": "9.0.14",
-      "resolved": "https://registry.npmjs.org/worker-timers-worker/-/worker-timers-worker-9.0.14.tgz",
-      "integrity": "sha512-/qF06C60sXmSLfUl7WglvrDIbspmPOM8UrG63Dnn4bi2x4/DfqHS/+dxF5B+MdHnYO5tVuZYLHdAodrKdabTIg==",
+      "version": "9.0.15",
+      "resolved": "https://registry.npmjs.org/worker-timers-worker/-/worker-timers-worker-9.0.15.tgz",
+      "integrity": "sha512-KKUe7lZ/Aignr51H6hOUik8LwTnIgojH/1lwhli8A8qIEIyewogZTpNpMW5B6BF7nmwBOkUoTYgf1H3QShcjSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.29.2",
+        "@babel/runtime": "^7.29.7",
         "tslib": "^2.8.1",
-        "worker-factory": "^7.0.49"
+        "worker-factory": "^7.0.50"
       }
     },
     "node_modules/wrap-ansi": {
@@ -9079,9 +9079,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.21.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
-      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@types/node": "^22.13.0",
         "@vitest/coverage-v8": "^4.1.8",
         "eslint": "^10.8.0",
-        "geonicdb": "github:geolonia/geonicdb#e219739f0b10e241faf5f39bd4d1fff4b736add1",
+        "geonicdb": "github:geolonia/geonicdb#1e6c983deea8e63203044337040aacc930c18ddc",
         "mongodb": "^7.1.0",
         "mongodb-memory-server": "^11.0.1",
         "prettier": "^3.4.2",
@@ -5330,8 +5330,8 @@
     },
     "node_modules/geonicdb": {
       "version": "0.16.0",
-      "resolved": "git+ssh://git@github.com/geolonia/geonicdb.git#e219739f0b10e241faf5f39bd4d1fff4b736add1",
-      "integrity": "sha512-ca22yfyZEyE/bn71QjIYY7BKoSp2NUM7+/pe0Qm/NFhddDjb+vbHamASyeRg0Hdc2/Nw90a84tsiD1S/CLcXWw==",
+      "resolved": "git+ssh://git@github.com/geolonia/geonicdb.git#1e6c983deea8e63203044337040aacc930c18ddc",
+      "integrity": "sha512-LcyCBbGyxGl1iOzx0t6zJNaqqzRn0C9MPaPrETND7mmuLcXDVZZEF+xBAeLWFkvFJXGNw2+OrOMUI8Oes8ztsA==",
       "dev": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@types/node": "^22.13.0",
     "@vitest/coverage-v8": "^4.1.8",
     "eslint": "^10.8.0",
-    "geonicdb": "github:geolonia/geonicdb#475a758969976cdcf97d9015063617cd69c6c2f5",
+    "geonicdb": "github:geolonia/geonicdb#e219739f0b10e241faf5f39bd4d1fff4b736add1",
     "mongodb": "^7.1.0",
     "mongodb-memory-server": "^11.0.1",
     "prettier": "^3.4.2",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@types/node": "^22.13.0",
     "@vitest/coverage-v8": "^4.1.8",
     "eslint": "^10.8.0",
-    "geonicdb": "github:geolonia/geonicdb#e219739f0b10e241faf5f39bd4d1fff4b736add1",
+    "geonicdb": "github:geolonia/geonicdb#1e6c983deea8e63203044337040aacc930c18ddc",
     "mongodb": "^7.1.0",
     "mongodb-memory-server": "^11.0.1",
     "prettier": "^3.4.2",

--- a/src/client.ts
+++ b/src/client.ts
@@ -316,76 +316,55 @@ export class GdbClient {
     return false;
   }
 
-  /**
-   * #168: NGSI-LD entity writes require an inline JSON-LD `@context` under
-   * `application/ld+json` (server geolonia/geonicdb#1583). The CLI always sends
-   * `application/ld+json`, so inject the core context when an entity-write object
-   * body omits it; otherwise the server returns 400 BadRequestData. A
-   * caller-supplied `@context` is preserved (never overwritten). Arrays (batch
-   * bodies) and non-object bodies are left untouched.
-   *
-   * Scoped to the `/entities` endpoints ONLY, mirroring the exact range where the
-   * server enforces `@context` (geonicdb#1583: create/replace/append/patch-attrs).
-   * Other resources must not receive an injected `@context`:
-   *   - admin/auth/... use strict server schemas that reject the unexpected key.
-   *   - batch (`/entityOperations`, array bodies), temporal, subscriptions and
-   *     registrations are not yet `@context`-required server-side (tracked in
-   *     geonicdb#1599); extend this scope when the server does.
-   */
-  private maybeInjectCoreContext(resourcePath: string, body: unknown): unknown {
-    const isEntityWrite = resourcePath.startsWith(`${this.getBasePath()}/entities`);
-    if (
-      !isEntityWrite ||
-      body === null ||
-      typeof body !== "object" ||
-      Array.isArray(body) ||
-      "@context" in (body as Record<string, unknown>)
-    ) {
-      return body;
-    }
-    return { ...(body as Record<string, unknown>), "@context": NGSI_LD_CORE_CONTEXT };
+  /** Verbs whose `@context` must come from the body under `application/ld+json` (clause 6.3.5). */
+  private static readonly CONTEXT_SOURCE_VERBS = new Set(["POST", "PATCH", "PUT"]);
+
+  private isContextSourceVerb(method: string): boolean {
+    return GdbClient.CONTEXT_SOURCE_VERBS.has(method.toUpperCase());
   }
 
   /**
-   * Batch endpoints whose body is an array of entity objects. Their `@context`
-   * lives on each element, not on the request: the server reads it per entity
-   * (`attachContextRef` in geonicdb's batch controller). `entityOperations/delete`
-   * is excluded because its array holds ID strings, and `entityOperations/query`
-   * because its body is a Query object — the Link header carries the context there.
-   */
-  private static readonly ENTITY_ARRAY_WRITE_PATHS = [
-    "/entityOperations/create",
-    "/entityOperations/upsert",
-    "/entityOperations/update",
-    "/entityOperations/merge",
-  ];
-
-  /**
-   * #177: apply a user-supplied `--context` to entity-write bodies.
+   * #186/#189: make every NGSI-LD write body carry its JSON-LD `@context` inline.
    *
-   * Under `application/ld+json` — which this CLI always sends — the server takes
-   * the `@context` from the **body** and ignores the Link header
-   * (`extractContextRef`, ETSI GS CIM 009 clause 6.3.5). Without this, `--context`
-   * would be accepted on a write and then silently do nothing, which is the same
-   * class of quiet failure this flag exists to remove.
+   * Under `Content-Type: application/ld+json` — which this CLI always sends —
+   * ETSI GS CIM 009 clause 6.3.5 requires the `@context` of a POST/PATCH/PUT to
+   * come from the request body itself, and GeonicDB enforces this on every
+   * NGSI-LD write path (geolonia/geonicdb#1924, #2065): a body without `@context`
+   * is 400 BadRequestData (batch elements: a per-element 207 error). So the
+   * `@context` is resolved per JSON-LD document, in this order:
    *
-   * Scope mirrors where the server actually reads a body `@context` for entity
-   * writes: `/entities...` (object body) and the batch endpoints listed above
-   * (per-element). A caller-supplied `@context` always wins — an explicit
-   * `@context` in the payload is a deliberate choice.
+   *   1. an explicit `@context` already in the payload (a deliberate choice — never overwritten),
+   *   2. the user-supplied `--context` (without this the flag would be accepted
+   *      on a write and silently do nothing),
+   *   3. the NGSI-LD core context (so a plain payload stays valid, #168).
+   *
+   * Array bodies are handled per element, because each element is an independent
+   * JSON-LD document (clause 5.6.7.3). Non-object elements are left untouched —
+   * `entityOperations/delete` sends ID strings that have no place for a
+   * `@context`. Exclusion is decided by the SHAPE of the data, not by path,
+   * mirroring the server (`contextComplianceErrorForElement`).
+   *
+   * Out of scope, and deliberately untouched:
+   *   - GET/DELETE — clause 6.3.5 covers POST/PATCH/PUT only; reads carry their
+   *     context in the Link header (see `buildHeaders`).
+   *   - `/jsonldContexts` — its body IS a context document, not a JSON-LD
+   *     document with a `@context` term (the server excludes it the same way).
+   *   - non-NGSI-LD paths (admin/auth/rules/...) — they go through
+   *     `executeRawRequest` with absolute paths that never match the base path,
+   *     and their strict server schemas would reject the unexpected key.
+   *
+   * https://cim.etsi.org/NGSI-LD/official/clause-6.html
    */
-  private applyContextToBody(resourcePath: string, body: unknown): unknown {
-    if (!this.context) return body;
-    const relative = resourcePath.slice(this.getBasePath().length);
-    const injected = toBodyContext(this.context);
+  private prepareNgsiLdWriteBody(method: string, resourcePath: string, body: unknown): unknown {
+    if (!this.isContextSourceVerb(method)) return body;
+    if (!resourcePath.startsWith(`${this.getBasePath()}/`)) return body;
+    if (resourcePath.startsWith(`${this.getBasePath()}/jsonldContexts`)) return body;
 
-    if (relative.startsWith("/entities")) {
-      return GdbClient.withContext(body, injected);
+    const context = this.context ? toBodyContext(this.context) : NGSI_LD_CORE_CONTEXT;
+    if (Array.isArray(body)) {
+      return body.map((element) => GdbClient.withContext(element, context));
     }
-    if (GdbClient.ENTITY_ARRAY_WRITE_PATHS.includes(relative) && Array.isArray(body)) {
-      return body.map((entry) => GdbClient.withContext(entry, injected));
-    }
-    return body;
+    return GdbClient.withContext(body, context);
   }
 
   /** Add `@context` to a plain-object payload, leaving anything else untouched. */
@@ -413,13 +392,16 @@ export class GdbClient {
   ): Promise<ClientResponse<T>> {
     const resourcePath = `${this.getBasePath()}${path}`;
     const url = this.buildUrl(resourcePath, options?.params);
-    // #177: NGSI-LD requests carry the @context; raw admin/auth paths never do.
-    const headers = this.buildHeaders(options?.headers, { contextLink: true });
+    // #177/#186: NGSI-LD READS carry the @context in a Link header; raw
+    // admin/auth paths never do. Writes must NOT — under application/ld+json a
+    // JSON-LD Link header on POST/PATCH/PUT is a 400 (clause 6.3.5 "No mixes",
+    // geolonia/geonicdb#1924); their @context travels in the body instead
+    // (`prepareNgsiLdWriteBody`).
+    const headers = this.buildHeaders(options?.headers, {
+      contextLink: !this.isContextSourceVerb(method),
+    });
     const injectedBody = options?.body
-      ? this.maybeInjectCoreContext(
-          resourcePath,
-          this.applyContextToBody(resourcePath, options.body),
-        )
+      ? this.prepareNgsiLdWriteBody(method, resourcePath, options.body)
       : undefined;
     const body = injectedBody ? JSON.stringify(injectedBody) : undefined;
 
@@ -473,10 +455,10 @@ export class GdbClient {
       delete headers["NGSILD-Tenant"];
     }
     // executeRawRequest takes absolute paths (auth/admin/health). The scope check
-    // in maybeInjectCoreContext leaves non-/entities paths untouched, so this is a
-    // no-op for those; kept for consistency in case an entities path is ever routed here.
+    // in prepareNgsiLdWriteBody leaves non-NGSI-LD paths untouched, so this is a
+    // no-op for those; kept for consistency in case an NGSI-LD path is ever routed here.
     const injectedBody = options?.body
-      ? this.maybeInjectCoreContext(path, options.body)
+      ? this.prepareNgsiLdWriteBody(method, path, options.body)
       : undefined;
     const body = injectedBody ? JSON.stringify(injectedBody) : undefined;
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -2,7 +2,6 @@ import type { ClientOptions, ClientResponse, NgsiError } from "./types.js";
 import { clientCredentialsGrant } from "./oauth.js";
 import { getTokenStatus } from "./token.js";
 import { buildContextLinkHeader, toBodyContext } from "./context.js";
-import { printWarning } from "./output.js";
 import { sanitizeServerText } from "./sanitize.js";
 
 /**
@@ -32,7 +31,6 @@ export class GdbClient {
   private verbose: boolean;
   private dryRun: boolean;
   private context?: string[];
-  private contextWarningEmitted = false;
   private refreshPromise?: Promise<boolean>;
 
   constructor(options: ClientOptions) {
@@ -61,10 +59,11 @@ export class GdbClient {
     if (this.service) headers["NGSILD-Tenant"] = this.service;
     // #177: reads carry the JSON-LD @context in a Link header — it is the only
     // channel a GET has, and the server compacts the response using exactly the
-    // context the request supplied (ETSI GS CIM 009 clause 5.5.7).
+    // context the request supplied (ETSI GS CIM 009 clause 5.5.7). Every value
+    // is applied: the server merges all link-values (geolonia/geonicdb#1818 is
+    // fixed), so no "only the first is used" warning is needed anymore.
     if (options?.contextLink && this.context) {
       headers["Link"] = buildContextLinkHeader(this.context);
-      this.warnOnceAboutMultipleContexts(this.context.length);
     }
 
     if (this.token) {
@@ -78,27 +77,6 @@ export class GdbClient {
     }
 
     return headers;
-  }
-
-  /**
-   * #177/#183: the CLI sends every `--context` as its own link-value
-   * (RFC 8288 §3), but GeonicDB reads only the first (geolonia/geonicdb#1818).
-   * Announce the drop rather than let the extra vocabularies vanish into a
-   * response full of absolute URIs — that silence is the exact failure the flag
-   * exists to remove.
-   *
-   * Emitted from here, not from client construction, so it fires only when a
-   * Link header is genuinely attached: `admin` and `auth` go through raw paths
-   * that carry no context, and warning there would claim something untrue.
-   * Once per client, so a paginated command does not repeat it per page.
-   */
-  private warnOnceAboutMultipleContexts(count: number): void {
-    if (count <= 1 || this.contextWarningEmitted) return;
-    this.contextWarningEmitted = true;
-    printWarning(
-      `Sending ${count} @context URIs, but GeonicDB currently applies only the first ` +
-        `(geolonia/geonicdb#1818). Terms defined only in the others will be returned as full URIs.`,
-    );
   }
 
   private buildUrl(path: string, params?: Record<string, string>): string {
@@ -358,7 +336,11 @@ export class GdbClient {
   private prepareNgsiLdWriteBody(method: string, resourcePath: string, body: unknown): unknown {
     if (!this.isContextSourceVerb(method)) return body;
     if (!resourcePath.startsWith(`${this.getBasePath()}/`)) return body;
-    if (resourcePath.startsWith(`${this.getBasePath()}/jsonldContexts`)) return body;
+    // Exact match, mirroring the server's CONTEXT_DOCUMENT_PATHS: only the
+    // collection body IS a context document. A future /jsonldContexts/{id}
+    // write would fall under the normal clause 6.3.5 rule on the server, so a
+    // prefix match here would withhold the @context it requires.
+    if (resourcePath === `${this.getBasePath()}/jsonldContexts`) return body;
 
     const context = this.context ? toBodyContext(this.context) : NGSI_LD_CORE_CONTEXT;
     if (Array.isArray(body)) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -374,13 +374,15 @@ export class GdbClient {
   ): Promise<ClientResponse<T>> {
     const resourcePath = `${this.getBasePath()}${path}`;
     const url = this.buildUrl(resourcePath, options?.params);
-    // #177/#186: NGSI-LD READS carry the @context in a Link header; raw
-    // admin/auth paths never do. Writes must NOT — under application/ld+json a
-    // JSON-LD Link header on POST/PATCH/PUT is a 400 (clause 6.3.5 "No mixes",
-    // geolonia/geonicdb#1924); their @context travels in the body instead
-    // (`prepareNgsiLdWriteBody`).
+    // #177/#186: NGSI-LD READS (GET/DELETE) carry the @context in a Link
+    // header; raw admin/auth paths never do. Writes must NOT — under
+    // application/ld+json a JSON-LD Link header on POST/PATCH/PUT is a 400
+    // (clause 6.3.5 "No mixes", geolonia/geonicdb#1924); their @context travels
+    // in the body instead (`prepareNgsiLdWriteBody`). An allowlist, not
+    // !isContextSourceVerb: other verbs (HEAD/OPTIONS) have no compaction to
+    // steer, so they get no Link either.
     const headers = this.buildHeaders(options?.headers, {
-      contextLink: !this.isContextSourceVerb(method),
+      contextLink: ["GET", "DELETE"].includes(method.toUpperCase()),
     });
     const injectedBody = options?.body
       ? this.prepareNgsiLdWriteBody(method, resourcePath, options.body)

--- a/src/commands/snapshots.ts
+++ b/src/commands/snapshots.ts
@@ -89,7 +89,12 @@ export function registerSnapshotsCommand(program: Command): void {
       withErrorHandler(async (_opts: unknown, cmd: Command) => {
         const client = createClient(cmd);
 
-        await client.post("/snapshots");
+        // The server requires a body for snapshot creation ("Request body is
+        // required") — a body-less POST only ever appeared to work against
+        // `createServer`, which fabricated `{}` for it (geolonia/geonicdb#2118).
+        // An explicit `{}` works everywhere, and the client injects the JSON-LD
+        // `@context` clause 6.3.5 demands of an ld+json object body.
+        await client.post("/snapshots", {});
         printSuccess("Snapshot created.");
       }),
     );

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -328,6 +328,35 @@ describe("GdbClient", () => {
       expect((sentBody() as Record<string, unknown>)["@context"]).toEqual([CTX, CTX2]);
     });
 
+    // Precedence: an explicit @context in the payload beats --context.
+    it("keeps a payload @context even when --context is configured", async () => {
+      const client = new GdbClient({ baseUrl: "http://localhost:3000", context: [CTX] });
+      mockOk(201);
+
+      await client.post("/entities", {
+        id: "urn:ngsi-ld:Building:1",
+        type: "Building",
+        "@context": "https://explicit.example/ctx.jsonld",
+      });
+
+      expect((sentBody() as Record<string, unknown>)["@context"]).toBe(
+        "https://explicit.example/ctx.jsonld",
+      );
+    });
+
+    // Several --context values on a WRITE go into the body as an array and,
+    // unlike the old Link-header path, warrant no warning — the server reads
+    // the whole body array.
+    it("injects all contexts into a write body without warning", async () => {
+      const client = new GdbClient({ baseUrl: "http://localhost:3000", context: [CTX, CTX2] });
+      mockOk(201);
+
+      await client.post("/subscriptions", { type: "Subscription" });
+
+      expect((sentBody() as Record<string, unknown>)["@context"]).toEqual([CTX, CTX2]);
+      expect(printWarning).not.toHaveBeenCalled();
+    });
+
     it("never overrides a caller-supplied @context", async () => {
       const client = new GdbClient({ baseUrl: "http://localhost:3000", context: [CTX] });
       mockOk(201);
@@ -436,39 +465,14 @@ describe("GdbClient", () => {
       ]);
     });
 
-    // #183: warn where the header is actually attached, not at client
-    // construction — admin/auth use raw paths that carry no context.
-    it("warns once when several contexts are actually sent", async () => {
-      const client = new GdbClient({ baseUrl: "http://localhost:3000", context: [CTX, CTX2] });
-      // A fresh Response per call: a body can only be read once.
-      vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
-        new Response(JSON.stringify([]), {
-          status: 200,
-          headers: { "Content-Type": "application/ld+json" },
-        }),
-      );
-
-      await client.get("/entities");
-      await client.get("/types");
-
-      expect(printWarning).toHaveBeenCalledTimes(1);
-      expect(printWarning).toHaveBeenCalledWith(expect.stringContaining("geonicdb#1818"));
-    });
-
-    it("does not warn for a single context", async () => {
-      const client = new GdbClient({ baseUrl: "http://localhost:3000", context: [CTX] });
-      mockOk(200, []);
-
-      await client.get("/entities");
-
-      expect(printWarning).not.toHaveBeenCalled();
-    });
-
-    it("does not warn on raw paths, which never carry a Link header", async () => {
+    // geolonia/geonicdb#1818 is fixed — the server merges every link-value, so
+    // the old "only the first is applied" warning is gone. Passing several
+    // contexts is a silent, fully-working operation now.
+    it("does not warn when several contexts are sent (#1818 is fixed)", async () => {
       const client = new GdbClient({ baseUrl: "http://localhost:3000", context: [CTX, CTX2] });
       mockOk(200, []);
 
-      await client.rawRequest("GET", "/admin/deployments");
+      await client.get("/entities");
 
       expect(printWarning).not.toHaveBeenCalled();
     });

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -144,9 +144,10 @@ describe("GdbClient", () => {
     expect(sentBody["@context"]).toBe(custom);
   });
 
-  // Batch is excluded to match the server's current #1583 scope (entity endpoints
-  // only); server-side batch @context enforcement is tracked in geonicdb#1599.
-  it("does NOT inject @context into batch (array) bodies (#168)", async () => {
+  // #189: the server enforces clause 6.3.5 on every NGSI-LD write path
+  // (geonicdb#2065) and batch elements are independent JSON-LD documents
+  // (clause 5.6.7.3), so each object element gets the core context.
+  it("injects the core @context into each element of a batch (array) body (#189)", async () => {
     const client = new GdbClient({ baseUrl: "http://localhost:3000" });
     const batch = [{ id: "Room:001", type: "Room" }];
 
@@ -159,19 +160,64 @@ describe("GdbClient", () => {
     const sentBody = JSON.parse(
       (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body as string,
     );
-    expect(sentBody).toEqual(batch);
-    expect(Array.isArray(sentBody)).toBe(true);
+    expect(sentBody).toEqual([
+      {
+        id: "Room:001",
+        type: "Room",
+        "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
+      },
+    ]);
   });
 
-  it("does NOT inject @context into non-entity endpoints (#168)", async () => {
+  // #189: subscriptions/registrations/temporal are NGSI-LD writes too — the
+  // server 400s them without a body @context (geonicdb#1599/#2065).
+  it("injects the core @context into every NGSI-LD write body, not just entities (#189)", async () => {
+    for (const path of ["/subscriptions", "/csourceRegistrations", "/temporal/entities", "/entityOperations/query"]) {
+      vi.restoreAllMocks();
+      const client = new GdbClient({ baseUrl: "http://localhost:3000" });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify({}), { status: 201 }),
+      );
+
+      await client.post(path, { type: "Anything" });
+
+      const sentBody = JSON.parse(
+        (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body as string,
+      );
+      expect(sentBody["@context"], `missing @context on ${path}`).toBe(
+        "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
+      );
+    }
+  });
+
+  // The /jsonldContexts body IS a context document — injecting a @context term
+  // into it would corrupt the registration (the server excludes it the same way).
+  it("does NOT inject @context into a /jsonldContexts registration body (#189)", async () => {
     const client = new GdbClient({ baseUrl: "http://localhost:3000" });
-    const body = { description: "sub", type: "Subscription" };
+    const body = { url: "https://example.org/ctx.jsonld", kind: "cached" };
 
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({}), { status: 201 }),
     );
 
-    await client.post("/subscriptions", body);
+    await client.post("/jsonldContexts", body);
+
+    const sentBody = JSON.parse(
+      (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body as string,
+    );
+    expect("@context" in sentBody).toBe(false);
+    expect(sentBody).toEqual(body);
+  });
+
+  it("does NOT inject @context into raw (non-NGSI-LD) write bodies (#189)", async () => {
+    const client = new GdbClient({ baseUrl: "http://localhost:3000" });
+    const body = { name: "a-rule" };
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({}), { status: 201 }),
+    );
+
+    await client.rawRequest("POST", "/rules", { body });
 
     const sentBody = JSON.parse(
       (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body as string,
@@ -322,26 +368,72 @@ describe("GdbClient", () => {
       expect(sentBody()).toEqual(ids);
     });
 
-    // The Query body is not an entity; the server reads the Link header for it.
-    it("leaves a batch query body untouched but still sends the Link header", async () => {
+    // #186: the Query operation is a POST, so its @context must travel in the
+    // body — a Link header alongside application/ld+json is a 400 (clause 6.3.5).
+    it("puts the context into a batch query body and sends no Link header", async () => {
       const client = new GdbClient({ baseUrl: "http://localhost:3000", context: [CTX] });
       mockOk(200, []);
 
-      const query = { type: "Building" };
-      await client.post("/entityOperations/query", query);
+      await client.post("/entityOperations/query", { type: "Building" });
 
-      expect(sentBody()).toEqual(query);
-      expect(sentHeaders().Link).toBe(LINK_ONE);
+      expect(sentBody()).toEqual({ type: "Building", "@context": CTX });
+      expect("Link" in sentHeaders()).toBe(false);
     });
 
-    it("does not inject a context into non-entity resources", async () => {
+    it("injects the context into every NGSI-LD write body, not just entities (#189)", async () => {
       const client = new GdbClient({ baseUrl: "http://localhost:3000", context: [CTX] });
       mockOk(201);
 
       const sub = { type: "Subscription", description: "sub" };
       await client.post("/subscriptions", sub);
 
-      expect(sentBody()).toEqual(sub);
+      expect(sentBody()).toEqual({ ...sub, "@context": CTX });
+    });
+
+    // #186: clause 6.3.5 "No mixes" — a JSON-LD Link header on a POST/PATCH/PUT
+    // under application/ld+json is rejected with 400 by the server.
+    it("never sends a Link header on writes, even with a context configured", async () => {
+      const calls: Array<() => Promise<unknown>> = [];
+      const client = new GdbClient({ baseUrl: "http://localhost:3000", context: [CTX] });
+      calls.push(
+        () => client.post("/entities", { id: "urn:x", type: "T" }),
+        () => client.patch("/entities/urn:x/attrs", { a: { type: "Property", value: 1 } }),
+        () => client.put("/entities/urn:x", { id: "urn:x", type: "T" }),
+        () => client.post("/subscriptions", { type: "Subscription" }),
+        () => client.post("/entityOperations/upsert", [{ id: "urn:x", type: "T" }]),
+      );
+      for (const call of calls) {
+        vi.restoreAllMocks();
+        mockOk(201);
+        await call();
+        expect("Link" in sentHeaders()).toBe(false);
+      }
+    });
+
+    it("still sends the Link header on DELETE, which has no body channel", async () => {
+      const client = new GdbClient({ baseUrl: "http://localhost:3000", context: [CTX] });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 204 }));
+
+      await client.delete("/entities/urn:x");
+
+      expect(sentHeaders().Link).toBe(LINK_ONE);
+    });
+
+    // Mixed-shape array: exclusion is decided by element shape, not by path —
+    // ID strings (entityOperations/delete) must never gain a @context wrapper.
+    it("injects into object elements only, leaving non-object elements alone", async () => {
+      const client = new GdbClient({ baseUrl: "http://localhost:3000", context: [CTX] });
+      mockOk(200);
+
+      await client.post("/entityOperations/create", [
+        { id: "urn:ngsi-ld:Building:1", type: "Building" },
+        "urn:ngsi-ld:Building:2",
+      ]);
+
+      expect(sentBody()).toEqual([
+        { id: "urn:ngsi-ld:Building:1", type: "Building", "@context": CTX },
+        "urn:ngsi-ld:Building:2",
+      ]);
     });
 
     // #183: warn where the header is actually attached, not at client

--- a/tests/e2e/features/context.feature
+++ b/tests/e2e/features/context.feature
@@ -102,6 +102,43 @@ Feature: JSON-LD @context on NGSI-LD requests
     Then the exit code should be 0
     And the JSON output key "type" should be "Vehicle"
 
+  # geonicdb-cli#186: clause 6.3.5 "No mixes" — under application/ld+json (which
+  # the CLI always sends) a POST/PATCH/PUT must take its @context from the body,
+  # and a JSON-LD Link header on such a request is rejected with 400 by the
+  # server (geolonia/geonicdb#1924). The Link channel is for reads only.
+  # https://cim.etsi.org/NGSI-LD/official/clause-6.html
+  Scenario: A write sends the @context in the body, never as a Link header
+    When I run `geonic entities create '{"id":"urn:ngsi-ld:Vehicle:e2e11","type":"Vehicle","plateNumber":{"type":"Property","value":"LNK-000"}}' --context https://example.org/e2e-vocab.jsonld --verbose`
+    Then the exit code should be 0
+    And stderr should not contain "> Link:"
+    And stderr should contain "e2e-vocab.jsonld"
+
+  Scenario: A read still sends the @context as a Link header
+    Given an entity "urn:ngsi-ld:Vehicle:e2e12" exists using the custom vocabulary
+    When I run `geonic entities get urn:ngsi-ld:Vehicle:e2e12 --context https://example.org/e2e-vocab.jsonld --verbose`
+    Then the exit code should be 0
+    And stderr should contain "> Link:"
+    And the JSON output key "type" should be "Vehicle"
+
+  # geonicdb-cli#189: every NGSI-LD write body must carry a @context inline —
+  # since geolonia/geonicdb#2065 the server rejects a bare body with 400 (or a
+  # per-element 207 for batches). The core context is injected when the user
+  # supplies none; the body assertion below is deliberate, because a green
+  # status alone could come from a server that stopped enforcing the rule.
+  Scenario: A write without --context gets the core @context injected into the body
+    When I run `geonic subscriptions create '{"type":"Subscription","entities":[{"type":"Vehicle"}],"notification":{"endpoint":{"uri":"http://localhost:3000/notify"}}}' --verbose`
+    Then the exit code should be 0
+    And stderr should contain "ngsi-ld-core-context.jsonld"
+
+  # The over-injection guard: entityOperations/delete sends bare ID strings that
+  # have no place for a @context (clause 5.6.10.3) — wrapping them would make
+  # the server reject the whole request.
+  Scenario: Batch delete ID strings are not wrapped with a @context
+    Given an entity "urn:ngsi-ld:Vehicle:e2e13" exists using the custom vocabulary
+    When I run `geonic batch delete '["urn:ngsi-ld:Vehicle:e2e13"]' --verbose`
+    Then the exit code should be 0
+    And stderr should not contain "@context"
+
   Scenario: An invalid @context URI is rejected before any request is made
     When I run `geonic entities list --context not-a-url`
     Then the exit code should be 1

--- a/tests/e2e/features/context.feature
+++ b/tests/e2e/features/context.feature
@@ -130,6 +130,15 @@ Feature: JSON-LD @context on NGSI-LD requests
     Then the exit code should be 0
     And stderr should contain "ngsi-ld-core-context.jsonld"
 
+  # temporal entityOperations query is a POST too — its Query body carries the
+  # @context (no Link header), same clause 6.3.5 rule as the entity paths.
+  Scenario: --context applies to temporal batch query reads
+    Given a temporal entity "urn:ngsi-ld:Vehicle:e2e14" exists using the custom vocabulary
+    When I run `geonic temporal entityOperations query '{"entities":[{"type":"Vehicle"}]}' --context https://example.org/e2e-vocab.jsonld --verbose`
+    Then the exit code should be 0
+    And stderr should not contain "> Link:"
+    And the output should not contain "example-vocab/ns#plateNumber"
+
   # The over-injection guard: entityOperations/delete sends bare ID strings that
   # have no place for a @context (clause 5.6.10.3) — wrapping them would make
   # the server reject the whole request.
@@ -149,18 +158,25 @@ Feature: JSON-LD @context on NGSI-LD requests
     Then the exit code should be 1
     And stderr should contain "must not contain"
 
-  # geolonia/geonicdb#1818: the server reads only the first link-value, so the
-  # dropped vocabularies must be announced rather than silently lost.
-  Scenario: Supplying several contexts warns that only the first is applied
+  # geolonia/geonicdb#1818 is fixed: the server merges every supplied @context,
+  # so the CLI no longer warns when several are passed. The two vocabularies
+  # below each define only ONE of the entity's terms — both terms coming back
+  # compacted proves both contexts were applied (not just the first).
+  Scenario: Several contexts are all applied, without a warning
     Given an entity "urn:ngsi-ld:Vehicle:e2e10" exists using the custom vocabulary
-    And a JSON-LD context "https://example.org/e2e-second.jsonld" is registered with:
+    And a JSON-LD context "https://example.org/e2e-type-only.jsonld" is registered with:
       """
-      { "Unrelated": "https://example-vocab/ns#Unrelated" }
+      { "Vehicle": "https://example-vocab/ns#Vehicle" }
       """
-    When I run `geonic entities get urn:ngsi-ld:Vehicle:e2e10 --context https://example.org/e2e-vocab.jsonld --context https://example.org/e2e-second.jsonld`
+    And a JSON-LD context "https://example.org/e2e-attr-only.jsonld" is registered with:
+      """
+      { "plateNumber": "https://example-vocab/ns#plateNumber" }
+      """
+    When I run `geonic entities get urn:ngsi-ld:Vehicle:e2e10 --context https://example.org/e2e-type-only.jsonld --context https://example.org/e2e-attr-only.jsonld`
     Then the exit code should be 0
-    And stderr should contain "geonicdb#1818"
+    And stderr should not contain "geonicdb#1818"
     And the JSON output key "type" should be "Vehicle"
+    And the JSON output should have key "plateNumber"
 
   # A non-ASCII URI cannot go into a header (ByteString), and used to surface as
   # an unreadable TypeError from deep inside fetch.

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -72,11 +72,13 @@ describe("snapshots command", () => {
   });
 
   describe("create", () => {
-    it("posts to /snapshots with no body", async () => {
+    // #189: the server requires a body ("Request body is required"); the client
+    // layer turns the explicit {} into {"@context": core} under ld+json.
+    it("posts an explicit empty body to /snapshots", async () => {
       mockClient.post.mockResolvedValue(mockResponse(undefined, 201));
       await runCommand(program, ["snapshots", "create"]);
 
-      expect(mockClient.post).toHaveBeenCalledWith("/snapshots");
+      expect(mockClient.post).toHaveBeenCalledWith("/snapshots", {});
       expect(printSuccess).toHaveBeenCalledWith("Snapshot created.");
     });
   });


### PR DESCRIPTION
Closes #186
Closes #189
Closes #187

## 何を直したか

GeonicDB 本体が ETSI GS CIM 009 **clause 6.3.5** (`@context` の供給元規則 / "No mixes") を全 NGSI-LD 書き込み経路へ enforcement した (geolonia/geonicdb#1924 / #2065) ことへの追従。週次互換性チェックの失敗 (#187) はこのクラスが原因だった。

1. **書き込み (POST/PATCH/PUT) では JSON-LD `Link` ヘッダを送らない** (#186) — `application/ld+json` との併用はリクエスト単位の 400。`Link` は読み取り (GET/DELETE) 専用チャネルに。
2. **core `@context` / `--context` の本文注入を NGSI-LD 全書き込み経路へ拡張** (#189) — object ボディ (entities / subscriptions / registrations / temporal / query / snapshots) と配列ボディの各 object 要素。非 object 要素 (`entityOperations/delete` の ID 文字列) は**形**で除外 (サーバの `contextComplianceErrorForElement` と同じ判定軸)、`/jsonldContexts` は完全一致で除外 (サーバの `CONTEXT_DOCUMENT_PATHS` と同一)。優先順: payload 明示 > `--context` > core context。
3. **`snapshots create` はボディ `{}` を明示送信** — サーバはボディ必須 ("Request body is required")。従来は local server のボディ捏造 (geolonia/geonicdb#2118) で偶然通っていた。
4. **geonicdb pin を `1e6c983d`** (clause 6.3.5 全経路 enforcement + #2118 修正込み) へ更新 (#187)。
5. 複数 `--context` の #1818 警告を削除 — geolonia/geonicdb#1818 は解消済みでサーバは全 link-value をマージする (README も追従)。

## 再現ファースト

pin を新サーバへ上げ、**修正前の CLI で E2E 29 シナリオが赤** (batch / subscriptions / registrations / temporal / context の 400・207) であることを実測 → 修正後 **203/203 全緑**。

## 変異注入 (すべて赤を実測・復元済み)

- M1 (client.ts 全体を base に revert): E2E 29 シナリオ赤
- M2a (`contextLink: true` — 旧挙動): unit 2 赤
- M2b (注入スコープを `/entities` のみへ): unit 6 赤
- M2c (jsonldContexts 除外行の削除): unit 1 赤
- near-miss: DELETE は Link を維持 / 混在配列の非 object 要素は不変 / `/jsonldContexts` 非注入

## 独立レビュー (サイトー)

blocking 2 件 (snapshots テスト未追従 / clone の 400) と M2/L1/L2/L3 を反映済み。M1 提案 (空 `@context` をサーバの `isAbsentBodyContext` 相当で absent 扱いし注入) は**棄却**: 明示された payload の `@context` は空でも利用者の意図的な選択で、CLI が黙って書き換えるのはこのフラグが排除しようとしている quiet failure と同じクラス。サーバの 400 が正当な裁定。

派生で本体側に 2 件起票: geolonia/geonicdb#2126 (#2119 レビューの軽微指摘) / geolonia/geonicdb#2127 (snapshots PATCH が ld+json で詰む)。

## 仕様参照

- https://cim.etsi.org/NGSI-LD/official/clause-6.html (clause 6.3.5)
- https://cim.etsi.org/NGSI-LD/official/clause-5.html (clause 5.6.7.3 / 5.6.10.3)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改善**
  - JSON-LD の `@context` を書き込み本文へ自動適用し、既存値や指定値を優先して保持します。
  - 複数のコンテキストをすべて利用でき、不要な警告を表示しなくなりました。
  - 書き込み時の `Link` ヘッダー送信を停止し、読み取り時のみ使用します。
  - スナップショット作成時に空の JSON 本文を送信するよう改善しました。

- **ドキュメント**
  - JSON-LD コンテキストの新しい動作を README と変更履歴に反映しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->