### PR TITLE
release: v0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## [Unreleased]
 
+## [0.25.0] - 2026-08-17
+
 ### 2026-08-17
 - **Feat**: `temporal entities list` / `get` に `--time-property` を追加し、NGSI-LD `timeproperty` クエリへ載せる (closes #202, 本体 geolonia/geonicdb#2267 / PR #2338 対応) (#206)。許容値は本体と同じ `observedAt` / `createdAt` / `modifiedAt` / `deletedAt`（未知値・空文字はサーバが 400。CLI は未指定時のみ省略し、明示された空文字は転送する）
 - **Feat**: `entities attrs delete` に `--dataset-id` / `--delete-all` を追加し、多重属性インスタンスを CLI から削除できるようにした (closes #197, 本体 geolonia/geonicdb#2177 対応)。未指定時は既定インスタンスのみ削除する既存挙動を維持。両方指定はリクエスト前に拒否。404 時は `--dataset-id` / `--delete-all` を案内する Hint を付与 (#204)
@@ -407,7 +409,8 @@
 ### 2026-02-26
 - **Docs**: README にインストール手順・使い方・コマンドリファレンスを追加 (#1)
 
-[Unreleased]: https://github.com/geolonia/geonicdb-cli/compare/v0.24.0...HEAD
+[Unreleased]: https://github.com/geolonia/geonicdb-cli/compare/v0.25.0...HEAD
+[0.25.0]: https://github.com/geolonia/geonicdb-cli/compare/v0.24.0...v0.25.0
 [0.24.0]: https://github.com/geolonia/geonicdb-cli/compare/v0.23.0...v0.24.0
 [0.23.0]: https://github.com/geolonia/geonicdb-cli/compare/v0.22.1...v0.23.0
 [0.22.1]: https://github.com/geolonia/geonicdb-cli/compare/v0.22.0...v0.22.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolonia/geonicdb-cli",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolonia/geonicdb-cli",
-      "version": "0.24.0",
+      "version": "0.25.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolonia/geonicdb-cli",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "description": "A CLI client for the GeonicDB",
   "type": "module",
   "bin": {


### PR DESCRIPTION
v0.25.0 リリース。

## 含まれる変更
- #206 (closes #202): temporal entities list/get に --time-property
- #204 (closes #197): entities attrs delete に --dataset-id / --delete-all
- #205 (closes #199): rules list/create に --service-path
- #208 (closes #203): jsonldContexts E2E から kind 除去
- #209 (closes #201): registrations list にセレクタ必須ガード
- #207 (closes #200): POST query too-wide 追従と --local
- #210 (closes #198): models update に --api-dry-run

## リリース手順
- package.json / package-lock.json を 0.25.0 に bump
- CHANGELOG の [Unreleased] を [0.25.0] - 2026-08-17 に確定
- マージ後 v0.25.0 タグ push で publish.yml が CI 検証のうえ npm 公開

MINOR bump: 新機能追加のため。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **変更履歴**
  - バージョン0.25.0の変更履歴を追加しました。
  - 未リリース版および0.25.0の比較リンクを更新しました。

- **リリース**
  - アプリケーションのバージョンを0.25.0に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->