### PR TITLE
fix(e2e): POST /jsonldContexts フィクスチャから kind を外す (#203)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## [Unreleased]
 
+### 2026-08-17
+- **Fix**: POST `/jsonldContexts` の E2E フィクスチャ登録からクライアント指定 `kind` を外した (closes #203, 本体 geolonia/geonicdb#2297) (#208)。Add @context は常に Hosted で、`kind` 指定は 400 になるため、本体取り込み後に context E2E が落ちるのを防ぐ。unit の `/jsonldContexts` 登録例も追随
+
 ## [0.24.0] - 2026-08-13
 
 ### 2026-08-13

--- a/tests/add-context-body.test.ts
+++ b/tests/add-context-body.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { buildAddContextBody } from "./e2e/support/add-context-body.js";
+
+describe("buildAddContextBody (#203)", () => {
+  it("omits kind so Add @context stays Hosted (geonicdb #2297)", () => {
+    const body = buildAddContextBody("https://example.org/e2e-vocab.jsonld", {
+      Vehicle: "https://example-vocab/ns#Vehicle",
+    });
+
+    expect(body).toEqual({
+      url: "https://example.org/e2e-vocab.jsonld",
+      body: {
+        "@context": { Vehicle: "https://example-vocab/ns#Vehicle" },
+      },
+    });
+    // Any client-supplied kind (cached / hosted / implicitlyCreated) is 400.
+    expect(body).not.toHaveProperty("kind");
+  });
+
+  // near-miss: URL-only registration is schema-valid, but E2E needs an embedded
+  // body — SSRF hardening blocks fetching the fixture URL from loopback.
+  it("embeds the @context body for local resolver use", () => {
+    const body = buildAddContextBody("https://example.org/e2e-vocab.jsonld", {
+      plateNumber: "https://example-vocab/ns#plateNumber",
+    });
+    expect(body.body["@context"]).toEqual({
+      plateNumber: "https://example-vocab/ns#plateNumber",
+    });
+  });
+});

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -194,7 +194,8 @@ describe("GdbClient", () => {
   // into it would corrupt the registration (the server excludes it the same way).
   it("does NOT inject @context into a /jsonldContexts registration body (#189)", async () => {
     const client = new GdbClient({ baseUrl: "http://localhost:3000" });
-    const body = { url: "https://example.org/ctx.jsonld", kind: "cached" };
+    // No `kind`: Add @context is always Hosted; client kind is 400 (geonicdb #2297 / #203).
+    const body = { url: "https://example.org/ctx.jsonld" };
 
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({}), { status: 201 }),

--- a/tests/e2e/step_definitions/context.steps.ts
+++ b/tests/e2e/step_definitions/context.steps.ts
@@ -1,5 +1,6 @@
 import { Given } from "@cucumber/cucumber";
 import { strict as assert } from "node:assert";
+import { buildAddContextBody } from "../support/add-context-body.js";
 import type { GdbWorld } from "../support/world.js";
 
 /**
@@ -46,11 +47,12 @@ async function apiRequest(
 Given(
   /^a JSON-LD context "([^"]+)" is registered with:$/,
   async function (this: GdbWorld, url: string, docString: string) {
-    const { status, text } = await apiRequest(this, "POST", "/ngsi-ld/v1/jsonldContexts", {
-      url,
-      kind: "cached",
-      body: { "@context": JSON.parse(docString) },
-    });
+    const { status, text } = await apiRequest(
+      this,
+      "POST",
+      "/ngsi-ld/v1/jsonldContexts",
+      buildAddContextBody(url, JSON.parse(docString)),
+    );
     assert.equal(status, 201, `Registering ${url} failed: HTTP ${status} ${text}`);
   },
 );

--- a/tests/e2e/support/add-context-body.ts
+++ b/tests/e2e/support/add-context-body.ts
@@ -1,0 +1,16 @@
+/**
+ * Body for POST /ngsi-ld/v1/jsonldContexts (Add @context).
+ *
+ * Must not include `kind`: geolonia/geonicdb#2297 rejects any client-supplied
+ * kind with 400 — the entry is always Hosted (ETSI GS CIM 009 clause 5.13.2.4).
+ * Cached / ImplicitlyCreated are broker-origin only.
+ */
+export function buildAddContextBody(
+  url: string,
+  context: unknown,
+): { url: string; body: { "@context": unknown } } {
+  return {
+    url,
+    body: { "@context": context },
+  };
+}


### PR DESCRIPTION
## Summary
- E2E の `POST /ngsi-ld/v1/jsonldContexts` フィクスチャからクライアント指定 `kind: "cached"` を削除した（本体 geolonia/geonicdb#2297 対応）
- Add @context は常に Hosted。クライアント `kind` は 400 になるため、本体取り込み後に context E2E が落ちるのを防ぐ
- unit の `/jsonldContexts` 登録例も追随。`buildAddContextBody` ヘルパーと回帰テストを追加

## 原因
issue の見立てどおり。`tests/e2e/step_definitions/context.steps.ts` が `kind: "cached"` を送っており、本体 `CreateNgsiLdContextSchema`（clause 5.13.2.4 / #2297）がクライアント `kind` を拒否する。

## 修正内容
- `buildAddContextBody(url, context)` を追加し、`url` + `body.@context` のみ送る
- `tests/client.test.ts` の登録例から `kind` を削除

## テスト
- 修正前（kind 付き）: `tests/add-context-body.test.ts` が赤
- 修正後: 同テスト緑
- 変異注入: `kind: "hosted"` を戻すと赤（cached 以外でも検知）→ 復元
- ローカル: `lint` / `typecheck` / `npm test`（1047）/ E2E context 系（207 scenarios）pass

## スコープ外
- `package.json` の geonicdb pin（`1e6c983`）は #2297 より前のまま。pin 更新は別途

Closes #203


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * JSON-LDコンテキスト登録時のリクエスト形式を現行API仕様に合わせ、`kind` の指定を省略するよう更新しました。
  * `kind` を指定した場合にエラーとなる仕様、およびHosted形式・埋め込みコンテキストの登録を正しく検証できるようになりました。

* **テスト**
  * コンテキスト登録リクエストの生成・送信に関するテストを追加・更新しました。

* **ドキュメント**
  * 変更内容を未リリースの変更履歴に追記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->