### PR TITLE
ci: CodeRabbit の request_changes_workflow を有効化し APPROVE を出せるようにする

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+#
+# CodeRabbit 設定 — 本体 (geolonia/geonicdb) と同じ構成。
+#
+# PR 作成時 + 毎 push (増分レビュー) で自動発火する。手動で `@coderabbitai review` を
+# 打たなくても、PR を開けば/push すればレビューが走る。
+#
+# 注意: CodeRabbit は **base ブランチ (main) の .coderabbit.yaml** を読むため、この設定は
+# main にマージされて初めて有効になる。
+language: ja-JP
+reviews:
+  # PR 作成時・push 時の自動レビューを有効化
+  auto_review:
+    enabled: true
+  # 変更サマリの自動生成は残す (レビュー本体より軽く、PR の把握に有用)
+  high_level_summary: true
+  # レビュー結果を GitHub の review state に反映する (既定 false = 常に COMMENTED)。
+  #
+  #   true  → 指摘がある間は REQUEST_CHANGES、全指摘が resolve され pre-merge チェックが
+  #           緑になったら自動で APPROVE。
+  #   false → APPROVE も REQUEST_CHANGES も出さず、COMMENTED のみ。
+  #
+  # 目的は 2 つ:
+  #   1. `reviewDecision` を機能させる — false のままだと CodeRabbit が指摘を出しても
+  #      `reviewDecision` に一切反映されず、未解決スレッドの有無だけが頼りになる。
+  #   2. org ruleset "branch-rules: main-protection" の必須承認 (1 件) を CodeRabbit の
+  #      APPROVE で満たせるようにする。本リポジトリに CODEOWNERS は無いため
+  #      `require_code_owner_review` は no-op であり、`require_last_push_approval` も
+  #      「最終 push 者以外の承認」なので CodeRabbit の承認で満たされる。
+  #      これにより本体と同様、--admin バイパスなしでマージできる。
+  request_changes_workflow: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -5,8 +5,10 @@
 # PR 作成時 + 毎 push (増分レビュー) で自動発火する。手動で `@coderabbitai review` を
 # 打たなくても、PR を開けば/push すればレビューが走る。
 #
-# 注意: CodeRabbit は **base ブランチ (main) の .coderabbit.yaml** を読むため、この設定は
-# main にマージされて初めて有効になる。
+# 注意: CodeRabbit は **レビュー対象の feature branch にある .coderabbit.yaml** をその
+# レビューに自動適用する。したがってこの設定は main へのマージ前 (このファイルを含む
+# PR 自身) から有効になる。
+# https://docs.coderabbit.ai/getting-started/yaml-configuration
 language: ja-JP
 reviews:
   # PR 作成時・push 時の自動レビューを有効化


### PR DESCRIPTION
## 概要

本体 (geolonia/geonicdb) と同等の `.coderabbit.yaml` を導入し、CodeRabbit がレビュー結果を GitHub の review state (APPROVE / REQUEST_CHANGES) に反映できるようにする。

## 背景

- main のブランチ保護は org 共通 ruleset で本体と完全同一 (必須承認 1 件)
- しかし CLI には `.coderabbit.yaml` が無く、CodeRabbit は常に **COMMENTED のみ** (#191, #184 で実測)
- そのため必須承認を CodeRabbit で満たせず、`reviewDecision` も機能していなかった

## 変更内容

- `.coderabbit.yaml` を追加 (本体と同じ構成: `auto_review.enabled: true` / `high_level_summary: true` / `request_changes_workflow: true`)
- コメントは CLI の ruleset 実態に合わせて記述 (CODEOWNERS 不在のため `require_code_owner_review` は no-op、`require_last_push_approval` は「最終 push 者以外の承認」なので CodeRabbit の APPROVE で満たされる)

## 注意 (レビューで訂正済み)

当初「CodeRabbit は base ブランチ (main) の設定を読むため効果はマージ後から」と書いたが、これは誤り。**CodeRabbit はレビュー対象の feature branch にある `.coderabbit.yaml` をそのレビューに自動適用する**ため、本 PR 自身から `request_changes_workflow` が有効になっている (本 PR に CHANGES_REQUESTED が付いたことが実証)。

設定ファイルのみの変更で、CLI のソースコード・依存関係には触れていない。
