### PR TITLE
docs(cli): POST query の too-wide 検証に追従し --local を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## [Unreleased]
 
+### 2026-08-17
+- **Docs** / **Feat**: 本体 geolonia/geonicdb#2290 (#2308) の POST query too-wide 検証に追従 (closes #200)。`batch query` / `temporal entityOperations query` のヘルプと README に「`id` / `idPattern` だけでは 400 BadRequestData。`type` / 非システム `attrs` / 非システム `q` / `geoQ`、または `--local`」を明記し、両コマンドに `--local` (`?local=true`) を追加
+
 ## [0.24.0] - 2026-08-13
 
 ### 2026-08-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ## [Unreleased]
 
 ### 2026-08-17
-- **Docs** / **Feat**: 本体 geolonia/geonicdb#2290 (#2308) の POST query too-wide 検証に追従 (closes #200)。`batch query` / `temporal entityOperations query` のヘルプと README に「`id` / `idPattern` だけでは 400 BadRequestData。`type` / 非システム `attrs` / 非システム `q` / `geoQ`、または `--local`」を明記し、両コマンドに `--local` (`?local=true`) を追加
+- **Docs** / **Feat**: 本体 geolonia/geonicdb#2290 (#2308) の POST query too-wide 検証に追従 (closes #200)。`batch query` / `temporal entityOperations query` のヘルプと README に「`id` / `idPattern` だけでは 400 BadRequestData。`type` / 非システム `attrs` / 非システム `q` / `geoQ`、または `--local`」を明記し、両コマンドに `--local` (`?local=true`) を追加 (#207)
 
 ## [0.24.0] - 2026-08-13
 

--- a/README.md
+++ b/README.md
@@ -366,6 +366,16 @@ For safety, `entities purge` requires confirmation. In non-interactive contexts 
 
 `batch` is available as an alias for `entityOperations`.
 
+`entityOperations query` posts the JSON body as-is to `POST /entityOperations/query`. After geolonia/geonicdb#2290 (ETSI GS CIM 009 clause 5.7.2.4), a **too-wide** body returns **400 BadRequestData**: the payload must include at least one of `type`, a non-system `attrs`, a non-system `q`, or `geoQ`. `id` / `idPattern` alone are **not** enough. Use `--local` (`?local=true`) for a local-scope scan or id-only lookup.
+
+```bash
+# Restricted by type + attrs (sufficient selector)
+geonic batch query '{"entities":[{"type":"Sensor"}],"attrs":["temperature"]}'
+
+# Id-only lookup — requires --local (otherwise 400 Too wide query)
+geonic batch query '{"entities":[{"id":"urn:ngsi-ld:Sensor:001"}]}' --local
+```
+
 ### import — Bulk-load entities (large datasets)
 
 `entityOperations upsert` sends the whole payload in a single request, so it is bounded by the
@@ -479,7 +489,9 @@ Temporal `--order-by` follows NGSI-LD v1.9.1 grammar (`name`, `name;desc`, compo
 |---|---|
 | `temporal entityOperations query [json]` | Query temporal entities (POST) |
 
-Supports the same representation flags as the GET paths: `--options`, `--aggr-methods`, `--aggr-period` (same fail-fast guards). The flags are sent in the query string; the server also accepts the spec-canonical `temporalQ` object in the request body (ETSI GS CIM 009 Table 5.2.21-1), which takes precedence over the flags. Aggregation on this POST route requires a GeonicDB with geolonia/geonicdb#1816 (after v0.16.0) — older servers silently ignore it here, so use `temporal entities list --options aggregatedValues` against those. `--order-by` is intentionally unsupported on this POST route.
+Supports the same representation flags as the GET paths: `--options`, `--aggr-methods`, `--aggr-period` (same fail-fast guards), plus `--local` (`?local=true`). The flags are sent in the query string; the server also accepts the spec-canonical `temporalQ` object in the request body (ETSI GS CIM 009 Table 5.2.21-1), which takes precedence over the flags. Aggregation on this POST route requires a GeonicDB with geolonia/geonicdb#1816 (after v0.16.0) — older servers silently ignore it here, so use `temporal entities list --options aggregatedValues` against those. `--order-by` is intentionally unsupported on this POST route.
+
+After geolonia/geonicdb#2290 (ETSI GS CIM 009 clause 5.7.4.4), a **too-wide** POST body returns **400 BadRequestData** — same contract as `entityOperations query` (`type` / non-system `attrs` / non-system `q` / `geoQ`, or `--local`). `id` / `idPattern` alone are not enough.
 
 ### snapshots — Snapshot operations
 

--- a/src/commands/batch.ts
+++ b/src/commands/batch.ts
@@ -161,15 +161,27 @@ export function registerBatchCommand(program: Command): void {
         '    "entities": [{"type": "Sensor"}],\n' +
         '    "attrs": ["temperature"],\n' +
         '    "q": "temperature>30"\n' +
-        "  }",
+        "  }\n\n" +
+        "Too-wide queries return 400 BadRequestData (ETSI GS CIM 009 clause 5.7.2.4;\n" +
+        "geolonia/geonicdb#2290). The body must include at least one of type, a\n" +
+        "non-system attrs, a non-system q, or geoQ — id / idPattern alone are not\n" +
+        "enough. For an unrestricted local scan (or id-only lookup), pass --local\n" +
+        "(?local=true).",
+    )
+    .option(
+      "--local",
+      "Limit to local scope (?local=true). Exempts the too-wide query check",
     )
     .action(
       withErrorHandler(async (json: unknown, _opts: unknown, cmd: Command) => {
         const client = createClient(cmd);
         const format = getFormat(cmd);
         const data = await parseJsonInput(json as string | undefined);
+        const params = cmd.opts().local ? { local: "true" } : undefined;
 
-        const response = await client.post("/entityOperations/query", data);
+        const response = params
+          ? await client.post("/entityOperations/query", data, params)
+          : await client.post("/entityOperations/query", data);
         outputResponse(response, format);
       }),
     );
@@ -178,6 +190,10 @@ export function registerBatchCommand(program: Command): void {
     {
       description: "Query with inline JSON",
       command: `geonic batch query '{"entities":[{"type":"Sensor"}],"attrs":["temperature"]}'`,
+    },
+    {
+      description: "Id-only lookup (requires --local; id alone is a too-wide 400)",
+      command: `geonic batch query '{"entities":[{"id":"urn:ngsi-ld:Sensor:001"}]}' --local`,
     },
     {
       description: "Query from a file",

--- a/src/commands/temporal.ts
+++ b/src/commands/temporal.ts
@@ -239,7 +239,12 @@ function createQueryAction() {
     const body = await parseJsonInput(json as string | undefined);
     const client = createClient(cmd);
     const format = getFormat(cmd);
-    const params = buildRepresentationParams(cmd.opts());
+    const cmdOpts = cmd.opts();
+    const params = buildRepresentationParams(cmdOpts);
+    // geolonia/geonicdb#2290 / clause 5.7.4.4: local scope exempts the too-wide
+    // check (id / idPattern alone are not enough). Same query-param channel as
+    // aggregation flags (clause 6.3.18).
+    if (cmdOpts.local) params.local = "true";
 
     const response =
       Object.keys(params).length > 0
@@ -370,7 +375,16 @@ export function registerTemporalCommand(program: Command): void {
           "Aggregation flags are sent in the query string (the server also accepts them in " +
           "the body's temporalQ object, which takes precedence). Requires geonicdb with " +
           "geolonia/geonicdb#1816; older servers (<= v0.16.0) silently ignore aggregation " +
-          "here — use `temporal entities list --options aggregatedValues` against those.",
+          "here — use `temporal entities list --options aggregatedValues` against those.\n\n" +
+          "Too-wide queries return 400 BadRequestData (ETSI GS CIM 009 clause 5.7.4.4;\n" +
+          "geolonia/geonicdb#2290). The body must include at least one of type, a\n" +
+          "non-system attrs, a non-system q, or geoQ — id / idPattern alone are not\n" +
+          "enough. For an unrestricted local scan (or id-only lookup), pass --local\n" +
+          "(?local=true).",
+      )
+      .option(
+        "--local",
+        "Limit to local scope (?local=true). Exempts the too-wide query check",
       ),
   );
   opsQuery.action(createQueryAction());
@@ -379,6 +393,10 @@ export function registerTemporalCommand(program: Command): void {
     {
       description: "Query with inline JSON",
       command: `geonic temporal entityOperations query '{"entities":[{"type":"Sensor"}],"attrs":["temperature"]}'`,
+    },
+    {
+      description: "Id-only lookup (requires --local; id alone is a too-wide 400)",
+      command: `geonic temporal entityOperations query '{"entities":[{"id":"urn:ngsi-ld:Sensor:001"}],"temporalQ":{"timerel":"after","timeAt":"2020-01-01T00:00:00Z"}}' --local`,
     },
     {
       description: "Query from a file",
@@ -416,6 +434,10 @@ export function registerTemporalCommand(program: Command): void {
   addRepresentationOptions(
     temporal
       .command("query [json]", { hidden: true })
-      .description("Query temporal entities (deprecated: use temporal entityOperations query)"),
+      .description("Query temporal entities (deprecated: use temporal entityOperations query)")
+      .option(
+        "--local",
+        "Limit to local scope (?local=true). Exempts the too-wide query check",
+      ),
   ).action(createQueryAction());
 }

--- a/tests/batch.test.ts
+++ b/tests/batch.test.ts
@@ -83,6 +83,41 @@ describe("batch (entityOperations) command", () => {
       expect(mockClient.post).toHaveBeenCalledWith("/entityOperations/query", queryPayload);
       expect(outputResponse).toHaveBeenCalled();
     });
+
+    // #200 / geonicdb#2290: id-only body is a too-wide 400 unless ?local=true.
+    it("passes --local as local=true query param (#200)", async () => {
+      const queryPayload = { entities: [{ id: "urn:ngsi-ld:Sensor:001" }] };
+      vi.mocked(parseJsonInput).mockResolvedValue(queryPayload);
+      mockClient.post.mockResolvedValue(mockResponse([{ id: "urn:ngsi-ld:Sensor:001" }], 200));
+
+      await runCommand(program, [
+        "entityOperations",
+        "query",
+        '{"entities":[{"id":"urn:ngsi-ld:Sensor:001"}]}',
+        "--local",
+      ]);
+
+      expect(mockClient.post).toHaveBeenCalledWith("/entityOperations/query", queryPayload, {
+        local: "true",
+      });
+    });
+
+    // near-miss: without --local the third (params) argument must stay absent —
+    // accidentally always sending local=true would change federation semantics.
+    it("does not send local when --local is omitted (near-miss)", async () => {
+      const queryPayload = { entities: [{ type: "Sensor" }] };
+      vi.mocked(parseJsonInput).mockResolvedValue(queryPayload);
+      mockClient.post.mockResolvedValue(mockResponse([], 200));
+
+      await runCommand(program, [
+        "entityOperations",
+        "query",
+        '{"entities":[{"type":"Sensor"}]}',
+      ]);
+
+      expect(mockClient.post).toHaveBeenCalledWith("/entityOperations/query", queryPayload);
+      expect(mockClient.post.mock.calls[0]).toHaveLength(2);
+    });
   });
 
   describe("merge", () => {

--- a/tests/temporal.test.ts
+++ b/tests/temporal.test.ts
@@ -281,6 +281,57 @@ describe("temporal commands", () => {
         body,
       );
     });
+
+    // #200 / geonicdb#2290: id-only body is a too-wide 400 unless ?local=true.
+    it("passes --local as local=true query param (#200)", async () => {
+      const body = {
+        entities: [{ id: "urn:ngsi-ld:Sensor:001" }],
+        temporalQ: { timerel: "after", timeAt: "2020-01-01T00:00:00Z" },
+      };
+      vi.mocked(parseJsonInput).mockResolvedValue(body);
+      client.post.mockResolvedValue(mockResponse([]));
+      const program = makeProgram();
+      await runCommand(program, [
+        "temporal",
+        "entityOperations",
+        "query",
+        "{}",
+        "--local",
+      ]);
+      expect(client.post).toHaveBeenCalledWith(
+        "/temporal/entityOperations/query",
+        body,
+        { local: "true" },
+      );
+    });
+
+    // near-miss: --local must compose with aggregation flags, not replace them.
+    it("composes --local with aggregation params (near-miss)", async () => {
+      const body = { entities: [{ type: "Sensor" }] };
+      vi.mocked(parseJsonInput).mockResolvedValue(body);
+      client.post.mockResolvedValue(mockResponse([]));
+      const program = makeProgram();
+      await runCommand(program, [
+        "temporal",
+        "entityOperations",
+        "query",
+        "{}",
+        "--local",
+        "--aggr-methods",
+        "avg",
+        "--aggr-period",
+        "PT1H",
+      ]);
+      expect(client.post).toHaveBeenCalledWith(
+        "/temporal/entityOperations/query",
+        body,
+        {
+          local: "true",
+          aggrMethods: "avg",
+          aggrPeriodDuration: "PT1H",
+        },
+      );
+    });
   });
 
   // #181/#188: NGSI-LD representation parameters on the GET retrieval paths.


### PR DESCRIPTION
## Summary

- 本体 geolonia/geonicdb#2290 (#2308) で `POST /entityOperations/query` と temporal 同経路に too-wide 検証が入った。`id` / `idPattern` だけでは **400 BadRequestData**（clause 5.7.2.4 / 5.7.4.4）。
- **原因**: CLI はユーザー JSON をそのまま POST しており、免除条件の `?local=true` を付ける手段も、契約の告知も無かった。
- **修正**: `batch query` / `temporal entityOperations query`（hidden alias 含む）に `--local` を追加。ヘルプ・README・CHANGELOG に too-wide 契約を明記。

Closes #200

## テスト

- 追加: `--local` → `local=true` を送る回帰（batch / temporal）。near-miss（未指定時は params 無し / aggr と compose）。
- 修正前=赤（`unknown option '--local'`）/ 修正後=緑 / 変異注入で `#200` が赤→復元済み。
- ローカル: `lint` / `typecheck` / `npm test` (1049) / `test:e2e` (207) すべて pass。

## スコープ外

- `entities list` への `--local`（GET #2288）
- geonicdb pin の #2308 追従（E2E は type 付き query のため現状パス）
- クライアント側 too-wide 事前拒否（issue 未要求）

## Test plan

- [ ] `geonic batch query --help` に too-wide 説明と `--local` がある
- [ ] `geonic batch query '{"entities":[{"id":"..."}]}' --local` が `?local=true` 付きで POST される（`--dry-run` 可）
- [ ] `geonic temporal entityOperations query ... --local` 同様
- [ ] CI 全緑


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - `batch query` と `temporal entityOperations query` に `--local` オプションを追加しました。
  - `--local` 指定時は、IDのみの検索など広範囲なクエリをローカル検索として実行できます。
  - temporal検索では、集計オプションと `--local` を組み合わせて利用できます。

- **ドキュメント**
  - too-wideクエリの制約、リクエスト条件、利用例をREADMEとヘルプに追加しました。
  - temporal検索のクエリ条件と集計に関する説明を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->