### PR TITLE
release: v0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## [Unreleased]
 
+## [0.24.0] - 2026-08-13
+
 ### 2026-08-13
 - **Feat**: NGSI-LD temporal の表現パラメータに対応した (closes #181, closes #188, 本体 geolonia/geonicdb#1804 / #1814 / #1816 / #1817 対応) (#194)
   - `temporal entities list` / `get` に `--options` (`temporalValues` (alias `simplified`) | `aggregatedValues` | `sysAttrs`) と `--aggr-methods` / `--aggr-period` を追加 (ETSI GS CIM 009 clause 6.3.11 / 6.3.12)
@@ -396,7 +398,9 @@
 ### 2026-02-26
 - **Docs**: README にインストール手順・使い方・コマンドリファレンスを追加 (#1)
 
-[Unreleased]: https://github.com/geolonia/geonicdb-cli/compare/v0.22.1...HEAD
+[Unreleased]: https://github.com/geolonia/geonicdb-cli/compare/v0.24.0...HEAD
+[0.24.0]: https://github.com/geolonia/geonicdb-cli/compare/v0.23.0...v0.24.0
+[0.23.0]: https://github.com/geolonia/geonicdb-cli/compare/v0.22.1...v0.23.0
 [0.22.1]: https://github.com/geolonia/geonicdb-cli/compare/v0.22.0...v0.22.1
 [0.22.0]: https://github.com/geolonia/geonicdb-cli/compare/v0.21.0...v0.22.0
 [0.21.0]: https://github.com/geolonia/geonicdb-cli/compare/v0.20.0...v0.21.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolonia/geonicdb-cli",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolonia/geonicdb-cli",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolonia/geonicdb-cli",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "A CLI client for the GeonicDB",
   "type": "module",
   "bin": {


### PR DESCRIPTION
v0.24.0 リリース。

## 含まれる変更
- **#194 (closes #181, closes #188)**: NGSI-LD temporal 表現パラメータ (`--options` / `--aggr-methods` / `--aggr-period`) を GET 経路へ追加し、`entityOperations query` (POST) の `--aggr-*` を本体 geonicdb#1816 の集約実装へ配線。決定的 400 / silent no-op の組合せは CLI で fail-fast。
- **#193 (closes #190)**: バッチ件数上限のプラン別化 (本体 geonicdb#2082) へ `import --batch-size` のヘルプ・README を追従。
- **#192 (closes #182)**: bulk import のリトライ判定で `504 LdContextNotAvailable` を非リトライ化。
- **#191 (closes #186, #189, #187)**: ETSI GS CIM 009 clause 6.3.5 の `@context` 供給元規則へ全面準拠 (書き込みは body 注入、Link は読み取り専用チャネル)。

## リリース手順
- package.json / package-lock.json を 0.24.0 に bump。
- CHANGELOG の `[Unreleased]` を `[0.24.0] - 2026-08-13` に確定 (欠落していた `[0.23.0]` の compare リンクも補完)。
- マージ後 `v0.24.0` タグ push で publish.yml が CI 検証のうえ npm 公開 (OIDC Trusted Publishing)。

MINOR bump: 新機能追加 (temporal 表現パラメータ) のため。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **変更**
  - 製品バージョンを **0.24.0** に更新しました。
  - リリース履歴に **0.24.0（2026年8月13日）** を追加しました。
  - 各バージョン間の比較リンクを最新の状態に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->