### PR TITLE
docs(import): バッチ上限のプラン別化 (geonicdb#2082) へ追従 (closes #190)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## [Unreleased]
 
+### 2026-08-13
+- **Docs**: バッチ件数上限のプラン別化 (本体 geolonia/geonicdb#2082: T0/T5 100, T30 500, T40 1,000) に合わせて `import --batch-size` のヘルプと README を更新した (closes #190) (#193)。CLI 側に 100 のハードコードや上限超過メッセージの文字列照合が無いことを実測で確認し、`--batch-size 1000` が CLI 側で cap されない回帰ガードを追加
+
 ### 2026-08-06
 - **Fix**: #178 / #179 のマージ後レビュー (Cursor CLI の別系統 2 モデル) で検出した 5 件を修正 (closes #183) (#184)
   - **非 ASCII の `--context` が実行時 TypeError になっていた**。`Link` ヘッダーは ByteString 制約があるため、`https://example.org/日本語.jsonld` のような URI は fetch の深部で `Cannot convert argument to a ByteString...` を投げていた。検証境界で拒否し、percent-encoded / punycode 形式を案内する。`@context` URL は完全一致で比較されるため、正規化して送るのではなく拒否する (#178 の設計を維持)

--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ geonic import entities.ndjson --dry-run
 |---|---|
 | `--input-format <fmt>` | `ndjson` (default, streamed) or `json` (a JSON array, loaded into memory) |
 | `--mode <mode>` | `upsert` (merge, default) or `replace` |
-| `--batch-size <n>` | Entities per request (default 100; must not exceed your plan's max batch size) |
+| `--batch-size <n>` | Entities per request (default 100 = safe on every plan; raise it up to your plan's batch limit — T30 500, T40 1,000, absolute max 1,000) |
 | `--max-bytes <n>` | Max request body bytes per chunk (default 1,000,000) |
 | `--concurrency <n>` | Concurrent requests (default 1 = sequential; a shared cooldown honors 429s) |
 | `--retries <n>` | Max retries per chunk on 429/5xx/timeout (default 5) |
@@ -407,6 +407,14 @@ geonic import entities.ndjson --dry-run
 | `--bisect` / `--bisect-max <n>` | On a `400`/`413` chunk, binary-split to isolate the offending entity |
 
 Notes:
+- **Batch size is plan-dependent** (geolonia/geonicdb#2082): T0/T5 plans allow 100 entities per
+  batch request, T30 500, T40 1,000 (1,000 is also the absolute ceiling; a tenant-specific
+  `maxBatchSize` quota overrides the plan value). The default `--batch-size 100` works on every
+  plan; on a higher plan, raising it reduces HTTP round-trips (the rate-quota weight is per
+  entity, so the total cost is unchanged). Exceeding your plan's limit fails the chunk with
+  `400` `"Batch size N cannot exceed the plan limit of M entities per batch"` — the CLI shows the
+  server message as-is, so the remedy is to lower `--batch-size` (or raise the plan). With
+  `--bisect`, an oversized chunk is split instead of being lost.
 - Input is read from a file path or, with `-` / a pipe, from stdin. **Resume is only available for
   file input** (stdin cannot be replayed) and **only with `--mode upsert`** (replaying a `replace`
   would overwrite newer state).

--- a/README.md
+++ b/README.md
@@ -414,7 +414,9 @@ Notes:
   entity, so the total cost is unchanged). Exceeding your plan's limit fails the chunk with
   `400` `"Batch size N cannot exceed the plan limit of M entities per batch"` — the CLI shows the
   server message as-is, so the remedy is to lower `--batch-size` (or raise the plan). With
-  `--bisect`, an oversized chunk is split instead of being lost.
+  `--bisect`, a `400`/`413` chunk is binary-split (up to `--bisect-max`) to isolate the
+  offending entities; anything that still fails is recorded as failed (use `--errors-out`
+  to capture it for re-submission).
 - Input is read from a file path or, with `-` / a pipe, from stdin. **Resume is only available for
   file input** (stdin cannot be replayed) and **only with `--mode upsert`** (replaying a `replace`
   would overwrite newer state).

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -95,7 +95,7 @@ export function registerImportCommand(program: Command): void {
     // (T0/T5 100, T30 500, T40 1,000; absolute max 1,000). The default stays 100
     // so it works on every plan; the CLI does not hard-cap the value — the server
     // owns the limit and its 400 names the plan limit explicitly.
-    .option("--batch-size <n>", "Entities per request (default 100 = safe on every plan; plan limits: T0/T5 100, T30 500, T40 1,000)", parsePositiveInt, 100)
+    .option("--batch-size <n>", "Entities per request (default 100 = safe on every plan; plan limits: T0/T5 100, T30 500, T40 1,000; the server rejects values over your plan limit, absolute max 1,000)", parsePositiveInt, 100)
     .option("--max-bytes <n>", "Max request body bytes per chunk", parsePositiveInt, 1_000_000)
     .option("--concurrency <n>", "Concurrent requests (default 1 = sequential)", parsePositiveInt, 1)
     .option("--retries <n>", "Max retries per chunk on 429/5xx/timeout", parsePositiveInt, 5)

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -91,7 +91,11 @@ export function registerImportCommand(program: Command): void {
     )
     .option("--input-format <fmt>", "Input format: ndjson (default) or json", parseInputFormat, "ndjson")
     .option("--mode <mode>", "upsert (merge, default) or replace", parseMode, "upsert")
-    .option("--batch-size <n>", "Entities per request (default 100; must not exceed your plan's max batch size)", parsePositiveInt, 100)
+    // #190: the per-request cap is plan-dependent since geolonia/geonicdb#2082
+    // (T0/T5 100, T30 500, T40 1,000; absolute max 1,000). The default stays 100
+    // so it works on every plan; the CLI does not hard-cap the value — the server
+    // owns the limit and its 400 names the plan limit explicitly.
+    .option("--batch-size <n>", "Entities per request (default 100 = safe on every plan; plan limits: T0/T5 100, T30 500, T40 1,000)", parsePositiveInt, 100)
     .option("--max-bytes <n>", "Max request body bytes per chunk", parsePositiveInt, 1_000_000)
     .option("--concurrency <n>", "Concurrent requests (default 1 = sequential)", parsePositiveInt, 1)
     .option("--retries <n>", "Max retries per chunk on 429/5xx/timeout", parsePositiveInt, 5)

--- a/tests/import.test.ts
+++ b/tests/import.test.ts
@@ -78,6 +78,15 @@ describe("import command", () => {
     expect(output.printSuccess).toHaveBeenCalled();
   });
 
+  // #190: batch limits are plan-based (T30 500 / T40 1,000; geolonia/geonicdb#2082).
+  // The CLI must not hard-cap --batch-size at the lowest plan's 100 — the server
+  // owns the limit and reports overruns with an explicit 400.
+  it("accepts a plan-level --batch-size up to 1000 without a client-side cap (#190)", async () => {
+    await runCommand(program, ["import", "data.ndjson", "--batch-size", "1000"]);
+    const opts = ctorSpy.mock.calls[0][1] as Record<string, unknown>;
+    expect(opts).toMatchObject({ batchSize: 1000 });
+  });
+
   it("uses stdin (no fingerprint) for '-'", async () => {
     await runCommand(program, ["import", "-"]);
     const opts = ctorSpy.mock.calls[0][1] as Record<string, unknown>;


### PR DESCRIPTION
Closes #190

## 内容

本体 geolonia/geonicdb#2082 / #2091 でバッチ 1 回あたりの件数上限がプラン別 (T0/T5 100, T30 500, T40 1,000 / 絶対上限 1,000) になったことへの追従。issue の確認 4 点を実測した結果、**コードの動作変更は不要**で、ドキュメント/ヘルプの更新 + 回帰ガード 1 件を追加した。

1. **チャンクサイズの 100 ハードコード**: 無い。`--batch-size` はフラグ (既定 100) で、上位プランは `--batch-size 1000` まで指定可能。既定 100 は全プランで安全なので据え置き (上げると T0/T5 で即 400 になる)
2. **エラーメッセージの文字列照合**: 無い。CLI はサーバの 400 `detail` (`Batch size N cannot exceed the plan limit of M entities per batch`) を verbatim 表示するので、プラン上限か絶対上限かはサーバの文言がそのまま伝わる
3. **実効上限の取得**: super_admin 権限が要るため CLI からの自動取得はしない。README にプラン表と対処 (batch-size を下げる / プランを上げる) を記載
4. **--bisect との相互作用**: 400 チャンクは分割されるため、過大チャンクは救済される旨を README に明記

## 変更

- `--batch-size` のヘルプとコメント、README の import 節にプラン別上限の説明を追加
- 回帰ガード: `--batch-size 1000` が CLI 側で cap されず loader へ届くことを unit で固定 (将来「最低プランの 100 で hard cap」する退行を防ぐ)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * `import --batch-size` の既定値、プラン別上限、テナント固有の上書きについて説明を更新しました。
  * 上限超過時のエラーや、`--bisect` による分割・失敗エンティティの記録について追記しました。
  * 上位プランで大きなバッチサイズを利用でき、HTTP通信回数を削減できる点を明記しました。

* **テスト**
  * バッチサイズ1,000がクライアント側で一律に制限されないことを確認する回帰テストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->