### PR TITLE
fix(rules): --service-path を list/create に追加 (closes #199)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## [Unreleased]
 
+### 2026-08-17
+- **Fix**: `rules list` / `rules create` に `--service-path` を追加し、本体 #2259 の `GET /rules` 既定変更（未指定時は全 servicePath ではなく認可と同じ単一 path）に追従した (closes #199, 本体 geolonia/geonicdb#2259 / #2280 対応)。help の "all" 表現も実態に合わせて修正
+
 ## [0.24.0] - 2026-08-13
 
 ### 2026-08-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ## [Unreleased]
 
 ### 2026-08-17
-- **Fix**: `rules list` / `rules create` に `--service-path` を追加し、本体 #2259 の `GET /rules` 既定変更（未指定時は全 servicePath ではなく認可と同じ単一 path）に追従した (closes #199, 本体 geolonia/geonicdb#2259 / #2280 対応) (#205)。help の "all" 表現も実態に合わせて修正
+- **Fix**: `rules list` / `rules create` に `--service-path` を追加し、本体 #2259 の `GET /rules` 既定変更（未指定時は全 servicePath ではなく認可と同じ単一 path）に追従した (closes #199, 本体 geolonia/geonicdb#2259 / #2280 対応)。help の "all" 表現も実態に合わせて修正 (#205)
 
 ## [0.24.0] - 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ## [Unreleased]
 
 ### 2026-08-17
-- **Fix**: `rules list` / `rules create` に `--service-path` を追加し、本体 #2259 の `GET /rules` 既定変更（未指定時は全 servicePath ではなく認可と同じ単一 path）に追従した (closes #199, 本体 geolonia/geonicdb#2259 / #2280 対応)。help の "all" 表現も実態に合わせて修正
+- **Fix**: `rules list` / `rules create` に `--service-path` を追加し、本体 #2259 の `GET /rules` 既定変更（未指定時は全 servicePath ではなく認可と同じ単一 path）に追従した (closes #199, 本体 geolonia/geonicdb#2259 / #2280 対応) (#205)。help の "all" 表現も実態に合わせて修正
 
 ## [0.24.0] - 2026-08-13
 

--- a/src/commands/rules.ts
+++ b/src/commands/rules.ts
@@ -12,22 +12,32 @@ export function registerRulesCommand(program: Command): void {
   // rules list
   const list = rules
     .command("list")
-    .description("List all configured rules and their current status")
+    .description(
+      "List rules for the given servicePath (default: `/` when omitted) and their current status",
+    )
+    .option("--service-path <path>", "Filter by servicePath (query `servicePath`; e.g. /sensors)")
     .option("--limit <n>", "Maximum number of results", parseNonNegativeInt)
     .option("--offset <n>", "Skip N results", parseNonNegativeInt)
     .action(
       withErrorHandler(async (_opts: unknown, cmd: Command) => {
+        const opts = cmd.opts() as { servicePath?: string; limit?: number; offset?: number };
         const client = createClient(cmd);
         const format = getFormat(cmd);
-        const response = await fetchPaginatedList(client, "/rules", cmd.opts());
+        const extraParams: Record<string, string> = {};
+        if (opts.servicePath !== undefined) extraParams.servicePath = opts.servicePath;
+        const response = await fetchPaginatedList(client, "/rules", opts, extraParams);
         outputResponse(response, format);
       }),
     );
 
   addExamples(list, [
     {
-      description: "List all rules as JSON",
+      description: "List rules for the default servicePath (/) as JSON",
       command: "geonic rules list",
+    },
+    {
+      description: "List rules under a specific servicePath",
+      command: "geonic rules list --service-path /sensors",
     },
     {
       description: "List rules in table format to review status at a glance",
@@ -72,6 +82,8 @@ export function registerRulesCommand(program: Command): void {
     .summary("Create a new rule")
     .description(
       "Create a new rule\n\n" +
+        "The rule's servicePath is set via --service-path (query `servicePath`); " +
+        "when omitted the server uses Fiware-ServicePath (default `/`).\n\n" +
         "JSON payload example:\n" +
         "  {\n" +
         '    "name": "high-temp-alert",\n' +
@@ -80,12 +92,19 @@ export function registerRulesCommand(program: Command): void {
         '    "actions": [{"type": "webhook", "url": "http://localhost:5000/alert", "method": "POST"}]\n' +
         "  }",
     )
+    .option("--service-path <path>", "Create under this servicePath (query `servicePath`; e.g. /sensors)")
     .action(
       withErrorHandler(async (json: unknown, _opts: unknown, cmd: Command) => {
         const body = await parseJsonInput(json as string | undefined);
+        const opts = cmd.opts() as { servicePath?: string };
         const client = createClient(cmd);
         const format = getFormat(cmd);
-        const response = await client.rawRequest("POST", "/rules", { body });
+        const params =
+          opts.servicePath !== undefined ? { servicePath: opts.servicePath } : undefined;
+        const response = await client.rawRequest("POST", "/rules", {
+          body,
+          ...(params ? { params } : {}),
+        });
         outputResponse(response, format);
         printSuccess("Rule created.");
       }),
@@ -95,6 +114,10 @@ export function registerRulesCommand(program: Command): void {
     {
       description: "Create with inline JSON",
       command: `geonic rules create '{"name":"high-temp-alert","conditions":[{"type":"celExpression","expression":"entity.temperature > 30"}],"actions":[{"type":"webhook","url":"http://localhost:5000/alert","method":"POST"}]}'`,
+    },
+    {
+      description: "Create under a specific servicePath",
+      command: `geonic rules create --service-path /sensors '{"name":"sensor-alert","conditions":[{"type":"celExpression","expression":"entity.temperature > 30"}],"actions":[{"type":"webhook","url":"http://localhost:5000/alert","method":"POST"}]}'`,
     },
     {
       description: "Create from a file",

--- a/tests/rules.test.ts
+++ b/tests/rules.test.ts
@@ -37,6 +37,49 @@ describe("rules command", () => {
         params: { limit: "10", offset: "5" },
       });
     });
+
+    it("forwards --service-path as servicePath query param", async () => {
+      mockClient.rawRequest.mockResolvedValue(mockResponse([{ id: "rule1" }]));
+      await runCommand(program, ["rules", "list", "--service-path", "/sensors"]);
+
+      expect(mockClient.rawRequest).toHaveBeenCalledWith("GET", "/rules", {
+        params: { servicePath: "/sensors" },
+      });
+    });
+
+    it("omits servicePath when --service-path is not given (near-miss vs explicit /)", async () => {
+      mockClient.rawRequest.mockResolvedValue(mockResponse([{ id: "rule1" }]));
+      await runCommand(program, ["rules", "list"]);
+
+      const call = mockClient.rawRequest.mock.calls[0];
+      expect(call[2]?.params).not.toHaveProperty("servicePath");
+
+      mockClient.rawRequest.mockClear();
+      mockClient.rawRequest.mockResolvedValue(mockResponse([{ id: "rule1" }]));
+      await runCommand(program, ["rules", "list", "--service-path", "/"]);
+
+      expect(mockClient.rawRequest).toHaveBeenCalledWith("GET", "/rules", {
+        params: { servicePath: "/" },
+      });
+    });
+
+    it("forwards --service-path together with pagination", async () => {
+      mockClient.rawRequest.mockResolvedValue(mockResponse([{ id: "rule1" }]));
+      await runCommand(program, [
+        "rules",
+        "list",
+        "--service-path",
+        "/sensors",
+        "--limit",
+        "10",
+        "--offset",
+        "5",
+      ]);
+
+      expect(mockClient.rawRequest).toHaveBeenCalledWith("GET", "/rules", {
+        params: { servicePath: "/sensors", limit: "10", offset: "5" },
+      });
+    });
   });
 
   describe("get", () => {
@@ -64,6 +107,37 @@ describe("rules command", () => {
       expect(mockClient.rawRequest).toHaveBeenCalledWith("POST", "/rules", { body: ruleData });
       expect(outputResponse).toHaveBeenCalled();
       expect(printSuccess).toHaveBeenCalledWith("Rule created.");
+    });
+
+    it("forwards --service-path as servicePath query param on create", async () => {
+      const ruleData = { name: "TestRule", condition: "temp>30" };
+      vi.mocked(parseJsonInput).mockResolvedValue(ruleData);
+      mockClient.rawRequest.mockResolvedValue(mockResponse({ id: "rule1" }, 201));
+
+      await runCommand(program, [
+        "rules",
+        "create",
+        '{"name":"TestRule"}',
+        "--service-path",
+        "/sensors",
+      ]);
+
+      expect(mockClient.rawRequest).toHaveBeenCalledWith("POST", "/rules", {
+        body: ruleData,
+        params: { servicePath: "/sensors" },
+      });
+    });
+
+    it("omits servicePath params when --service-path is not given on create", async () => {
+      const ruleData = { name: "TestRule", condition: "temp>30" };
+      vi.mocked(parseJsonInput).mockResolvedValue(ruleData);
+      mockClient.rawRequest.mockResolvedValue(mockResponse({ id: "rule1" }, 201));
+
+      await runCommand(program, ["rules", "create", '{"name":"TestRule"}']);
+
+      expect(mockClient.rawRequest).toHaveBeenCalledWith("POST", "/rules", { body: ruleData });
+      const call = mockClient.rawRequest.mock.calls[0];
+      expect(call[2]).not.toHaveProperty("params");
     });
   });
 


### PR DESCRIPTION
## Summary

- 本体 #2259 / #2280 で `GET /rules` の既定が「全 servicePath」→「認可と同じ単一 servicePath（既定 `/`）」に変わったが、CLI は `?servicePath=` を送る手段が無く、非 `/` のルールを一覧できなかった
- `rules list` / `rules create` に `--service-path` を追加し、クエリ `servicePath` として送る。help の "all" 表現も実態に合わせて修正
- `create` も本体がクエリ優先で作成先を決めるため、同様にフラグが必要と確認して追加した

Closes #199

## 原因

`src/commands/rules.ts` の list は `fetchPaginatedList(client, "/rules", cmd.opts())` のみで limit/offset しか渡していなかった。CLI 全体に `Fiware-ServicePath` / `--service-path` も無い。本体側の既定変更（認可バイパス修正）により、未指定時は `/` のルールしか返らなくなった。

## 修正内容

- `rules list --service-path <path>` → `GET /rules?servicePath=...`
- `rules create --service-path <path>` → `POST /rules?servicePath=...`
- 未指定時はクエリを付けない（本体の既定解決に委ねる）。`--service-path /` 明示時は `servicePath=/` を送る
- help / examples / CHANGELOG 更新

## テスト

- 単体: `--service-path` 転送、未指定時 omit、明示 `/`（near-miss）、pagination 併用、create 転送
- **修正前**: 4 failed（`unknown option '--service-path'`）/ **修正後**: 13 passed
- **変異注入**: list の転送を `if (false && ...)` に壊すと 3 件赤、create 同様で 1 件赤。復元後緑
- ローカル: `npm run lint && npm run typecheck && npm test` 緑
- E2E: 未実行（CLI→クエリ配線のみ。multi-servicePath fixture 無し）

## スコープ外

- グローバル `--service-path` / `Fiware-ServicePath` ヘッダ対応（entities 等への波及は別 issue 候補）
- get/update/delete/activate/deactivate（本体 #2283 の by-id 再認可と別軸）

## Test plan

- [ ] `geonic rules list --help` に `--service-path` があり、"all" が消えている
- [ ] `geonic rules list --service-path /sensors --dry-run` で `servicePath=/sensors` が付く
- [ ] `geonic rules create --service-path /sensors ... --dry-run` でも同様
- [ ] フラグ無しでは `servicePath` クエリが付かない
- [ ] CI 全緑


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * `rules list` でサービスパスによる絞り込みに対応しました。
  * `rules create` でサービスパスを指定できるようになりました。
  * サービスパス指定はページネーションと併用できます。未指定時は既定値を適用します。

* **ドキュメント**
  * 各コマンドのヘルプにサービスパスの説明と使用例を追加しました。
  * ルール取得時の既定動作変更と、ヘルプ内の表現を反映しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->