### PR TITLE
fix(retry): 504 LdContextNotAvailable を非リトライにする (closes #182)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## [Unreleased]
 
+### 2026-08-13
+- **Fix**: bulk import のリトライ判定で `504 LdContextNotAvailable` を非リトライにした (closes #182, 本体 geolonia/geonicdb#1801 対応) (#192)。`@context` URL の打ち間違いのような恒久エラーがリトライ回数を使い切るまでバックオフし続けていた。判定はステータスでなくエラーボディの `type` (`https://uri.etsi.org/ngsi-ld/errors/LdContextNotAvailable`) で行い、type を持たない素の 504 (ゲートウェイタイムアウト等) は従来どおりリトライする
+
 ### 2026-08-06
 - **Fix**: #178 / #179 のマージ後レビュー (Cursor CLI の別系統 2 モデル) で検出した 5 件を修正 (closes #183) (#184)
   - **非 ASCII の `--context` が実行時 TypeError になっていた**。`Link` ヘッダーは ByteString 制約があるため、`https://example.org/日本語.jsonld` のような URI は fetch の深部で `Cannot convert argument to a ByteString...` を投げていた。検証境界で拒否し、percent-encoded / punycode 形式を案内する。`@context` URL は完全一致で比較されるため、正規化して送るのではなく拒否する (#178 の設計を維持)

--- a/src/retry.ts
+++ b/src/retry.ts
@@ -23,12 +23,29 @@ const DEFAULT_BASE_DELAY_MS = 500;
 const DEFAULT_MAX_DELAY_MS = 30_000;
 
 /**
+ * #182: the NGSI-LD error type for a `@context` the server could not dereference.
+ * GeonicDB returns it as 504 (ETSI GS CIM 009 clause 6.3.2 Table 6.3.2-1,
+ * geolonia/geonicdb#1801), which the status-based rule below would retry.
+ */
+const LD_CONTEXT_NOT_AVAILABLE = "https://uri.etsi.org/ngsi-ld/errors/LdContextNotAvailable";
+
+/**
  * Determine whether an error is worth retrying: server-side transient failures
  * (429 / 5xx), network errors, and request timeouts (AbortError). Client input
  * errors (4xx other than 429) are NOT retryable — retrying won't help.
+ *
+ * #182: `504 LdContextNotAvailable` is excluded from the 5xx rule. The 504 says
+ * the server could not resolve the request's `@context` URL — for a bulk import
+ * that URL is identical on every chunk and every attempt, so the dominant cause
+ * (a mistyped or unregistered context) can never succeed on retry; backing off
+ * just makes an input error look like a slow server. The cost of this choice is
+ * that a genuinely transient DNS failure fails fast too — acceptable, because
+ * the failed entities land in `--errors-out` and are re-submittable, while the
+ * status quo (retrying a typo to exhaustion) has no such recovery.
  */
 export function isRetryableError(err: unknown): boolean {
   if (err instanceof GdbClientError) {
+    if (err.ngsiError?.type === LD_CONTEXT_NOT_AVAILABLE) return false;
     return err.status === 429 || err.status >= 500;
   }
   if (err instanceof Error) {

--- a/tests/loader.test.ts
+++ b/tests/loader.test.ts
@@ -323,6 +323,25 @@ describe("BulkImporter", () => {
     expect(client.post).toHaveBeenCalledTimes(1);
   });
 
+  // #182: a 504 LdContextNotAvailable is a permanent input error (the @context
+  // URL is the same on every attempt) — the chunk must fail once, not burn the
+  // retry budget with backoff.
+  it("does not retry a 504 LdContextNotAvailable (#182)", async () => {
+    const client = {
+      post: vi.fn().mockRejectedValue(
+        new GdbClientError("Could not resolve @context", 504, {
+          type: "https://uri.etsi.org/ngsi-ld/errors/LdContextNotAvailable",
+        }),
+      ),
+    };
+    const onRetry = vi.fn();
+    const importer = new BulkImporter(client as never, baseOpts({ onRetry }));
+    const result = await importer.run(fromArray(records(["a"])));
+    expect(result.failed).toBe(1);
+    expect(client.post).toHaveBeenCalledTimes(1);
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+
   it("retries a 429 then succeeds", async () => {
     const client = {
       post: vi

--- a/tests/retry.test.ts
+++ b/tests/retry.test.ts
@@ -28,6 +28,29 @@ describe("isRetryableError", () => {
     expect(isRetryableError("nope")).toBe(false);
     expect(isRetryableError(new Error("plain"))).toBe(false);
   });
+
+  // #182: 504 LdContextNotAvailable = the request's @context could not be
+  // resolved. The URL is the same on every attempt, so retrying cannot help.
+  it("treats 504 LdContextNotAvailable as non-retryable (#182)", () => {
+    const err = new GdbClientError("Could not resolve @context", 504, {
+      type: "https://uri.etsi.org/ngsi-ld/errors/LdContextNotAvailable",
+      title: "LD Context Not Available",
+    });
+    expect(isRetryableError(err)).toBe(false);
+  });
+
+  // near-miss: a 504 WITHOUT that error type (e.g. a gateway timeout) must stay
+  // retryable — the exclusion keys on the NGSI-LD error type, not the status.
+  it("keeps a plain 504 (no LdContextNotAvailable type) retryable", () => {
+    expect(isRetryableError(new GdbClientError("upstream timeout", 504))).toBe(true);
+    expect(
+      isRetryableError(
+        new GdbClientError("boom", 504, {
+          type: "https://uri.etsi.org/ngsi-ld/errors/InternalError",
+        }),
+      ),
+    ).toBe(true);
+  });
 });
 
 describe("withRetry", () => {


### PR DESCRIPTION
Closes #182

## 何を直したか

本体 geolonia/geonicdb#1801 で `@context` 解決失敗が `400 BadRequestData` → `504 LdContextNotAvailable` に変わり、bulk import (`withRetry`) がホスト名の打ち間違いのような**恒久エラーでもリトライ回数を使い切るまでバックオフし続ける**ようになっていた (「入力ミスなのに、なぜか遅くて、最後に失敗する」体験)。

issue の対応案 1 を採用: ステータスではなく**エラーボディの `type`** (`https://uri.etsi.org/ngsi-ld/errors/LdContextNotAvailable`) で判定して非リトライにする。

- `@context` URL はチャンクごと・試行ごとに同一なので、支配的な原因 (typo / 未登録 context) はリトライで直りようがない
- トレードオフ (一時的な DNS 障害も即失敗) は許容: 失敗エンティティは `--errors-out` で再投入可能で、現状 (typo を使い切るまでリトライ) には回復手段が無い
- **near-miss**: `type` を持たない素の 504 (ゲートウェイタイムアウト等) や別 type の 504 は従来どおりリトライ対象のまま (テストで固定)

## テスト / 変異注入

- unit: `isRetryableError` の type 判定 + near-miss 2 種 (`tests/retry.test.ts`)、loader 経由で「1 回だけ送って失敗・onRetry 不発火」(`tests/loader.test.ts`)
- M1 (type 判定行を削除): **2 件赤**を実測 → 復元で 47/47 緑
- E2E での再現は行わない: 504 LdContextNotAvailable の実発火には実 DNS 失敗する外部 `@context` が必要で、CI で flaky になる。契約は unit で `type` 文字列まで固定した


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * bulk import で、`LdContextNotAvailable` 型の HTTP 504 エラーを再試行しないようにしました。
  * エラー型がない 504 や `InternalError` の 504 は、従来どおり再試行されます。
* **テスト**
  * 上記エラー発生時に再試行されないこと、およびその他の 504 が再試行されることを確認するテストを追加しました。
* **ドキュメント**
  * 修正内容を変更履歴に追記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->