### PR TITLE
feat(attrs): entities attrs delete に --dataset-id / --delete-all を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## [Unreleased]
 
+### 2026-08-17
+- **Feat**: `entities attrs delete` に `--dataset-id` / `--delete-all` を追加し、多重属性インスタンスを CLI から削除できるようにした (closes #197, 本体 geolonia/geonicdb#2177 対応) (#204)。未指定時は既定インスタンスのみ削除する既存挙動を維持。両方指定はリクエスト前に拒否。404 時は `--dataset-id` / `--delete-all` を案内する Hint を付与
+
 ## [0.24.0] - 2026-08-13
 
 ### 2026-08-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ## [Unreleased]
 
 ### 2026-08-17
-- **Feat**: `entities attrs delete` に `--dataset-id` / `--delete-all` を追加し、多重属性インスタンスを CLI から削除できるようにした (closes #197, 本体 geolonia/geonicdb#2177 対応) (#204)。未指定時は既定インスタンスのみ削除する既存挙動を維持。両方指定はリクエスト前に拒否。404 時は `--dataset-id` / `--delete-all` を案内する Hint を付与
+- **Feat**: `entities attrs delete` に `--dataset-id` / `--delete-all` を追加し、多重属性インスタンスを CLI から削除できるようにした (closes #197, 本体 geolonia/geonicdb#2177 対応)。未指定時は既定インスタンスのみ削除する既存挙動を維持。両方指定はリクエスト前に拒否。404 時は `--dataset-id` / `--delete-all` を案内する Hint を付与 (#204)
 
 ## [0.24.0] - 2026-08-13
 

--- a/src/commands/attrs.ts
+++ b/src/commands/attrs.ts
@@ -198,13 +198,19 @@ export function addAttrsSubcommands(attrs: Command): void {
           opts: { datasetId?: string; deleteAll?: boolean },
           cmd: Command,
         ) => {
-          if (opts.datasetId && opts.deleteAll) {
+          // Commander omits the option (undefined) when unset; an explicit
+          // empty `--dataset-id ""` must not be treated as "omit" or the
+          // default instance would be deleted by accident.
+          if (opts.datasetId !== undefined && opts.deleteAll) {
             throw new Error("Cannot specify both --dataset-id and --delete-all.");
+          }
+          if (opts.datasetId !== undefined && opts.datasetId === "") {
+            throw new Error("--dataset-id must not be empty.");
           }
 
           const client = createClient(cmd);
           const params: Record<string, string> = {};
-          if (opts.datasetId) params.datasetId = opts.datasetId;
+          if (opts.datasetId !== undefined) params.datasetId = opts.datasetId;
           if (opts.deleteAll) params.deleteAll = "true";
 
           const path = `/entities/${encodeURIComponent(entityId)}/attrs/${encodeURIComponent(attrName)}`;

--- a/src/commands/attrs.ts
+++ b/src/commands/attrs.ts
@@ -1,4 +1,5 @@
 import type { Command } from "commander";
+import { GdbClientError } from "../client.js";
 import {
   withErrorHandler,
   createClient,
@@ -179,22 +180,48 @@ export function addAttrsSubcommands(attrs: Command): void {
   // attrs delete
   const del = attrs
     .command("delete")
-    .description("Remove an attribute from an entity permanently")
+    .description(
+      "Remove an attribute from an entity permanently\n\n" +
+        "Without --dataset-id or --delete-all, only the default instance " +
+        "(no datasetId) is deleted. Multi-instance attributes need " +
+        "--dataset-id <id> or --delete-all (ETSI GS CIM 009 clause 5.6.5.4).",
+    )
     .argument("<entityId>", "Entity ID")
     .argument("<attrName>", "Attribute name")
+    .option("--dataset-id <id>", "Delete only the attribute instance with this datasetId")
+    .option("--delete-all", "Delete all instances of the attribute (including those with datasetId)")
     .action(
       withErrorHandler(
         async (
           entityId: string,
           attrName: string,
-          _opts: unknown,
+          opts: { datasetId?: string; deleteAll?: boolean },
           cmd: Command,
         ) => {
-          const client = createClient(cmd);
+          if (opts.datasetId && opts.deleteAll) {
+            throw new Error("Cannot specify both --dataset-id and --delete-all.");
+          }
 
-          await client.delete(
-            `/entities/${encodeURIComponent(entityId)}/attrs/${encodeURIComponent(attrName)}`,
-          );
+          const client = createClient(cmd);
+          const params: Record<string, string> = {};
+          if (opts.datasetId) params.datasetId = opts.datasetId;
+          if (opts.deleteAll) params.deleteAll = "true";
+
+          const path = `/entities/${encodeURIComponent(entityId)}/attrs/${encodeURIComponent(attrName)}`;
+          try {
+            if (Object.keys(params).length > 0) {
+              await client.delete(path, params);
+            } else {
+              await client.delete(path);
+            }
+          } catch (err: unknown) {
+            if (err instanceof GdbClientError && err.status === 404) {
+              throw new Error(
+                `${err.message}\nHint: A default attribute instance (without datasetId) may not exist. Try --dataset-id <id> or --delete-all.`,
+              );
+            }
+            throw err;
+          }
           printSuccess("Attribute deleted.");
         },
       ),
@@ -210,6 +237,16 @@ export function addAttrsSubcommands(attrs: Command): void {
       description: "Remove a deprecated attribute from a building entity",
       command:
         "geonic entities attrs delete urn:ngsi-ld:Building:store01 legacyCode",
+    },
+    {
+      description: "Delete a specific multi-instance attribute by datasetId",
+      command:
+        "geonic entities attrs delete urn:ngsi-ld:Sensor:001 temperature --dataset-id urn:ngsi-ld:Dataset:outdoor",
+    },
+    {
+      description: "Delete all instances of a multi-instance attribute",
+      command:
+        "geonic entities attrs delete urn:ngsi-ld:Sensor:001 temperature --delete-all",
     },
   ]);
 }

--- a/tests/attrs.test.ts
+++ b/tests/attrs.test.ts
@@ -144,6 +144,21 @@ describe("attrs subcommand", () => {
       expect(mockClient.delete).not.toHaveBeenCalled();
     });
 
+    it('rejects an empty --dataset-id before any request', async () => {
+      await expect(
+        runCommand(program, [
+          "attrs",
+          "delete",
+          "urn:ngsi-ld:Sensor:001",
+          "temperature",
+          "--dataset-id",
+          "",
+        ]),
+      ).rejects.toThrow("--dataset-id must not be empty.");
+
+      expect(mockClient.delete).not.toHaveBeenCalled();
+    });
+
     it("hints at --dataset-id / --delete-all when delete returns 404", async () => {
       mockClient.delete.mockRejectedValue(new GdbClientError("Attribute not found", 404));
 

--- a/tests/attrs.test.ts
+++ b/tests/attrs.test.ts
@@ -6,6 +6,7 @@ import type { MockClient } from "./test-helpers.js";
 import { createClient, getFormat, outputResponse } from "../src/helpers.js";
 import { parseJsonInput } from "../src/input.js";
 import { printSuccess } from "../src/output.js";
+import { GdbClientError } from "../src/client.js";
 import { addAttrsSubcommands } from "../src/commands/attrs.js";
 
 describe("attrs subcommand", () => {
@@ -90,6 +91,83 @@ describe("attrs subcommand", () => {
         `/entities/${encodeURIComponent("urn:ngsi-ld:Sensor:001")}/attrs/${encodeURIComponent("temperature")}`,
       );
       expect(printSuccess).toHaveBeenCalledWith("Attribute deleted.");
+    });
+
+    it("passes datasetId query param when --dataset-id is set", async () => {
+      mockClient.delete.mockResolvedValue(mockResponse(undefined, 204));
+      await runCommand(program, [
+        "attrs",
+        "delete",
+        "urn:ngsi-ld:Sensor:001",
+        "temperature",
+        "--dataset-id",
+        "urn:ngsi-ld:Dataset:outdoor",
+      ]);
+
+      expect(mockClient.delete).toHaveBeenCalledWith(
+        `/entities/${encodeURIComponent("urn:ngsi-ld:Sensor:001")}/attrs/${encodeURIComponent("temperature")}`,
+        { datasetId: "urn:ngsi-ld:Dataset:outdoor" },
+      );
+      expect(printSuccess).toHaveBeenCalledWith("Attribute deleted.");
+    });
+
+    it("passes deleteAll=true when --delete-all is set", async () => {
+      mockClient.delete.mockResolvedValue(mockResponse(undefined, 204));
+      await runCommand(program, [
+        "attrs",
+        "delete",
+        "urn:ngsi-ld:Sensor:001",
+        "temperature",
+        "--delete-all",
+      ]);
+
+      expect(mockClient.delete).toHaveBeenCalledWith(
+        `/entities/${encodeURIComponent("urn:ngsi-ld:Sensor:001")}/attrs/${encodeURIComponent("temperature")}`,
+        { deleteAll: "true" },
+      );
+      expect(printSuccess).toHaveBeenCalledWith("Attribute deleted.");
+    });
+
+    it("rejects combining --dataset-id and --delete-all before any request", async () => {
+      await expect(
+        runCommand(program, [
+          "attrs",
+          "delete",
+          "urn:ngsi-ld:Sensor:001",
+          "temperature",
+          "--dataset-id",
+          "urn:ngsi-ld:Dataset:outdoor",
+          "--delete-all",
+        ]),
+      ).rejects.toThrow("Cannot specify both --dataset-id and --delete-all.");
+
+      expect(mockClient.delete).not.toHaveBeenCalled();
+    });
+
+    it("hints at --dataset-id / --delete-all when delete returns 404", async () => {
+      mockClient.delete.mockRejectedValue(new GdbClientError("Attribute not found", 404));
+
+      await expect(
+        runCommand(program, ["attrs", "delete", "urn:ngsi-ld:Sensor:001", "temperature"]),
+      ).rejects.toThrow(/--dataset-id|--delete-all/);
+
+      expect(mockClient.delete).toHaveBeenCalled();
+    });
+
+    // near-miss: non-404 errors must not get the multi-instance hint
+    it("does not rewrite non-404 delete errors with the datasetId hint", async () => {
+      mockClient.delete.mockRejectedValue(new GdbClientError("Forbidden", 403));
+
+      let caught: unknown;
+      try {
+        await runCommand(program, ["attrs", "delete", "urn:ngsi-ld:Sensor:001", "temperature"]);
+      } catch (err) {
+        caught = err;
+      }
+
+      expect(caught).toBeInstanceOf(GdbClientError);
+      expect((caught as Error).message).toBe("Forbidden");
+      expect((caught as Error).message).not.toMatch(/--dataset-id|--delete-all/);
     });
   });
 });


### PR DESCRIPTION
## Summary
- `geonic entities attrs delete` が常にクエリ無し DELETE を送っており、多重属性 (`datasetId` 付きインスタンス) を CLI から削除できなかった（本体 geolonia/geonicdb#2177 の規則統一後は 404 が増える）
- `--dataset-id` / `--delete-all` を追加し、ETSI GS CIM 009 clause 5.6.5.4 のクエリへ配線。相互排他。404 時は既定インスタンス不在の Hint を付与
- 回帰テスト（修正前赤 / 修正後緑）と変異注入（`datasetId` → `datasetID` で追加テストが赤）を確認

Closes #197

## 原因
`src/commands/attrs.ts` の `attrs delete` にフラグが無く、`client.delete(path)` のみ。issue の見立てどおり。

## 修正内容
- `--dataset-id <id>` → `datasetId` クエリ
- `--delete-all` → `deleteAll=true`
- 両方指定はリクエスト前にエラー
- 404 時 Hint / help examples 追加

## Test plan
- [x] `npx vitest run tests/attrs.test.ts`（修正前 4 failed → 修正後 10 passed）
- [x] 変異注入: `params.datasetId` → `params.datasetID` で `passes datasetId query param...` が赤 → 復元
- [x] near-miss: 403 は Hint を付けない
- [x] `npm run lint && npm run typecheck && npm test`
- [ ] CI 全緑

## スコープ外
- `attrs get` / `update` への `datasetId` 対応（別 issue 候補）


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 属性削除コマンドで、`--dataset-id` による特定インスタンスの削除に対応しました。
  * `--delete-all` により、複数の属性インスタンスを一括削除できるようになりました。
  * 404エラー時に、利用可能な指定方法を案内するヒントを表示します。
  * 両オプションを同時に指定した場合や、空のIDを指定した場合は実行前に拒否します。

* **ドキュメント**
  * 新しい削除オプションと動作を変更履歴に追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->