### PR TITLE
feat(models): update に --api-dry-run を追加 (closes #198)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ## [Unreleased]
 
 ### 2026-08-17
-- **Feat**: `models update` に `--api-dry-run` を追加した (closes #198, 本体 geolonia/geonicdb#2098 / #2207 対応)。`PATCH /custom-data-models/{type}?dryRun=true` を送り、更新を適用せず既存エンティティの適合性レポートを返す。グローバル `--dry-run`（curl 表示）とは別フラグ。`conformance.violating > 0` のとき非 0 終了、`truncated` / `scopeLimited` は警告のみ (#210)
+- **Feat**: `models update` に `--api-dry-run` を追加した (closes #198, 本体 geolonia/geonicdb#2098 / #2207 対応)。`PATCH /custom-data-models/{type}?dryRun=true` を送り、更新を適用せず既存エンティティの適合性レポートを返す。グローバル `--dry-run`（curl 表示）とは別フラグ。`conformance.violating > 0` または非空の `uniqueConstraintViolations` のとき非 0 終了、`truncated` / `scopeLimited` / `undetermined` は警告のみ。グローバル `--dry-run` との併用は拒否する (#210)
 
 ## [0.24.0] - 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ## [Unreleased]
 
 ### 2026-08-17
-- **Feat**: `models update` に `--api-dry-run` を追加した (closes #198, 本体 geolonia/geonicdb#2098 / #2207 対応)。`PATCH /custom-data-models/{type}?dryRun=true` を送り、更新を適用せず既存エンティティの適合性レポートを返す。グローバル `--dry-run`（curl 表示）とは別フラグ。`conformance.violating > 0` のとき非 0 終了、`truncated` / `scopeLimited` は警告のみ
+- **Feat**: `models update` に `--api-dry-run` を追加した (closes #198, 本体 geolonia/geonicdb#2098 / #2207 対応)。`PATCH /custom-data-models/{type}?dryRun=true` を送り、更新を適用せず既存エンティティの適合性レポートを返す。グローバル `--dry-run`（curl 表示）とは別フラグ。`conformance.violating > 0` のとき非 0 終了、`truncated` / `scopeLimited` は警告のみ (#210)
 
 ## [0.24.0] - 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## [Unreleased]
 
+### 2026-08-17
+- **Feat**: `models update` に `--api-dry-run` を追加した (closes #198, 本体 geolonia/geonicdb#2098 / #2207 対応)。`PATCH /custom-data-models/{type}?dryRun=true` を送り、更新を適用せず既存エンティティの適合性レポートを返す。グローバル `--dry-run`（curl 表示）とは別フラグ。`conformance.violating > 0` のとき非 0 終了、`truncated` / `scopeLimited` は警告のみ
+
 ## [0.24.0] - 2026-08-13
 
 ### 2026-08-13

--- a/src/commands/models.ts
+++ b/src/commands/models.ts
@@ -22,13 +22,22 @@ export type ModelUpdateDryRunResponse = {
 };
 
 /**
- * Apply dry-run side effects: warn on truncated / scopeLimited, and fail the
- * process when any existing entity would violate the updated model.
+ * Apply dry-run side effects: warn on truncated / scopeLimited / undetermined,
+ * reject responses that are not a dry-run report, and fail the process when any
+ * existing entity would violate the updated model.
  * Returns the exit code that was set (0 or 1) for testability.
  */
 export function applyModelUpdateDryRunResult(data: unknown): number {
   const body = (data ?? {}) as ModelUpdateDryRunResponse;
-  const conformance = body.conformance ?? {};
+  const conformance = body.conformance;
+
+  if (body.dryRun !== true || conformance == null || typeof conformance !== "object") {
+    printWarning(
+      "Response is not an API dry-run conformance report; the server may not support ?dryRun=true and the update may have been applied.",
+    );
+    process.exitCode = 1;
+    return 1;
+  }
 
   if (conformance.truncated) {
     printWarning(
@@ -38,6 +47,12 @@ export function applyModelUpdateDryRunResult(data: unknown): number {
   if (conformance.scopeLimited) {
     printWarning(
       "Dry-run scan was limited to entities readable by the caller (scopeLimited); counts may under-report.",
+    );
+  }
+  const undetermined = conformance.undetermined ?? 0;
+  if (undetermined > 0) {
+    printWarning(
+      `Dry-run could not determine conformance for ${undetermined} entities; review them manually.`,
     );
   }
 

--- a/src/commands/models.ts
+++ b/src/commands/models.ts
@@ -1,7 +1,7 @@
 import type { Command } from "commander";
 import { withErrorHandler, createClient, getFormat, outputResponse, parseNonNegativeInt, fetchPaginatedList } from "../helpers.js";
 import { parseJsonInput } from "../input.js";
-import { printSuccess, printWarning } from "../output.js";
+import { printSuccess, printWarning, printError } from "../output.js";
 import { addExamples } from "./help.js";
 
 /** Shape of PATCH /custom-data-models/{type}?dryRun=true (GeonicDB #2098). */
@@ -13,6 +13,8 @@ export type ModelUpdateDryRunConformance = {
   maxScan?: number;
   scopeLimited?: boolean;
   samples?: unknown[];
+  /** Present only when non-empty (GeonicDB #2098). */
+  uniqueConstraintViolations?: string[];
 };
 
 export type ModelUpdateDryRunResponse = {
@@ -24,7 +26,7 @@ export type ModelUpdateDryRunResponse = {
 /**
  * Apply dry-run side effects: warn on truncated / scopeLimited / undetermined,
  * reject responses that are not a dry-run report, and fail the process when any
- * existing entity would violate the updated model.
+ * existing entity would violate the updated model (including uniqueConstraints).
  * Returns the exit code that was set (0 or 1) for testability.
  */
 export function applyModelUpdateDryRunResult(data: unknown): number {
@@ -57,7 +59,9 @@ export function applyModelUpdateDryRunResult(data: unknown): number {
   }
 
   const violating = conformance.violating ?? 0;
-  if (violating > 0) {
+  const ucViolations = conformance.uniqueConstraintViolations;
+  const hasUcViolations = Array.isArray(ucViolations) && ucViolations.length > 0;
+  if (violating > 0 || hasUcViolations) {
     process.exitCode = 1;
     return 1;
   }
@@ -198,10 +202,18 @@ export function registerModelsCommand(program: Command): void {
     .action(
       withErrorHandler(
         async (id: unknown, json: unknown, opts: { apiDryRun?: boolean }, cmd: Command) => {
+          const apiDryRun = !!opts.apiDryRun;
+          const globalDryRun = !!(cmd.optsWithGlobals() as { dryRun?: boolean }).dryRun;
+          if (apiDryRun && globalDryRun) {
+            printError(
+              "Cannot combine --api-dry-run with global --dry-run; omit --dry-run to run the API conformance check.",
+            );
+            process.exitCode = 1;
+            return;
+          }
           const body = await parseJsonInput(json as string | undefined);
           const client = createClient(cmd);
           const format = getFormat(cmd);
-          const apiDryRun = !!opts.apiDryRun;
           const response = await client.rawRequest(
             "PATCH",
             `/custom-data-models/${encodeURIComponent(String(id))}`,

--- a/src/commands/models.ts
+++ b/src/commands/models.ts
@@ -1,8 +1,53 @@
 import type { Command } from "commander";
 import { withErrorHandler, createClient, getFormat, outputResponse, parseNonNegativeInt, fetchPaginatedList } from "../helpers.js";
 import { parseJsonInput } from "../input.js";
-import { printSuccess } from "../output.js";
+import { printSuccess, printWarning } from "../output.js";
 import { addExamples } from "./help.js";
+
+/** Shape of PATCH /custom-data-models/{type}?dryRun=true (GeonicDB #2098). */
+export type ModelUpdateDryRunConformance = {
+  scanned?: number;
+  violating?: number;
+  undetermined?: number;
+  truncated?: boolean;
+  maxScan?: number;
+  scopeLimited?: boolean;
+  samples?: unknown[];
+};
+
+export type ModelUpdateDryRunResponse = {
+  type?: string;
+  dryRun?: boolean;
+  conformance?: ModelUpdateDryRunConformance;
+};
+
+/**
+ * Apply dry-run side effects: warn on truncated / scopeLimited, and fail the
+ * process when any existing entity would violate the updated model.
+ * Returns the exit code that was set (0 or 1) for testability.
+ */
+export function applyModelUpdateDryRunResult(data: unknown): number {
+  const body = (data ?? {}) as ModelUpdateDryRunResponse;
+  const conformance = body.conformance ?? {};
+
+  if (conformance.truncated) {
+    printWarning(
+      `Dry-run scan truncated at maxScan=${conformance.maxScan ?? "?"}; scanned/violating counts are lower bounds.`,
+    );
+  }
+  if (conformance.scopeLimited) {
+    printWarning(
+      "Dry-run scan was limited to entities readable by the caller (scopeLimited); counts may under-report.",
+    );
+  }
+
+  const violating = conformance.violating ?? 0;
+  if (violating > 0) {
+    process.exitCode = 1;
+    return 1;
+  }
+  return 0;
+}
 
 export function registerModelsCommand(program: Command): void {
   const models = program
@@ -126,20 +171,32 @@ export function registerModelsCommand(program: Command): void {
         "JSON payload: only specified fields are updated.\n" +
         '  e.g. {"description": "Updated model"}\n\n' +
         "uniqueConstraints replaces the whole constraint list (send [] to remove all).\n" +
-        "Adding a constraint fails with 400 if existing entities already violate it.",
+        "Adding a constraint fails with 400 if existing entities already violate it.\n\n" +
+        "--api-dry-run sends PATCH ?dryRun=true (GeonicDB extension): the update is NOT\n" +
+        "applied; the response is a conformance report for existing entities. Exit code is\n" +
+        "non-zero when conformance.violating > 0. Distinct from the global --dry-run (curl).",
+    )
+    .option(
+      "--api-dry-run",
+      "Preview update without applying it (PATCH ?dryRun=true); report entity conformance",
     )
     .action(
       withErrorHandler(
-        async (id: unknown, json: unknown, _opts: unknown, cmd: Command) => {
+        async (id: unknown, json: unknown, opts: { apiDryRun?: boolean }, cmd: Command) => {
           const body = await parseJsonInput(json as string | undefined);
           const client = createClient(cmd);
           const format = getFormat(cmd);
+          const apiDryRun = !!opts.apiDryRun;
           const response = await client.rawRequest(
             "PATCH",
             `/custom-data-models/${encodeURIComponent(String(id))}`,
-            { body },
+            apiDryRun ? { body, params: { dryRun: "true" } } : { body },
           );
           outputResponse(response, format);
+          if (apiDryRun) {
+            applyModelUpdateDryRunResult(response.data);
+            return;
+          }
           printSuccess("Model updated.");
         },
       ),
@@ -165,6 +222,10 @@ export function registerModelsCommand(program: Command): void {
     {
       description: "Remove all unique constraints",
       command: `geonic models update RoomReservation '{"uniqueConstraints":[]}'`,
+    },
+    {
+      description: "Preview a tightening update without applying it (API dry-run)",
+      command: `geonic models update TemperatureSensor '{"propertyDetails":{"temperature":{"ngsiType":"Property","valueType":"Number","validation":{"maximum":30}}}}' --api-dry-run`,
     },
   ]);
 

--- a/tests/models.test.ts
+++ b/tests/models.test.ts
@@ -334,6 +334,7 @@ describe("models (custom-data-models) command", () => {
     it("returns 1 and sets exitCode when violating > 0", () => {
       process.exitCode = undefined;
       const code = applyModelUpdateDryRunResult({
+        dryRun: true,
         conformance: { violating: 1, truncated: false, scopeLimited: false },
       });
       expect(code).toBe(1);
@@ -343,16 +344,34 @@ describe("models (custom-data-models) command", () => {
     it("near-miss: violating=0 returns 0 and does not set exitCode", () => {
       process.exitCode = undefined;
       const code = applyModelUpdateDryRunResult({
+        dryRun: true,
         conformance: { violating: 0, truncated: false, scopeLimited: false },
       });
       expect(code).toBe(0);
       expect(process.exitCode).toBeUndefined();
     });
 
-    it("treats missing conformance as zero violations", () => {
+    it("warns and fails when response is not a dry-run report", () => {
       process.exitCode = undefined;
-      expect(applyModelUpdateDryRunResult({ type: "X", dryRun: true })).toBe(0);
+      const code = applyModelUpdateDryRunResult({ type: "X", description: "applied" });
+      expect(code).toBe(1);
+      expect(process.exitCode).toBe(1);
+      expect(printWarning).toHaveBeenCalledWith(
+        expect.stringContaining("may not support ?dryRun=true"),
+      );
+    });
+
+    it("warns when undetermined > 0 without failing on zero violations", () => {
+      process.exitCode = undefined;
+      const code = applyModelUpdateDryRunResult({
+        dryRun: true,
+        conformance: { violating: 0, undetermined: 3, truncated: false, scopeLimited: false },
+      });
+      expect(code).toBe(0);
       expect(process.exitCode).toBeUndefined();
+      expect(printWarning).toHaveBeenCalledWith(
+        expect.stringContaining("could not determine conformance"),
+      );
     });
   });
 

--- a/tests/models.test.ts
+++ b/tests/models.test.ts
@@ -5,7 +5,7 @@ import type { MockClient } from "./test-helpers.js";
 
 import { createClient, getFormat, outputResponse } from "../src/helpers.js";
 import { parseJsonInput } from "../src/input.js";
-import { printSuccess, printWarning } from "../src/output.js";
+import { printSuccess, printWarning, printError } from "../src/output.js";
 import {
   applyModelUpdateDryRunResult,
   registerModelsCommand,
@@ -321,6 +321,22 @@ describe("models (custom-data-models) command", () => {
       );
       expect(printSuccess).toHaveBeenCalledWith("Model updated.");
     });
+
+    it("rejects combining --api-dry-run with global --dry-run", async () => {
+      process.exitCode = undefined;
+      await runCommand(program, [
+        "models",
+        "update",
+        "TemperatureSensor",
+        '{"description":"x"}',
+        "--api-dry-run",
+        "--dry-run",
+      ]);
+
+      expect(mockClient.rawRequest).not.toHaveBeenCalled();
+      expect(printError).toHaveBeenCalledWith(expect.stringContaining("Cannot combine"));
+      expect(process.exitCode).toBe(1);
+    });
   });
 
   describe("applyModelUpdateDryRunResult (#198)", () => {
@@ -346,6 +362,29 @@ describe("models (custom-data-models) command", () => {
       const code = applyModelUpdateDryRunResult({
         dryRun: true,
         conformance: { violating: 0, truncated: false, scopeLimited: false },
+      });
+      expect(code).toBe(0);
+      expect(process.exitCode).toBeUndefined();
+    });
+
+    it("sets exitCode=1 when uniqueConstraintViolations is non-empty even if violating=0", () => {
+      process.exitCode = undefined;
+      const code = applyModelUpdateDryRunResult({
+        dryRun: true,
+        conformance: {
+          violating: 0,
+          uniqueConstraintViolations: ["constraint 'unique-code' already violated"],
+        },
+      });
+      expect(code).toBe(1);
+      expect(process.exitCode).toBe(1);
+    });
+
+    it("near-miss: empty uniqueConstraintViolations does not fail", () => {
+      process.exitCode = undefined;
+      const code = applyModelUpdateDryRunResult({
+        dryRun: true,
+        conformance: { violating: 0, uniqueConstraintViolations: [] },
       });
       expect(code).toBe(0);
       expect(process.exitCode).toBeUndefined();

--- a/tests/models.test.ts
+++ b/tests/models.test.ts
@@ -1,12 +1,15 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import "./setup-command-mocks.js";
 import { createMockClient, mockResponse, createTestProgram, runCommand } from "./test-helpers.js";
 import type { MockClient } from "./test-helpers.js";
 
 import { createClient, getFormat, outputResponse } from "../src/helpers.js";
 import { parseJsonInput } from "../src/input.js";
-import { printSuccess } from "../src/output.js";
-import { registerModelsCommand } from "../src/commands/models.js";
+import { printSuccess, printWarning } from "../src/output.js";
+import {
+  applyModelUpdateDryRunResult,
+  registerModelsCommand,
+} from "../src/commands/models.js";
 
 describe("models (custom-data-models) command", () => {
   let mockClient: MockClient;
@@ -143,6 +146,213 @@ describe("models (custom-data-models) command", () => {
         `/custom-data-models/${encodeURIComponent("Slot")}`,
         { body: patchData },
       );
+    });
+  });
+
+  describe("update --api-dry-run (#198)", () => {
+    const originalExitCode = process.exitCode;
+
+    afterEach(() => {
+      process.exitCode = originalExitCode;
+    });
+
+    const conformingReport = {
+      type: "TemperatureSensor",
+      dryRun: true,
+      conformance: {
+        scanned: 2,
+        violating: 0,
+        undetermined: 0,
+        truncated: false,
+        maxScan: 10000,
+        scopeLimited: false,
+        samples: [],
+      },
+    };
+
+    const violatingReport = {
+      type: "TemperatureSensor",
+      dryRun: true,
+      conformance: {
+        scanned: 2,
+        violating: 1,
+        undetermined: 0,
+        truncated: false,
+        maxScan: 10000,
+        scopeLimited: false,
+        samples: [
+          {
+            entityId: "Sensor001",
+            errors: ["temperature: Value (50) exceeds maximum (30)"],
+          },
+        ],
+      },
+    };
+
+    it("sends PATCH with dryRun=true and does not print Model updated.", async () => {
+      const patchData = {
+        propertyDetails: {
+          temperature: {
+            ngsiType: "Property",
+            valueType: "Number",
+            validation: { maximum: 30 },
+          },
+        },
+      };
+      vi.mocked(parseJsonInput).mockResolvedValue(patchData);
+      mockClient.rawRequest.mockResolvedValue(mockResponse(conformingReport));
+      process.exitCode = undefined;
+
+      await runCommand(program, [
+        "models",
+        "update",
+        "TemperatureSensor",
+        JSON.stringify(patchData),
+        "--api-dry-run",
+      ]);
+
+      expect(mockClient.rawRequest).toHaveBeenCalledWith(
+        "PATCH",
+        `/custom-data-models/${encodeURIComponent("TemperatureSensor")}`,
+        { body: patchData, params: { dryRun: "true" } },
+      );
+      expect(outputResponse).toHaveBeenCalledWith(
+        expect.objectContaining({ data: conformingReport }),
+        "json",
+      );
+      expect(printSuccess).not.toHaveBeenCalled();
+      expect(process.exitCode).toBeUndefined();
+    });
+
+    it("sets exitCode=1 when conformance.violating > 0", async () => {
+      vi.mocked(parseJsonInput).mockResolvedValue({ description: "strict" });
+      mockClient.rawRequest.mockResolvedValue(mockResponse(violatingReport));
+      process.exitCode = undefined;
+
+      await runCommand(program, [
+        "models",
+        "update",
+        "TemperatureSensor",
+        '{"description":"strict"}',
+        "--api-dry-run",
+      ]);
+
+      expect(printSuccess).not.toHaveBeenCalled();
+      expect(process.exitCode).toBe(1);
+    });
+
+    it("near-miss: violating=0 keeps exit success even when truncated", async () => {
+      const truncatedClean = {
+        type: "TemperatureSensor",
+        dryRun: true,
+        conformance: {
+          scanned: 10000,
+          violating: 0,
+          undetermined: 0,
+          truncated: true,
+          maxScan: 10000,
+          scopeLimited: false,
+          samples: [],
+        },
+      };
+      vi.mocked(parseJsonInput).mockResolvedValue({ description: "x" });
+      mockClient.rawRequest.mockResolvedValue(mockResponse(truncatedClean));
+      process.exitCode = undefined;
+
+      await runCommand(program, [
+        "models",
+        "update",
+        "TemperatureSensor",
+        '{"description":"x"}',
+        "--api-dry-run",
+      ]);
+
+      expect(printWarning).toHaveBeenCalledWith(expect.stringContaining("truncated"));
+      expect(process.exitCode).toBeUndefined();
+      expect(printSuccess).not.toHaveBeenCalled();
+    });
+
+    it("warns when scopeLimited without failing on zero violations", async () => {
+      const scoped = {
+        type: "TemperatureSensor",
+        dryRun: true,
+        conformance: {
+          scanned: 1,
+          violating: 0,
+          undetermined: 0,
+          truncated: false,
+          maxScan: 10000,
+          scopeLimited: true,
+          samples: [],
+        },
+      };
+      vi.mocked(parseJsonInput).mockResolvedValue({ description: "x" });
+      mockClient.rawRequest.mockResolvedValue(mockResponse(scoped));
+      process.exitCode = undefined;
+
+      await runCommand(program, [
+        "models",
+        "update",
+        "TemperatureSensor",
+        '{"description":"x"}',
+        "--api-dry-run",
+      ]);
+
+      expect(printWarning).toHaveBeenCalledWith(expect.stringContaining("scopeLimited"));
+      expect(process.exitCode).toBeUndefined();
+    });
+
+    it("without --api-dry-run does not send dryRun param", async () => {
+      const patchData = { description: "live" };
+      vi.mocked(parseJsonInput).mockResolvedValue(patchData);
+      mockClient.rawRequest.mockResolvedValue(mockResponse({ type: "TemperatureSensor" }));
+
+      await runCommand(program, [
+        "models",
+        "update",
+        "TemperatureSensor",
+        '{"description":"live"}',
+      ]);
+
+      expect(mockClient.rawRequest).toHaveBeenCalledWith(
+        "PATCH",
+        `/custom-data-models/${encodeURIComponent("TemperatureSensor")}`,
+        { body: patchData },
+      );
+      expect(printSuccess).toHaveBeenCalledWith("Model updated.");
+    });
+  });
+
+  describe("applyModelUpdateDryRunResult (#198)", () => {
+    const originalExitCode = process.exitCode;
+
+    afterEach(() => {
+      process.exitCode = originalExitCode;
+      vi.mocked(printWarning).mockClear();
+    });
+
+    it("returns 1 and sets exitCode when violating > 0", () => {
+      process.exitCode = undefined;
+      const code = applyModelUpdateDryRunResult({
+        conformance: { violating: 1, truncated: false, scopeLimited: false },
+      });
+      expect(code).toBe(1);
+      expect(process.exitCode).toBe(1);
+    });
+
+    it("near-miss: violating=0 returns 0 and does not set exitCode", () => {
+      process.exitCode = undefined;
+      const code = applyModelUpdateDryRunResult({
+        conformance: { violating: 0, truncated: false, scopeLimited: false },
+      });
+      expect(code).toBe(0);
+      expect(process.exitCode).toBeUndefined();
+    });
+
+    it("treats missing conformance as zero violations", () => {
+      process.exitCode = undefined;
+      expect(applyModelUpdateDryRunResult({ type: "X", dryRun: true })).toBe(0);
+      expect(process.exitCode).toBeUndefined();
     });
   });
 

--- a/tests/test-helpers.ts
+++ b/tests/test-helpers.ts
@@ -48,6 +48,7 @@ export function createTestProgram(
     .option("-f, --format <fmt>", "Output format")
     .option("--no-color", "Disable color")
     .option("-v, --verbose", "Verbose output")
+    .option("--dry-run", "Print the equivalent curl command without executing")
     .exitOverride();
 
   registerFn(program);


### PR DESCRIPTION
## Summary
- `models update` に `--api-dry-run` を追加し、`PATCH /custom-data-models/{type}?dryRun=true`（本体 geolonia/geonicdb#2098）を実際に送って適合性レポートを返す
- グローバル `--dry-run`（curl 表示）とは分離。dry-run 時は `Model updated.` を出さない
- `conformance.violating > 0` で非 0 終了。`truncated` / `scopeLimited` は警告のみ（exit には載せない）

## 原因
未実装の enhancement。既存のグローバル `--dry-run` は curl 専用で API の `?dryRun=true` とは無関係。issue 文言の「`--dry-run` 追加」は衝突するため、裁可どおり `--api-dry-run` とした。

## テスト
- ユニット: `tests/models.test.ts`（dryRun クエリ送信 / 成功メッセージ非表示 / violating 終了コード / truncated・scopeLimited 警告 / near-miss）
- 変異注入: `dryRun:"true"→"false"` で 1 テスト赤、`violating>0→>1` で 2 テスト赤（near-miss は緑のまま）。戻し済み
- ローカル: `npm run lint && npm run typecheck && npm test` 緑
- E2E: 未実行（ローカル geonicdb pin に本体 #2098 が無い）

## スコープ外
- グローバル `--dry-run` の curl への `dryRun=true` 付与
- geonicdb pin 更新 + E2E シナリオ

Closes #198

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * `models update` に API dry-run オプションを追加しました。
  * 更新前に適合性を確認し、結果や違反件数を表示できるようになりました。
  * 違反がある場合は終了コード 1 を返します。
  * スキャンの切り詰め、対象範囲の制限、未判定項目がある場合に警告を表示します。
* **ドキュメント**
  * API dry-run の使用例と変更履歴を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->