### PR TITLE
feat(temporal): --time-property を list/get に追加 (closes #202)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## [Unreleased]
 
+### 2026-08-17
+- **Feat**: `temporal entities list` / `get` に `--time-property` を追加し、NGSI-LD `timeproperty` クエリへ載せる (closes #202, 本体 geolonia/geonicdb#2267 / PR #2338 対応)。許容値は本体と同じ `observedAt` / `createdAt` / `modifiedAt` / `deletedAt`（未知値はサーバが 400）
+
 ## [0.24.0] - 2026-08-13
 
 ### 2026-08-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ## [Unreleased]
 
 ### 2026-08-17
-- **Feat**: `temporal entities list` / `get` に `--time-property` を追加し、NGSI-LD `timeproperty` クエリへ載せる (closes #202, 本体 geolonia/geonicdb#2267 / PR #2338 対応) (#206)。許容値は本体と同じ `observedAt` / `createdAt` / `modifiedAt` / `deletedAt`（未知値はサーバが 400）
+- **Feat**: `temporal entities list` / `get` に `--time-property` を追加し、NGSI-LD `timeproperty` クエリへ載せる (closes #202, 本体 geolonia/geonicdb#2267 / PR #2338 対応) (#206)。許容値は本体と同じ `observedAt` / `createdAt` / `modifiedAt` / `deletedAt`（未知値・空文字はサーバが 400。CLI は未指定時のみ省略し、明示された空文字は転送する）
 
 ## [0.24.0] - 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ## [Unreleased]
 
 ### 2026-08-17
-- **Feat**: `temporal entities list` / `get` に `--time-property` を追加し、NGSI-LD `timeproperty` クエリへ載せる (closes #202, 本体 geolonia/geonicdb#2267 / PR #2338 対応)。許容値は本体と同じ `observedAt` / `createdAt` / `modifiedAt` / `deletedAt`（未知値はサーバが 400）
+- **Feat**: `temporal entities list` / `get` に `--time-property` を追加し、NGSI-LD `timeproperty` クエリへ載せる (closes #202, 本体 geolonia/geonicdb#2267 / PR #2338 対応) (#206)。許容値は本体と同じ `observedAt` / `createdAt` / `modifiedAt` / `deletedAt`（未知値はサーバが 400）
 
 ## [0.24.0] - 2026-08-13
 

--- a/README.md
+++ b/README.md
@@ -463,10 +463,11 @@ Notes:
 | `temporal entities create [json]` | Create a temporal entity |
 | `temporal entities delete <id>` | Delete a temporal entity |
 
-Temporal entities list supports: `--time-rel`, `--time-at`, `--end-time-at`, `--last-n`, `--order-by`, `--options`, `--aggr-methods`, `--aggr-period`.
+Temporal entities list supports: `--time-rel`, `--time-at`, `--end-time-at`, `--time-property`, `--last-n`, `--order-by`, `--options`, `--aggr-methods`, `--aggr-period`.
 
-Temporal entities get supports: `--time-rel`, `--time-at`, `--end-time-at`, `--last-n`, `--options`, `--aggr-methods`, `--aggr-period`.
+Temporal entities get supports: `--time-rel`, `--time-at`, `--end-time-at`, `--time-property`, `--last-n`, `--options`, `--aggr-methods`, `--aggr-period`.
 
+`--time-property` selects which temporal property the time filter compares against (NGSI-LD `timeproperty`; ETSI clause 4.11): `observedAt` (default), `createdAt`, `modifiedAt`, or `deletedAt`. Unknown values are rejected by the server with `400 BadRequestData`.
 Temporal `--order-by` follows NGSI-LD v1.9.1 grammar (`name`, `name;desc`, composites like `a;asc,b;desc`). The server returns `400` for `dist-*`/`geo:distance` and nested paths like `a.b`; combining it with `--aggr-methods` is rejected by the CLI before a request is sent (aggregations are sorted by entity ID server-side).
 
 `--options` selects the NGSI-LD temporal representation (ETSI GS CIM 009 clause 6.3.12): `temporalValues` (alias `simplified`) for `[value, timestamp]` pairs, `aggregatedValues` for aggregations, `sysAttrs` (clause 6.3.11) to include `createdAt`/`modifiedAt` (and `expiresAt` where set). It maps to the NGSI-LD `options` query parameter — unrelated to the CLI's own `--format` (json/table). The CLI rejects the deterministic server-side `400`s before sending a request: only one of `temporalValues`/`aggregatedValues` may be present (clause 6.3.12); `aggregatedValues` requires `--aggr-methods`; and `--aggr-methods` / `--aggr-period` must be given together (e.g. `--aggr-methods avg --aggr-period PT1H` — a period alone would be silently ignored by the server, methods alone is a server 400).

--- a/src/commands/temporal.ts
+++ b/src/commands/temporal.ts
@@ -111,6 +111,10 @@ function addTemporalListOptions(cmd: Command): Command {
     .option("--time-at <time>", "Temporal query start time (ISO 8601)")
     .option("--end-time-at <time>", "Temporal query end time (ISO 8601)")
     .option(
+      "--time-property <name>",
+      "Temporal property to compare (observedAt, createdAt, modifiedAt, deletedAt; default observedAt)",
+    )
+    .option(
       "--last-n <n>",
       "Return last N instances per attribute (server default caps to 100; max 1000)",
       parsePositiveInt,
@@ -141,6 +145,7 @@ function createListAction() {
     if (cmdOpts.timeRel) params["timerel"] = cmdOpts.timeRel;
     if (cmdOpts.timeAt) params["timeAt"] = cmdOpts.timeAt;
     if (cmdOpts.endTimeAt) params["endTimeAt"] = cmdOpts.endTimeAt;
+    if (cmdOpts.timeProperty) params["timeproperty"] = cmdOpts.timeProperty;
     if (cmdOpts.lastN !== undefined) params["lastN"] = String(cmdOpts.lastN);
     if (cmdOpts.limit !== undefined) params["limit"] = String(cmdOpts.limit);
     if (cmdOpts.offset !== undefined) params["offset"] = String(cmdOpts.offset);
@@ -170,6 +175,10 @@ function addTemporalGetOptions(cmd: Command): Command {
     .option("--time-at <time>", "Temporal query start time (ISO 8601)")
     .option("--end-time-at <time>", "Temporal query end time (ISO 8601)")
     .option(
+      "--time-property <name>",
+      "Temporal property to compare (observedAt, createdAt, modifiedAt, deletedAt; default observedAt)",
+    )
+    .option(
       "--last-n <n>",
       "Return last N instances per attribute (server default caps to 100; max 1000)",
       parsePositiveInt,
@@ -188,6 +197,7 @@ function createGetAction() {
     if (cmdOpts.timeRel) params["timerel"] = cmdOpts.timeRel;
     if (cmdOpts.timeAt) params["timeAt"] = cmdOpts.timeAt;
     if (cmdOpts.endTimeAt) params["endTimeAt"] = cmdOpts.endTimeAt;
+    if (cmdOpts.timeProperty) params["timeproperty"] = cmdOpts.timeProperty;
     if (cmdOpts.lastN !== undefined) params["lastN"] = String(cmdOpts.lastN);
     Object.assign(params, buildRepresentationParams(cmdOpts));
 
@@ -283,6 +293,11 @@ export function registerTemporalCommand(program: Command): void {
       description: "Filter by time (after a point)",
       command:
         "geonic temporal entities list --time-rel after --time-at 2025-06-01T00:00:00Z",
+    },
+    {
+      description: "Filter by creation time (timeproperty=createdAt)",
+      command:
+        "geonic temporal entities list --time-rel after --time-at 2025-06-01T00:00:00Z --time-property createdAt",
     },
     {
       description: "Order temporal entities (NGSI-LD v1.9.1 grammar)",

--- a/src/commands/temporal.ts
+++ b/src/commands/temporal.ts
@@ -145,7 +145,11 @@ function createListAction() {
     if (cmdOpts.timeRel) params["timerel"] = cmdOpts.timeRel;
     if (cmdOpts.timeAt) params["timeAt"] = cmdOpts.timeAt;
     if (cmdOpts.endTimeAt) params["endTimeAt"] = cmdOpts.endTimeAt;
-    if (cmdOpts.timeProperty) params["timeproperty"] = cmdOpts.timeProperty;
+    // undefined only = flag absent (server default observedAt). Empty string is
+    // forwarded so the server can 400 BadRequestData on unknown values (#202).
+    if (cmdOpts.timeProperty !== undefined) {
+      params["timeproperty"] = cmdOpts.timeProperty;
+    }
     if (cmdOpts.lastN !== undefined) params["lastN"] = String(cmdOpts.lastN);
     if (cmdOpts.limit !== undefined) params["limit"] = String(cmdOpts.limit);
     if (cmdOpts.offset !== undefined) params["offset"] = String(cmdOpts.offset);
@@ -197,7 +201,11 @@ function createGetAction() {
     if (cmdOpts.timeRel) params["timerel"] = cmdOpts.timeRel;
     if (cmdOpts.timeAt) params["timeAt"] = cmdOpts.timeAt;
     if (cmdOpts.endTimeAt) params["endTimeAt"] = cmdOpts.endTimeAt;
-    if (cmdOpts.timeProperty) params["timeproperty"] = cmdOpts.timeProperty;
+    // undefined only = flag absent (server default observedAt). Empty string is
+    // forwarded so the server can 400 BadRequestData on unknown values (#202).
+    if (cmdOpts.timeProperty !== undefined) {
+      params["timeproperty"] = cmdOpts.timeProperty;
+    }
     if (cmdOpts.lastN !== undefined) params["lastN"] = String(cmdOpts.lastN);
     Object.assign(params, buildRepresentationParams(cmdOpts));
 

--- a/tests/temporal.test.ts
+++ b/tests/temporal.test.ts
@@ -149,6 +149,20 @@ describe("temporal commands", () => {
       const params = client.get.mock.calls[0]?.[1] as Record<string, string>;
       expect(params).not.toHaveProperty("timeproperty");
     });
+
+    // Empty string is an explicit (invalid) value — forward it so the server
+    // can 400, rather than treating it as "flag absent → observedAt default".
+    it("forwards empty --time-property so the server can reject it", async () => {
+      client.get.mockResolvedValue(mockResponse([]));
+      const program = makeProgram();
+      await runCommand(program, [
+        "temporal", "entities", "list",
+        "--time-property", "",
+      ]);
+      expect(client.get).toHaveBeenCalledWith("/temporal/entities", {
+        timeproperty: "",
+      });
+    });
   });
 
   describe("temporal entities get", () => {
@@ -202,6 +216,19 @@ describe("temporal commands", () => {
           timeAt: "2025-06-01T00:00:00Z",
           timeproperty: "createdAt",
         },
+      );
+    });
+
+    it("forwards empty --time-property so the server can reject it", async () => {
+      client.get.mockResolvedValue(mockResponse({ id: "urn:sensor:001" }));
+      const program = makeProgram();
+      await runCommand(program, [
+        "temporal", "entities", "get", "urn:sensor:001",
+        "--time-property", "",
+      ]);
+      expect(client.get).toHaveBeenCalledWith(
+        "/temporal/entities/urn%3Asensor%3A001",
+        { timeproperty: "" },
       );
     });
 

--- a/tests/temporal.test.ts
+++ b/tests/temporal.test.ts
@@ -118,6 +118,37 @@ describe("temporal commands", () => {
       });
       expect(outputResponse).toHaveBeenCalledWith(expect.anything(), "json", true);
     });
+
+    // #202 / geolonia/geonicdb#2267: --time-property → timeproperty query param
+    it("passes --time-property createdAt as timeproperty (#202)", async () => {
+      client.get.mockResolvedValue(mockResponse([]));
+      const program = makeProgram();
+      await runCommand(program, [
+        "temporal", "entities", "list",
+        "--time-rel", "after",
+        "--time-at", "2025-01-01T00:00:00Z",
+        "--time-property", "createdAt",
+      ]);
+      expect(client.get).toHaveBeenCalledWith("/temporal/entities", {
+        timerel: "after",
+        timeAt: "2025-01-01T00:00:00Z",
+        timeproperty: "createdAt",
+      });
+    });
+
+    // near-miss: without the flag the query must not invent a timeproperty key
+    // (server default is observedAt only when the param is absent).
+    it("omits timeproperty when --time-property is not set", async () => {
+      client.get.mockResolvedValue(mockResponse([]));
+      const program = makeProgram();
+      await runCommand(program, [
+        "temporal", "entities", "list",
+        "--time-rel", "after",
+        "--time-at", "2025-01-01T00:00:00Z",
+      ]);
+      const params = client.get.mock.calls[0]?.[1] as Record<string, string>;
+      expect(params).not.toHaveProperty("timeproperty");
+    });
   });
 
   describe("temporal entities get", () => {
@@ -151,6 +182,25 @@ describe("temporal commands", () => {
           timeAt: "2025-06-01T00:00:00Z",
           endTimeAt: "2025-07-01T00:00:00Z",
           lastN: "10",
+        },
+      );
+    });
+
+    it("passes --time-property createdAt as timeproperty (#202)", async () => {
+      client.get.mockResolvedValue(mockResponse({ id: "urn:sensor:001" }));
+      const program = makeProgram();
+      await runCommand(program, [
+        "temporal", "entities", "get", "urn:sensor:001",
+        "--time-rel", "before",
+        "--time-at", "2025-06-01T00:00:00Z",
+        "--time-property", "createdAt",
+      ]);
+      expect(client.get).toHaveBeenCalledWith(
+        "/temporal/entities/urn%3Asensor%3A001",
+        {
+          timerel: "before",
+          timeAt: "2025-06-01T00:00:00Z",
+          timeproperty: "createdAt",
         },
       );
     });

--- a/tests/temporal.test.ts
+++ b/tests/temporal.test.ts
@@ -146,8 +146,11 @@ describe("temporal commands", () => {
         "--time-rel", "after",
         "--time-at", "2025-01-01T00:00:00Z",
       ]);
-      const params = client.get.mock.calls[0]?.[1] as Record<string, string>;
-      expect(params).not.toHaveProperty("timeproperty");
+      // Exact params object: timeproperty must be absent (not invented as observedAt).
+      expect(client.get).toHaveBeenCalledWith("/temporal/entities", {
+        timerel: "after",
+        timeAt: "2025-01-01T00:00:00Z",
+      });
     });
 
     // Empty string is an explicit (invalid) value — forward it so the server


### PR DESCRIPTION
## Summary

- **原因**: `temporal entities list` / `get` に `--time-rel` / `--time-at` / `--end-time-at` はあるが、`timeproperty` を渡すフラグが無く、CLI 経由では常にサーバ既定の `observedAt` 固定になっていた（issue の見立てどおり）。
- **修正**: `--time-property <name>` を追加し、クエリへ `timeproperty` として載せる。許容値は本体と同じ `observedAt` / `createdAt` / `modifiedAt` / `deletedAt`（未知値はサーバが 400）。本体 geolonia/geonicdb#2267 / PR #2338 対応。
- **テスト**: `createdAt` の round-trip（list/get）と near-miss（未指定時は `timeproperty` key を送らない）。変異注入で配線削除・既定値捏造がそれぞれ赤になることを確認。

Closes #202

## Test plan

- [x] 修正前: `geonic temporal entities list --time-property createdAt ...` → `unknown option`
- [x] 修正後: list/get の unit が `timeproperty: "createdAt"` を期待どおり送る
- [x] 変異注入（list/get 配線削除、未指定時の既定捏造）で追加テストが赤 → 復元
- [x] `npm run lint && npm run typecheck && npm test`（1048）

## スコープ外

- `temporal entityOperations query` は `--time-rel` 等も CLI フラグではなく body `temporalQ` 経由のため未追加
- CLI 側の許容値バリデーションは `--time-rel` と同様サーバに委ねる


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 時系列エンティティの一覧取得・詳細取得で、比較対象の時間属性を `--time-property` で指定できるようになりました。
  * `observedAt`、`createdAt`、`modifiedAt`、`deletedAt` に対応し、時間フィルターへ反映されます。
  * 未指定時は従来どおり `observedAt` を使用します。不明な値や空文字はサーバーで拒否されます。

* **ドキュメント**
  * 利用可能な値と、作成時刻などを使った時間フィルターの例を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->