### PR TITLE
fix(registrations): list にセレクタ必須ガードを追加 (closes #201)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## [Unreleased]
 
+### 2026-08-17
+- **Fix**: `registrations list` がセレクタ無しの `GET /csourceRegistrations` を呼ばないようにした (closes #201, 本体 geolonia/geonicdb#2304 対応)。ETSI GS CIM 009 clause 5.10.2.4 の too wide query に合わせ、`--type` / `--attrs` / `--query` / geoquery (`--georel` / `--geometry` / `--coords`) のいずれかを必須にし、無指定時はサーバへ送らず CLI 側で拒否する。フラグ名は既存の entities/temporal と同じ `--query` / `--coords`（クエリ param は `q` / `coordinates`）
+
 ## [0.24.0] - 2026-08-13
 
 ### 2026-08-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,8 @@
 
 ### 2026-08-17
 - **Feat**: `entities attrs delete` に `--dataset-id` / `--delete-all` を追加し、多重属性インスタンスを CLI から削除できるようにした (closes #197, 本体 geolonia/geonicdb#2177 対応)。未指定時は既定インスタンスのみ削除する既存挙動を維持。両方指定はリクエスト前に拒否。404 時は `--dataset-id` / `--delete-all` を案内する Hint を付与 (#204)
-<<<<<<< HEAD
-- **Fix**: `registrations list` がセレクタ無しの `GET /csourceRegistrations` を呼ばないようにした (closes #201, 本体 geolonia/geonicdb#2304 対応)。ETSI GS CIM 009 clause 5.10.2.4 の too wide query に合わせ、`--type` / `--attrs` / `--query` / geoquery (`--georel` / `--geometry` / `--coords`) のいずれかを必須にし、無指定時はサーバへ送らず CLI 側で拒否する。フラグ名は既存の entities/temporal と同じ `--query` / `--coords`（クエリ param は `q` / `coordinates`）(#209)
-=======
 - **Fix**: `rules list` / `rules create` に `--service-path` を追加し、本体 #2259 の `GET /rules` 既定変更（未指定時は全 servicePath ではなく認可と同じ単一 path）に追従した (closes #199, 本体 geolonia/geonicdb#2259 / #2280 対応)。help の "all" 表現も実態に合わせて修正 (#205)
->>>>>>> origin/main
+- **Fix**: `registrations list` がセレクタ無しの `GET /csourceRegistrations` を呼ばないようにした (closes #201, 本体 geolonia/geonicdb#2304 対応)。ETSI GS CIM 009 clause 5.10.2.4 の too wide query に合わせ、`--type` / `--attrs` / `--query` / geoquery (`--georel` / `--geometry` / `--coords`) のいずれかを必須にし、無指定時はサーバへ送らず CLI 側で拒否する。フラグ名は既存の entities/temporal と同じ `--query` / `--coords`（クエリ param は `q` / `coordinates`）(#209)
 
 ## [0.24.0] - 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ## [Unreleased]
 
 ### 2026-08-17
-- **Fix**: `registrations list` がセレクタ無しの `GET /csourceRegistrations` を呼ばないようにした (closes #201, 本体 geolonia/geonicdb#2304 対応)。ETSI GS CIM 009 clause 5.10.2.4 の too wide query に合わせ、`--type` / `--attrs` / `--query` / geoquery (`--georel` / `--geometry` / `--coords`) のいずれかを必須にし、無指定時はサーバへ送らず CLI 側で拒否する。フラグ名は既存の entities/temporal と同じ `--query` / `--coords`（クエリ param は `q` / `coordinates`）
+- **Fix**: `registrations list` がセレクタ無しの `GET /csourceRegistrations` を呼ばないようにした (closes #201, 本体 geolonia/geonicdb#2304 対応)。ETSI GS CIM 009 clause 5.10.2.4 の too wide query に合わせ、`--type` / `--attrs` / `--query` / geoquery (`--georel` / `--geometry` / `--coords`) のいずれかを必須にし、無指定時はサーバへ送らず CLI 側で拒否する。フラグ名は既存の entities/temporal と同じ `--query` / `--coords`（クエリ param は `q` / `coordinates`）(#209)
 
 ## [0.24.0] - 2026-08-13
 

--- a/README.md
+++ b/README.md
@@ -438,11 +438,13 @@ Notes:
 
 | Subcommand | Description |
 |---|---|
-| `reg list` | List registrations |
+| `reg list --type WeatherStation` | List registrations (requires a selector) |
 | `reg get <id>` | Get a registration by ID |
 | `reg create [json]` | Create a registration |
 | `reg update <id> [json]` | Update a registration |
 | `reg delete <id>` | Delete a registration |
+
+`reg list` requires **at least one selector** — `--type`, `--attrs`, `--query`, or a geoquery (`--georel` / `--geometry` / `--coords`). Pagination (`--limit` / `--offset` / `--count`) alone is not enough; without a selector the CLI refuses the request (ETSI GS CIM 009 clause 5.10.2.4 / too wide query) instead of forwarding a bare `GET /csourceRegistrations` that the broker would reject with 400.
 
 ### types — Browse entity types
 

--- a/src/commands/registrations.ts
+++ b/src/commands/registrations.ts
@@ -16,36 +16,72 @@ export function registerRegistrationsCommand(program: Command): void {
     .description("Manage context registrations");
 
   // registrations list
+  // GET /csourceRegistrations requires a selector (ETSI GS CIM 009 clause 5.10.2.4 /
+  // geonicdb#2304). Without type|attrs|q|geoquery the broker returns 400 Too wide query.
   const list = registrations
     .command("list")
-    .description("List registrations")
+    .description(
+      "List registrations (requires a selector: --type, --attrs, --query, or a geoquery)",
+    )
+    .option("--type <type>", "Filter by registered entity type")
+    .option("--attrs <a,b>", "Comma-separated list of attribute names to match")
+    .option("--query <q>", "NGSI-LD query expression (q)")
+    .option("--georel <rel>", "Geo-relationship (e.g. near;maxDistance==1000)")
+    .option("--geometry <geo>", "Geometry type for geo-query (e.g. Point)")
+    .option("--coords <coords>", "Coordinates for geo-query")
     .option("--limit <n>", "Maximum number of results", parseInt)
     .option("--offset <n>", "Skip N results", parseInt)
     .option("--count", "Include total count in response")
     .action(
-      withErrorHandler(async (_opts: unknown, cmd: Command) => {
+      withErrorHandler(async (opts: Record<string, unknown>, cmd: Command) => {
         const client = createClient(cmd);
         const format = getFormat(cmd);
-        const cmdOpts = cmd.opts();
+
+        // Mirror assertRegistrationQueryRestrictionPresent (geonicdb#2304):
+        // type | attrs | q | (georel|geometry|coordinates). Pagination alone is not enough.
+        if (!opts.type && !opts.attrs && !opts.query && !opts.georel && !opts.geometry && !opts.coords) {
+          throw new Error(
+            "Too wide query (ETSI GS CIM 009 clause 5.10.2.4): specify at least one of --type, --attrs, --query, or a geoquery (--georel / --geometry / --coords).",
+          );
+        }
 
         const params: Record<string, string> = {};
-        if (cmdOpts.limit !== undefined) params["limit"] = String(cmdOpts.limit);
-        if (cmdOpts.offset !== undefined) params["offset"] = String(cmdOpts.offset);
-        if (cmdOpts.count) params["count"] = "true";
+        if (opts.type) params.type = String(opts.type);
+        if (opts.attrs) params.attrs = String(opts.attrs);
+        if (opts.query) params.q = String(opts.query);
+        if (opts.georel) params.georel = String(opts.georel);
+        if (opts.geometry) params.geometry = String(opts.geometry);
+        if (opts.coords) params.coordinates = String(opts.coords);
+        if (opts.limit !== undefined) params.limit = String(opts.limit);
+        if (opts.offset !== undefined) params.offset = String(opts.offset);
+        if (opts.count) params.count = "true";
 
         const response = await client.get("/csourceRegistrations", params);
-        outputResponse(response, format, !!cmdOpts.count);
+        outputResponse(response, format, !!opts.count);
       }),
     );
 
   addExamples(list, [
     {
-      description: "List all registrations",
-      command: "geonic registrations list",
+      description: "List registrations for an entity type",
+      command: "geonic registrations list --type WeatherStation",
+    },
+    {
+      description: "Filter by attribute names",
+      command: "geonic registrations list --attrs temperature,humidity",
+    },
+    {
+      description: "Filter with an NGSI-LD query",
+      command: "geonic registrations list --query 'temperature>20'",
+    },
+    {
+      description: "Geo-query near a point",
+      command:
+        "geonic registrations list --georel 'near;maxDistance==1000' --geometry Point --coords '[139.7671,35.6812]'",
     },
     {
       description: "List with pagination",
-      command: "geonic registrations list --limit 10",
+      command: "geonic registrations list --type WeatherStation --limit 10",
     },
   ]);
 

--- a/src/commands/registrations.ts
+++ b/src/commands/registrations.ts
@@ -34,16 +34,17 @@ export function registerRegistrationsCommand(program: Command): void {
     .option("--count", "Include total count in response")
     .action(
       withErrorHandler(async (opts: Record<string, unknown>, cmd: Command) => {
-        const client = createClient(cmd);
-        const format = getFormat(cmd);
-
         // Mirror assertRegistrationQueryRestrictionPresent (geonicdb#2304):
         // type | attrs | q | (georel|geometry|coordinates). Pagination alone is not enough.
+        // Validate before createClient so a missing URL does not mask the too-wide message.
         if (!opts.type && !opts.attrs && !opts.query && !opts.georel && !opts.geometry && !opts.coords) {
           throw new Error(
             "Too wide query (ETSI GS CIM 009 clause 5.10.2.4): specify at least one of --type, --attrs, --query, or a geoquery (--georel / --geometry / --coords).",
           );
         }
+
+        const client = createClient(cmd);
+        const format = getFormat(cmd);
 
         const params: Record<string, string> = {};
         if (opts.type) params.type = String(opts.type);

--- a/tests/e2e/features/registrations.feature
+++ b/tests/e2e/features/registrations.feature
@@ -3,11 +3,12 @@ Feature: Registration management
   I want to manage context registrations
   So that I can register context sources
 
-  Scenario: List registrations when none exist
+  Scenario: List registrations refuses a too-wide query without a selector
     Given I am logged in
     When I run `geonic registrations list`
-    Then the exit code should be 0
-    And stdout should contain "[]"
+    Then the exit code should be 1
+    And the output should contain "Too wide query"
+    And the output should contain "clause 5.10.2.4"
 
   Scenario: Create a registration
     Given I am logged in
@@ -18,14 +19,14 @@ Feature: Registration management
   Scenario: List registrations after creation
     Given I am logged in
     And I run `geonic registrations create '{"type":"ContextSourceRegistration","information":[{"entities":[{"type":"Room"}]}],"endpoint":"http://localhost:4000/source"}'`
-    When I run `geonic registrations list`
+    When I run `geonic registrations list --type Room`
     Then the exit code should be 0
     And the output should contain "Room"
 
   Scenario: Get registration by ID
     Given I am logged in
     And I run `geonic registrations create '{"type":"ContextSourceRegistration","information":[{"entities":[{"type":"Room"}]}],"endpoint":"http://localhost:4000/source"}'`
-    And I run `geonic registrations list --format json`
+    And I run `geonic registrations list --type Room --format json`
     And I save the ID from the JSON output
     When I run `geonic registrations get $ID` replacing ID
     Then the exit code should be 0
@@ -34,7 +35,7 @@ Feature: Registration management
   Scenario: Delete a registration
     Given I am logged in
     And I run `geonic registrations create '{"type":"ContextSourceRegistration","information":[{"entities":[{"type":"Room"}]}],"endpoint":"http://localhost:4000/source"}'`
-    And I run `geonic registrations list --format json`
+    And I run `geonic registrations list --type Room --format json`
     And I save the ID from the JSON output
     When I run `geonic registrations delete $ID` replacing ID
     Then the exit code should be 0
@@ -43,6 +44,6 @@ Feature: Registration management
   Scenario: List registrations with count
     Given I am logged in
     And I run `geonic registrations create '{"type":"ContextSourceRegistration","information":[{"entities":[{"type":"Room"}]}],"endpoint":"http://localhost:4000/source"}'`
-    When I run `geonic registrations list --count`
+    When I run `geonic registrations list --type Room --count`
     Then the exit code should be 0
     And the output should contain "Count:"

--- a/tests/registrations.test.ts
+++ b/tests/registrations.test.ts
@@ -26,6 +26,7 @@ describe("registrations command", () => {
         /Too wide query.*clause 5\.10\.2\.4/,
       );
 
+      expect(createClient).not.toHaveBeenCalled();
       expect(mockClient.get).not.toHaveBeenCalled();
     });
 
@@ -34,6 +35,7 @@ describe("registrations command", () => {
         runCommand(program, ["registrations", "list", "--limit", "10", "--offset", "5", "--count"]),
       ).rejects.toThrow(/Too wide query.*clause 5\.10\.2\.4/);
 
+      expect(createClient).not.toHaveBeenCalled();
       expect(mockClient.get).not.toHaveBeenCalled();
     });
 

--- a/tests/registrations.test.ts
+++ b/tests/registrations.test.ts
@@ -21,29 +21,86 @@ describe("registrations command", () => {
   });
 
   describe("list", () => {
-    it("calls client.get with no params when no options given", async () => {
-      mockClient.get.mockResolvedValue(mockResponse([]));
-      await runCommand(program, ["registrations", "list"]);
+    it("refuses a too-wide list (no selector) before any server call", async () => {
+      await expect(runCommand(program, ["registrations", "list"])).rejects.toThrow(
+        /Too wide query.*clause 5\.10\.2\.4/,
+      );
 
-      expect(mockClient.get).toHaveBeenCalledWith("/csourceRegistrations", {});
+      expect(mockClient.get).not.toHaveBeenCalled();
+    });
+
+    it("refuses pagination-only options as a too-wide list (near-miss)", async () => {
+      await expect(
+        runCommand(program, ["registrations", "list", "--limit", "10", "--offset", "5", "--count"]),
+      ).rejects.toThrow(/Too wide query.*clause 5\.10\.2\.4/);
+
+      expect(mockClient.get).not.toHaveBeenCalled();
+    });
+
+    it("passes type selector and pagination params", async () => {
+      mockClient.get.mockResolvedValue(mockResponse([]));
+      await runCommand(program, [
+        "registrations",
+        "list",
+        "--type",
+        "WeatherStation",
+        "--limit",
+        "10",
+        "--offset",
+        "5",
+      ]);
+
+      expect(mockClient.get).toHaveBeenCalledWith("/csourceRegistrations", {
+        type: "WeatherStation",
+        limit: "10",
+        offset: "5",
+      });
       expect(outputResponse).toHaveBeenCalledWith(expect.anything(), "json", false);
     });
 
-    it("passes limit and offset params", async () => {
+    it("maps --query to q and --coords to coordinates", async () => {
       mockClient.get.mockResolvedValue(mockResponse([]));
-      await runCommand(program, ["registrations", "list", "--limit", "10", "--offset", "5"]);
+      await runCommand(program, [
+        "registrations",
+        "list",
+        "--query",
+        "temperature>20",
+        "--georel",
+        "near;maxDistance==1000",
+        "--geometry",
+        "Point",
+        "--coords",
+        "[139.7,35.6]",
+        "--attrs",
+        "temperature",
+      ]);
 
       expect(mockClient.get).toHaveBeenCalledWith("/csourceRegistrations", {
-        limit: "10",
-        offset: "5",
+        q: "temperature>20",
+        georel: "near;maxDistance==1000",
+        geometry: "Point",
+        coordinates: "[139.7,35.6]",
+        attrs: "temperature",
+      });
+    });
+
+    it("accepts geometry alone as a sufficient geoquery selector", async () => {
+      mockClient.get.mockResolvedValue(mockResponse([]));
+      await runCommand(program, ["registrations", "list", "--geometry", "Point"]);
+
+      expect(mockClient.get).toHaveBeenCalledWith("/csourceRegistrations", {
+        geometry: "Point",
       });
     });
 
     it("passes count param and sets showCount to true", async () => {
       mockClient.get.mockResolvedValue(mockResponse([], 200, 3));
-      await runCommand(program, ["registrations", "list", "--count"]);
+      await runCommand(program, ["registrations", "list", "--type", "Room", "--count"]);
 
-      expect(mockClient.get).toHaveBeenCalledWith("/csourceRegistrations", { count: "true" });
+      expect(mockClient.get).toHaveBeenCalledWith("/csourceRegistrations", {
+        type: "Room",
+        count: "true",
+      });
       expect(outputResponse).toHaveBeenCalledWith(expect.anything(), "json", true);
     });
   });


### PR DESCRIPTION
## Summary

- **原因**: `registrations list` が `--limit` / `--offset` / `--count` だけを送り、セレクタ無しで `GET /csourceRegistrations` を呼んでいた。本体 geolonia/geonicdb#2304 の too wide query 検証が入ると 400 になる。
- **修正**: `--type` / `--attrs` / `--query` / geoquery (`--georel` / `--geometry` / `--coords`) を追加し、いずれも無いときはサーバ未呼び出しで拒否。エラーに `Too wide query` と `clause 5.10.2.4` を含める。フラグ名は既存 entities/temporal と同じ `--query` / `--coords`（param は `q` / `coordinates`）。
- **テスト**: 無指定拒否・pagination-only near-miss・セレクタ→param マッピング。変異注入（ガード条件を `false &&` 化）で 2 テスト赤→復元。E2E feature も `--type` 必須化。

Closes #201

## Test plan

- [x] `npm run lint` / `npm run typecheck` / `npm test`（1048）
- [x] 修正前ガード除去で拒否テスト 2 件が赤、修正後緑
- [x] 変異注入: ガード無効化 → 同上 2 件赤 → 復元
- [x] E2E 207 scenarios passed（registrations feature 更新込み）
- [ ] CI 全チェック

## スコープ外

- geonicdb pin の #2304 以降への更新（CLI ガードは pin 無しでも効く）
- 空白のみセレクタの trim ミラー（本体は trim、CLI は truthiness。entities purge と同型）


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * `registrations list`で、型・属性・クエリ・地理条件を指定して登録情報を検索できるようになりました。
  * 件数取得、各種クエリ、地理条件、ページネーションに対応しました。

* **改善**
  * セレクターなし、またはページネーションのみの実行を事前に拒否し、不要なサーバーリクエストを防止します。

* **ドキュメント**
  * 必須セレクターと利用例をREADMEおよび変更履歴に追記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->