### PR TITLE
fix(auth): config.service にテナント名を保存する (closes #213)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## [Unreleased]
 
+### 2026-08-17
+- **Fix**: `auth login` が `config.service` に tenantId (UUID) ではなくテナント名を保存するようにした (closes #213)。UUID が `NGSILD-Tenant` に載ると本体が 400 になる。`tenantName` が取れない場合は `service` を書かず、サーバーの JWT リマップに委ねる
+
 ## [0.25.0] - 2026-08-17
 
 ### 2026-08-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ## [Unreleased]
 
 ### 2026-08-18
-- **Fix**: `auth login` が `config.service` に tenantId (UUID) ではなくテナント名を保存するようにした (closes #213)。`LoginResponse.user.tenantId` から解決し、`availableTenants[].tenantName` が `^[a-z0-9_]+$` を満たすときだけ `service` に書く。名前が取れない場合は既存の name 形 `service`（`profile create --tenant` 束縛）を温存し、UUID 等は削除する。`profile create --tenant` も name 形のときだけ `service` を書く
+- **Fix**: `auth login` が `config.service` に tenantId (UUID) ではなくテナント名を保存するようにした (closes #213)。`LoginResponse.user.tenantId` から解決し、`availableTenants[].tenantName` が `^[a-z0-9_]+$` を満たすときだけ `service` に書く。名前が取れない場合は既存の name 形 `service`（`profile create --tenant` 束縛）を温存し、UUID 等は削除する。`profile create --tenant` も name 形のときだけ `service` を書く (#218)
 
 ## [0.25.0] - 2026-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
 
 ## [Unreleased]
 
-### 2026-08-17
-- **Fix**: `auth login` が `config.service` に tenantId (UUID) ではなくテナント名を保存するようにした (closes #213)。UUID が `NGSILD-Tenant` に載ると本体が 400 になる。`tenantName` が取れない場合は `service` を書かず、サーバーの JWT リマップに委ねる
+### 2026-08-18
+- **Fix**: `auth login` が `config.service` に tenantId (UUID) ではなくテナント名を保存するようにした (closes #213)。`LoginResponse.user.tenantId` から解決し、`availableTenants[].tenantName` が `^[a-z0-9_]+$` を満たすときだけ `service` に書く。名前が取れない場合は既存の name 形 `service`（`profile create --tenant` 束縛）を温存し、UUID 等は削除する。`profile create --tenant` も name 形のときだけ `service` を書く
 
 ## [0.25.0] - 2026-08-17
 

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -8,7 +8,7 @@ import {
   outputResponse,
 } from "../helpers.js";
 import { GdbClientError } from "../client.js";
-import { loadConfig, saveConfig, getCurrentProfile, validateUrl } from "../config.js";
+import { loadConfig, saveConfig, getCurrentProfile, validateUrl, isTenantServiceName } from "../config.js";
 import { printSuccess, printError, printInfo, printWarning } from "../output.js";
 import { isInteractive, promptEmail, promptPassword, promptTenantSelection } from "../prompt.js";
 import type { TenantInfo } from "../types.js";
@@ -164,7 +164,10 @@ function createLoginCommand(): Command {
         }
 
         const availableTenants = data.availableTenants as TenantInfo[] | undefined;
-        let finalTenantId = data.tenantId as string | undefined;
+        // LoginResponse has tenantId under `user`, not at the top level
+        // (geonicdb LoginResponse / LoginUserInfo).
+        const loginUser = data.user as { tenantId?: string | null } | undefined;
+        let finalTenantId = loginUser?.tenantId ?? undefined;
 
         // Multi-tenant: resolve target tenant from flag, interactive prompt, or fall back to primary
         if (availableTenants && availableTenants.length > 1) {
@@ -255,12 +258,15 @@ function createLoginCommand(): Command {
           config.tenantId = finalTenantId;
           // NGSILD-Tenant must be a tenant *name* (`^[a-z0-9_]+$`). Saving the
           // UUID tenantId as config.service makes every subsequent command 400
-          // (closes #213). Prefer availableTenants[].tenantName; if missing,
-          // omit service so the server remaps from JWT tenantId (#596).
-          const tenantName = availableTenants?.find((t) => t.tenantId === finalTenantId)
+          // (closes #213). Prefer availableTenants[].tenantName when it passes
+          // the name regex; if unresolved, keep an existing name-shaped service
+          // (e.g. from `profile create --tenant miya`); otherwise clear.
+          const rawName = availableTenants?.find((t) => t.tenantId === finalTenantId)
             ?.tenantName;
-          if (tenantName) {
-            config.service = tenantName;
+          if (rawName && isTenantServiceName(rawName)) {
+            config.service = rawName;
+          } else if (config.service && isTenantServiceName(config.service)) {
+            // preserve existing name-shaped binding
           } else {
             delete config.service;
           }

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -252,8 +252,18 @@ function createLoginCommand(): Command {
           delete config.refreshToken;
         }
         if (finalTenantId) {
-          config.service = finalTenantId;
           config.tenantId = finalTenantId;
+          // NGSILD-Tenant must be a tenant *name* (`^[a-z0-9_]+$`). Saving the
+          // UUID tenantId as config.service makes every subsequent command 400
+          // (closes #213). Prefer availableTenants[].tenantName; if missing,
+          // omit service so the server remaps from JWT tenantId (#596).
+          const tenantName = availableTenants?.find((t) => t.tenantId === finalTenantId)
+            ?.tenantName;
+          if (tenantName) {
+            config.service = tenantName;
+          } else {
+            delete config.service;
+          }
         } else {
           delete config.service;
           delete config.tenantId;

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -293,18 +293,28 @@ function createLoginCommand(): Command {
           delete config.refreshToken;
         }
         if (finalTenantId) {
+          // Capture association before overwriting tenantId (#213 CodeRabbit).
+          const previousTenantId = config.tenantId;
+          const previousService = config.service;
           config.tenantId = finalTenantId;
           // NGSILD-Tenant must be a tenant *name* (`^[a-z0-9_]+$`). Saving the
           // UUID tenantId as config.service makes every subsequent command 400
           // (closes #213). Prefer availableTenants[].tenantName when it passes
           // the name regex; if unresolved, keep an existing name-shaped service
-          // (e.g. from `profile create --tenant miya`); otherwise clear.
+          // only when it still belongs to finalTenantId; otherwise clear.
           const rawName = availableTenants?.find((t) => t.tenantId === finalTenantId)
             ?.tenantName;
+          const previousServiceBelongsToFinal =
+            !!previousService &&
+            TENANT_SERVICE_NAME_RE.test(previousService) &&
+            (previousTenantId === finalTenantId ||
+              availableTenants?.some(
+                (t) => t.tenantId === finalTenantId && t.tenantName === previousService,
+              ) === true);
           if (rawName && TENANT_SERVICE_NAME_RE.test(rawName)) {
             config.service = rawName;
-          } else if (config.service && TENANT_SERVICE_NAME_RE.test(config.service)) {
-            // preserve existing name-shaped binding
+          } else if (previousServiceBelongsToFinal) {
+            config.service = previousService;
           } else {
             delete config.service;
           }

--- a/src/commands/profile.ts
+++ b/src/commands/profile.ts
@@ -8,6 +8,7 @@ import {
   loadConfig,
   saveConfig,
   validateUrl,
+  isTenantServiceName,
 } from "../config.js";
 import { printSuccess, printInfo, printError, printWarning } from "../output.js";
 import { getTokenStatus } from "../token.js";
@@ -108,8 +109,12 @@ export function registerProfileCommands(program: Command): void {
           init.url = validateUrl(globalOpts.url);
         }
         if (localOpts.tenant) {
-          init.service = localOpts.tenant;
+          // Always bind tenantId; only set service when the value is a valid
+          // NGSILD-Tenant name (closes #213 — UUID-as-service causes 400).
           init.tenantId = localOpts.tenant;
+          if (isTenantServiceName(localOpts.tenant)) {
+            init.service = localOpts.tenant;
+          }
         }
         createProfile(name, init);
         const tenantLabel = localOpts.tenant ? ` (tenant: ${localOpts.tenant})` : "";

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,16 @@ import { homedir } from "node:os";
 import { splitContextValues } from "./context.js";
 import type { GdbConfig, GdbConfigFile } from "./types.js";
 
+/**
+ * NGSILD-Tenant / Fiware-Service value shape.
+ * Matches geonicdb `TENANT.NAME_REGEX` (`src/config/defaults.ts`).
+ */
+export const TENANT_SERVICE_NAME_RE = /^[a-z0-9_]+$/;
+
+export function isTenantServiceName(value: string): boolean {
+  return TENANT_SERVICE_NAME_RE.test(value);
+}
+
 export function getConfigDir(): string {
   return process.env.GEONIC_CONFIG_DIR ?? join(homedir(), ".config", "geonic");
 }

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -733,6 +733,26 @@ describe("auth commands", () => {
       expect(saved.tenantId).toBe(tenantId);
     });
 
+    it("clears name-shaped service when logging into a different tenant without a resolvable name", async () => {
+      const previousTenantId = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+      const newTenantId = "ed945710-fb96-4d17-811b-425abcb9b70e";
+      vi.mocked(loadConfig).mockReturnValue({
+        service: "other_tenant",
+        tenantId: previousTenantId,
+      } as never);
+      vi.mocked(isInteractive).mockReturnValue(true);
+      vi.mocked(promptEmail).mockResolvedValue("user@example.com");
+      vi.mocked(promptPassword).mockResolvedValue("password1234");
+      client.rawRequest.mockResolvedValue(
+        mockResponse({ accessToken: "tok", user: loginUser(newTenantId) }),
+      );
+      const program = makeProgram();
+      await runCommand(program, ["auth", "login"]);
+      const saved = vi.mocked(saveConfig).mock.calls[0][0] as Record<string, unknown>;
+      expect(saved.tenantId).toBe(newTenantId);
+      expect(saved).not.toHaveProperty("service");
+    });
+
     it("does not write legacy tenantName that fails NAME_REGEX (near-miss)", async () => {
       const tenantId = "ed945710-fb96-4d17-811b-425abcb9b70e";
       vi.mocked(isInteractive).mockReturnValue(true);

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -397,17 +397,79 @@ describe("auth commands", () => {
       expect(saveConfig).toHaveBeenCalled();
     });
 
-    it("saves tenantId as service when present in login response", async () => {
+    // Regression #213: NGSILD-Tenant must be a tenant *name* (`^[a-z0-9_]+$`).
+    // Saving tenantId (UUID) as config.service makes every subsequent command 400.
+    it("saves tenantName as service (not tenantId UUID) when availableTenants has a name", async () => {
+      const tenantId = "ed945710-fb96-4d17-811b-425abcb9b70e";
+      const tenants = [
+        { tenantId, tenantName: "miya", role: "tenant_admin" },
+      ];
       vi.mocked(isInteractive).mockReturnValue(true);
       vi.mocked(promptEmail).mockResolvedValue("user@example.com");
-      vi.mocked(promptPassword).mockResolvedValue("pass123");
+      vi.mocked(promptPassword).mockResolvedValue("password1234");
       client.rawRequest.mockResolvedValue(
-        mockResponse({ accessToken: "tok", tenantId: "ed945710-fb96-4d17-811b-425abcb9b70e" }),
+        mockResponse({ accessToken: "tok", tenantId, availableTenants: tenants }),
+      );
+      const program = makeProgram();
+      await runCommand(program, ["auth", "login"]);
+      const saved = vi.mocked(saveConfig).mock.calls[0][0] as Record<string, unknown>;
+      expect(saved.service).toBe("miya");
+      expect(saved.tenantId).toBe(tenantId);
+      expect(saved.service).not.toBe(tenantId);
+    });
+
+    it("does not set service when tenantId is present but tenantName is unavailable", async () => {
+      const tenantId = "ed945710-fb96-4d17-811b-425abcb9b70e";
+      vi.mocked(isInteractive).mockReturnValue(true);
+      vi.mocked(promptEmail).mockResolvedValue("user@example.com");
+      vi.mocked(promptPassword).mockResolvedValue("password1234");
+      client.rawRequest.mockResolvedValue(
+        mockResponse({ accessToken: "tok", tenantId }),
+      );
+      const program = makeProgram();
+      await runCommand(program, ["auth", "login"]);
+      const saved = vi.mocked(saveConfig).mock.calls[0][0] as Record<string, unknown>;
+      expect(saved.tenantId).toBe(tenantId);
+      expect(saved).not.toHaveProperty("service");
+    });
+
+    // Near-miss: tenantId itself looks like a valid NGSILD-Tenant value, but without
+    // tenantName we must still omit service (do not fall back to tenantId).
+    it("does not fall back to tenantId for service when tenantName is missing (near-miss)", async () => {
+      const tenants = [{ tenantId: "city_a", role: "tenant_admin" }];
+      vi.mocked(isInteractive).mockReturnValue(true);
+      vi.mocked(promptEmail).mockResolvedValue("user@example.com");
+      vi.mocked(promptPassword).mockResolvedValue("password1234");
+      client.rawRequest.mockResolvedValue(
+        mockResponse({ accessToken: "tok", tenantId: "city_a", availableTenants: tenants }),
+      );
+      const program = makeProgram();
+      await runCommand(program, ["auth", "login"]);
+      const saved = vi.mocked(saveConfig).mock.calls[0][0] as Record<string, unknown>;
+      expect(saved.tenantId).toBe("city_a");
+      expect(saved).not.toHaveProperty("service");
+    });
+
+    it("clears a previously saved UUID service on re-login when tenantName is available", async () => {
+      const tenantId = "ed945710-fb96-4d17-811b-425abcb9b70e";
+      vi.mocked(loadConfig).mockReturnValue({
+        service: tenantId,
+        tenantId,
+      } as never);
+      vi.mocked(isInteractive).mockReturnValue(true);
+      vi.mocked(promptEmail).mockResolvedValue("user@example.com");
+      vi.mocked(promptPassword).mockResolvedValue("password1234");
+      client.rawRequest.mockResolvedValue(
+        mockResponse({
+          accessToken: "tok",
+          tenantId,
+          availableTenants: [{ tenantId, tenantName: "miya", role: "tenant_admin" }],
+        }),
       );
       const program = makeProgram();
       await runCommand(program, ["auth", "login"]);
       expect(saveConfig).toHaveBeenCalledWith(
-        expect.objectContaining({ token: "tok", service: "ed945710-fb96-4d17-811b-425abcb9b70e" }),
+        expect.objectContaining({ service: "miya", tenantId }),
         "default",
       );
     });
@@ -537,10 +599,11 @@ describe("auth commands", () => {
         body: { email: "user@example.com", password: "pass123" },
         skipTenantHeader: true,
       });
-      expect(saveConfig).toHaveBeenCalledWith(
-        expect.objectContaining({ token: "tok", service: "city_a" }),
-        "default",
-      );
+      const saved = vi.mocked(saveConfig).mock.calls[0][0] as Record<string, unknown>;
+      expect(saved.token).toBe("tok");
+      expect(saved.tenantId).toBe("city_a");
+      // No tenantName in availableTenants → omit service (#213)
+      expect(saved).not.toHaveProperty("service");
     });
 
     it("--tenant-id resolves by tenant ID and re-logins", async () => {
@@ -562,7 +625,11 @@ describe("auth commands", () => {
         skipTenantHeader: true,
       });
       expect(saveConfig).toHaveBeenCalledWith(
-        expect.objectContaining({ token: "tok-b", tenantId: "tid-bbb" }),
+        expect.objectContaining({
+          token: "tok-b",
+          tenantId: "tid-bbb",
+          service: "demo_bousai",
+        }),
         "default",
       );
     });
@@ -607,7 +674,7 @@ describe("auth commands", () => {
         skipTenantHeader: true,
       });
       expect(saveConfig).toHaveBeenCalledWith(
-        expect.objectContaining({ tenantId: "tid-bbb" }),
+        expect.objectContaining({ tenantId: "tid-bbb", service: "demo_bousai" }),
         "default",
       );
     });
@@ -627,7 +694,7 @@ describe("auth commands", () => {
       const program = makeProgram();
       await runCommand(program, ["auth", "login", "--tenant", "tid-bbb"]);
       expect(saveConfig).toHaveBeenCalledWith(
-        expect.objectContaining({ tenantId: "tid-bbb" }),
+        expect.objectContaining({ tenantId: "tid-bbb", service: "demo_bousai" }),
         "default",
       );
     });
@@ -653,7 +720,11 @@ describe("auth commands", () => {
         skipTenantHeader: true,
       });
       expect(saveConfig).toHaveBeenCalledWith(
-        expect.objectContaining({ token: "tok-b", tenantId: "tid-bbb" }),
+        expect.objectContaining({
+          token: "tok-b",
+          tenantId: "tid-bbb",
+          service: "demo_bousai",
+        }),
         "default",
       );
     });
@@ -665,15 +736,15 @@ describe("auth commands", () => {
       );
       const program = makeProgram();
       await runCommand(program, ["auth", "login"]);
-      expect(saveConfig).toHaveBeenCalledWith(
-        expect.objectContaining({ token: "tok", service: "city_a" }),
-        "default",
-      );
+      const saved = vi.mocked(saveConfig).mock.calls[0][0] as Record<string, unknown>;
+      expect(saved.token).toBe("tok");
+      expect(saved.tenantId).toBe("city_a");
+      expect(saved).not.toHaveProperty("service");
     });
 
     it("saves availableTenants list when login succeeds with one tenant", async () => {
       const tenants = [
-        { tenantId: "city_a", tenantName: "Smart City A", role: "tenant_admin" },
+        { tenantId: "city_a", tenantName: "smart_city_a", role: "tenant_admin" },
       ];
       client.rawRequest.mockResolvedValue(
         mockResponse({ accessToken: "tok", tenantId: "city_a", availableTenants: tenants }),
@@ -683,8 +754,9 @@ describe("auth commands", () => {
       expect(saveConfig).toHaveBeenCalledWith(
         expect.objectContaining({
           tenantId: "city_a",
+          service: "smart_city_a",
           availableTenants: [
-            { tenantId: "city_a", tenantName: "Smart City A", role: "tenant_admin" },
+            { tenantId: "city_a", tenantName: "smart_city_a", role: "tenant_admin" },
           ],
         }),
         "default",
@@ -717,7 +789,11 @@ describe("auth commands", () => {
         skipTenantHeader: true,
       });
       expect(saveConfig).toHaveBeenCalledWith(
-        expect.objectContaining({ token: "tok-b", service: "tid-bbb", tenantId: "tid-bbb" }),
+        expect.objectContaining({
+          token: "tok-b",
+          service: "demo_bousai",
+          tenantId: "tid-bbb",
+        }),
         "default",
       );
     });
@@ -744,9 +820,14 @@ describe("auth commands", () => {
       const program = makeProgram();
       await runCommand(program, ["auth", "login"]);
       expect(saveConfig).toHaveBeenCalledWith(
-        expect.objectContaining({ token: "tok-b", service: "city_b" }),
+        expect.objectContaining({
+          token: "tok-b",
+          tenantId: "city_b",
+        }),
         "default",
       );
+      const saved = vi.mocked(saveConfig).mock.calls[0][0] as Record<string, unknown>;
+      expect(saved).not.toHaveProperty("service");
     });
 
     it("prints error when --service tenant name not found", async () => {

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -43,6 +43,8 @@ vi.mock("../src/config.js", () => ({
   saveConfig: vi.fn(),
   getCurrentProfile: vi.fn(() => "default"),
   validateUrl: vi.fn((url: string) => url.replace(/\/+$/, "") + "/"),
+  TENANT_SERVICE_NAME_RE: /^[a-z0-9_]+$/,
+  isTenantServiceName: (value: string) => /^[a-z0-9_]+$/.test(value),
 }));
 
 vi.mock("../src/prompt.js", () => ({
@@ -331,7 +333,7 @@ describe("auth commands", () => {
       vi.mocked(promptEmail).mockResolvedValue("user@example.com");
       vi.mocked(promptPassword).mockResolvedValue("pass123");
       client.rawRequest.mockResolvedValue(
-        mockResponse({ accessToken: "tenant-token", tenantId: "my-tenant" }),
+        mockResponse({  accessToken: "tenant-token", user: { id: "u1", email: "user@example.com", role: "user", tenantId: "my-tenant" } }),
       );
       const program = makeProgram();
       await runCommand(program, ["auth", "login", "--tenant-id", "my-tenant"]);
@@ -399,6 +401,7 @@ describe("auth commands", () => {
 
     // Regression #213: NGSILD-Tenant must be a tenant *name* (`^[a-z0-9_]+$`).
     // Saving tenantId (UUID) as config.service makes every subsequent command 400.
+    // LoginResponse puts tenantId under `user` (not top-level).
     it("saves tenantName as service (not tenantId UUID) when availableTenants has a name", async () => {
       const tenantId = "ed945710-fb96-4d17-811b-425abcb9b70e";
       const tenants = [
@@ -408,7 +411,11 @@ describe("auth commands", () => {
       vi.mocked(promptEmail).mockResolvedValue("user@example.com");
       vi.mocked(promptPassword).mockResolvedValue("password1234");
       client.rawRequest.mockResolvedValue(
-        mockResponse({ accessToken: "tok", tenantId, availableTenants: tenants }),
+        mockResponse({
+          accessToken: "tok",
+          user: { id: "u1", email: "user@example.com", role: "user", tenantId },
+          availableTenants: tenants,
+        }),
       );
       const program = makeProgram();
       await runCommand(program, ["auth", "login"]);
@@ -418,13 +425,16 @@ describe("auth commands", () => {
       expect(saved.service).not.toBe(tenantId);
     });
 
-    it("does not set service when tenantId is present but tenantName is unavailable", async () => {
+    it("does not set service when user.tenantId is present but tenantName is unavailable", async () => {
       const tenantId = "ed945710-fb96-4d17-811b-425abcb9b70e";
       vi.mocked(isInteractive).mockReturnValue(true);
       vi.mocked(promptEmail).mockResolvedValue("user@example.com");
       vi.mocked(promptPassword).mockResolvedValue("password1234");
       client.rawRequest.mockResolvedValue(
-        mockResponse({ accessToken: "tok", tenantId }),
+        mockResponse({
+          accessToken: "tok",
+          user: { id: "u1", email: "user@example.com", role: "user", tenantId },
+        }),
       );
       const program = makeProgram();
       await runCommand(program, ["auth", "login"]);
@@ -441,7 +451,11 @@ describe("auth commands", () => {
       vi.mocked(promptEmail).mockResolvedValue("user@example.com");
       vi.mocked(promptPassword).mockResolvedValue("password1234");
       client.rawRequest.mockResolvedValue(
-        mockResponse({ accessToken: "tok", tenantId: "city_a", availableTenants: tenants }),
+        mockResponse({
+          accessToken: "tok",
+          availableTenants: tenants,
+          user: { id: "u1", email: "user@example.com", role: "user", tenantId: "city_a" },
+        }),
       );
       const program = makeProgram();
       await runCommand(program, ["auth", "login"]);
@@ -462,7 +476,7 @@ describe("auth commands", () => {
       client.rawRequest.mockResolvedValue(
         mockResponse({
           accessToken: "tok",
-          tenantId,
+          user: { id: "u1", email: "user@example.com", role: "user", tenantId },
           availableTenants: [{ tenantId, tenantName: "miya", role: "tenant_admin" }],
         }),
       );
@@ -472,6 +486,76 @@ describe("auth commands", () => {
         expect.objectContaining({ service: "miya", tenantId }),
         "default",
       );
+    });
+
+    // Mutation target: delete config.service when existing value is UUID and
+    // tenantName cannot be resolved. Removing that branch leaves the UUID.
+    it("clears existing UUID service when tenantName is unavailable (mutation guard)", async () => {
+      const tenantId = "ed945710-fb96-4d17-811b-425abcb9b70e";
+      vi.mocked(loadConfig).mockReturnValue({
+        service: tenantId,
+        tenantId,
+      } as never);
+      vi.mocked(isInteractive).mockReturnValue(true);
+      vi.mocked(promptEmail).mockResolvedValue("user@example.com");
+      vi.mocked(promptPassword).mockResolvedValue("password1234");
+      client.rawRequest.mockResolvedValue(
+        mockResponse({
+          accessToken: "tok",
+          user: { id: "u1", email: "user@example.com", role: "user", tenantId },
+          // availableTenants without tenantName — cannot resolve a service name
+          availableTenants: [{ tenantId, role: "tenant_admin" }],
+        }),
+      );
+      const program = makeProgram();
+      await runCommand(program, ["auth", "login"]);
+      const saved = vi.mocked(saveConfig).mock.calls[0][0] as Record<string, unknown>;
+      expect(saved.tenantId).toBe(tenantId);
+      expect(saved).not.toHaveProperty("service");
+    });
+
+    it("preserves existing name-shaped service when tenantName is unavailable", async () => {
+      const tenantId = "ed945710-fb96-4d17-811b-425abcb9b70e";
+      vi.mocked(loadConfig).mockReturnValue({
+        service: "miya",
+        tenantId,
+      } as never);
+      vi.mocked(isInteractive).mockReturnValue(true);
+      vi.mocked(promptEmail).mockResolvedValue("user@example.com");
+      vi.mocked(promptPassword).mockResolvedValue("password1234");
+      client.rawRequest.mockResolvedValue(
+        mockResponse({
+          accessToken: "tok",
+          user: { id: "u1", email: "user@example.com", role: "user", tenantId },
+        }),
+      );
+      const program = makeProgram();
+      await runCommand(program, ["auth", "login"]);
+      const saved = vi.mocked(saveConfig).mock.calls[0][0] as Record<string, unknown>;
+      expect(saved.service).toBe("miya");
+      expect(saved.tenantId).toBe(tenantId);
+    });
+
+    // Near-miss for NAME_REGEX: legacy tenantName with hyphen must not be written.
+    it("does not write legacy tenantName that fails NAME_REGEX (near-miss)", async () => {
+      const tenantId = "ed945710-fb96-4d17-811b-425abcb9b70e";
+      vi.mocked(isInteractive).mockReturnValue(true);
+      vi.mocked(promptEmail).mockResolvedValue("user@example.com");
+      vi.mocked(promptPassword).mockResolvedValue("password1234");
+      client.rawRequest.mockResolvedValue(
+        mockResponse({
+          accessToken: "tok",
+          user: { id: "u1", email: "user@example.com", role: "user", tenantId },
+          availableTenants: [
+            { tenantId, tenantName: "legacy-name", role: "tenant_admin" },
+          ],
+        }),
+      );
+      const program = makeProgram();
+      await runCommand(program, ["auth", "login"]);
+      const saved = vi.mocked(saveConfig).mock.calls[0][0] as Record<string, unknown>;
+      expect(saved.tenantId).toBe(tenantId);
+      expect(saved).not.toHaveProperty("service");
     });
 
     it("does not set service when tenantId is absent from login response", async () => {
@@ -562,7 +646,7 @@ describe("auth commands", () => {
         { tenantId: "city_b", role: "user" },
       ];
       client.rawRequest.mockResolvedValue(
-        mockResponse({ accessToken: "tok", tenantId: "city_a", availableTenants: tenants }),
+        mockResponse({  accessToken: "tok",  availableTenants: tenants, user: { id: "u1", email: "user@example.com", role: "user", tenantId: "city_a" } }),
       );
       const program = makeProgram();
       await expect(
@@ -589,7 +673,7 @@ describe("auth commands", () => {
         { tenantId: "city_b", role: "user" },
       ];
       client.rawRequest.mockResolvedValue(
-        mockResponse({ accessToken: "tok", tenantId: "city_a", availableTenants: tenants }),
+        mockResponse({  accessToken: "tok",  availableTenants: tenants, user: { id: "u1", email: "user@example.com", role: "user", tenantId: "city_a" } }),
       );
       const program = makeProgram();
       await runCommand(program, ["auth", "login", "--tenant-id", "city_a"]);
@@ -613,10 +697,10 @@ describe("auth commands", () => {
       ];
       client.rawRequest
         .mockResolvedValueOnce(
-          mockResponse({ accessToken: "tok-a", tenantId: "tid-aaa", availableTenants: tenants }),
+          mockResponse({  accessToken: "tok-a",  availableTenants: tenants, user: { id: "u1", email: "user@example.com", role: "user", tenantId: "tid-aaa" } }),
         )
         .mockResolvedValueOnce(
-          mockResponse({ accessToken: "tok-b", tenantId: "tid-bbb" }),
+          mockResponse({  accessToken: "tok-b", user: { id: "u1", email: "user@example.com", role: "user", tenantId: "tid-bbb" } }),
         );
       const program = makeProgram();
       await runCommand(program, ["auth", "login", "--tenant-id", "tid-bbb"]);
@@ -640,7 +724,7 @@ describe("auth commands", () => {
         { tenantId: "tid-bbb", tenantName: "demo_bousai", role: "user" },
       ];
       client.rawRequest.mockResolvedValueOnce(
-        mockResponse({ accessToken: "tok-a", tenantId: "tid-aaa", availableTenants: tenants }),
+        mockResponse({  accessToken: "tok-a",  availableTenants: tenants, user: { id: "u1", email: "user@example.com", role: "user", tenantId: "tid-aaa" } }),
       );
       const program = makeProgram();
       await expect(
@@ -662,10 +746,10 @@ describe("auth commands", () => {
       ];
       client.rawRequest
         .mockResolvedValueOnce(
-          mockResponse({ accessToken: "tok-a", tenantId: "tid-aaa", availableTenants: tenants }),
+          mockResponse({  accessToken: "tok-a",  availableTenants: tenants, user: { id: "u1", email: "user@example.com", role: "user", tenantId: "tid-aaa" } }),
         )
         .mockResolvedValueOnce(
-          mockResponse({ accessToken: "tok-b", tenantId: "tid-bbb" }),
+          mockResponse({  accessToken: "tok-b", user: { id: "u1", email: "user@example.com", role: "user", tenantId: "tid-bbb" } }),
         );
       const program = makeProgram();
       await runCommand(program, ["auth", "login", "--tenant", "demo_bousai"]);
@@ -686,10 +770,10 @@ describe("auth commands", () => {
       ];
       client.rawRequest
         .mockResolvedValueOnce(
-          mockResponse({ accessToken: "tok-a", tenantId: "tid-aaa", availableTenants: tenants }),
+          mockResponse({  accessToken: "tok-a",  availableTenants: tenants, user: { id: "u1", email: "user@example.com", role: "user", tenantId: "tid-aaa" } }),
         )
         .mockResolvedValueOnce(
-          mockResponse({ accessToken: "tok-b", tenantId: "tid-bbb" }),
+          mockResponse({  accessToken: "tok-b", user: { id: "u1", email: "user@example.com", role: "user", tenantId: "tid-bbb" } }),
         );
       const program = makeProgram();
       await runCommand(program, ["auth", "login", "--tenant", "tid-bbb"]);
@@ -707,10 +791,10 @@ describe("auth commands", () => {
       vi.mocked(promptTenantSelection).mockResolvedValue(tenants[1]);
       client.rawRequest
         .mockResolvedValueOnce(
-          mockResponse({ accessToken: "tok-a", tenantId: "tid-aaa", availableTenants: tenants }),
+          mockResponse({  accessToken: "tok-a",  availableTenants: tenants, user: { id: "u1", email: "user@example.com", role: "user", tenantId: "tid-aaa" } }),
         )
         .mockResolvedValueOnce(
-          mockResponse({ accessToken: "tok-b", tenantId: "tid-bbb" }),
+          mockResponse({  accessToken: "tok-b", user: { id: "u1", email: "user@example.com", role: "user", tenantId: "tid-bbb" } }),
         );
       const program = makeProgram();
       await runCommand(program, ["auth", "login"]);
@@ -732,7 +816,7 @@ describe("auth commands", () => {
     it("succeeds without explicit tenant when only one tenant is available", async () => {
       const tenants = [{ tenantId: "city_a", role: "tenant_admin" }];
       client.rawRequest.mockResolvedValue(
-        mockResponse({ accessToken: "tok", tenantId: "city_a", availableTenants: tenants }),
+        mockResponse({  accessToken: "tok",  availableTenants: tenants, user: { id: "u1", email: "user@example.com", role: "user", tenantId: "city_a" } }),
       );
       const program = makeProgram();
       await runCommand(program, ["auth", "login"]);
@@ -747,7 +831,7 @@ describe("auth commands", () => {
         { tenantId: "city_a", tenantName: "smart_city_a", role: "tenant_admin" },
       ];
       client.rawRequest.mockResolvedValue(
-        mockResponse({ accessToken: "tok", tenantId: "city_a", availableTenants: tenants }),
+        mockResponse({  accessToken: "tok",  availableTenants: tenants, user: { id: "u1", email: "user@example.com", role: "user", tenantId: "city_a" } }),
       );
       const program = makeProgram();
       await runCommand(program, ["auth", "login"]);
@@ -777,10 +861,10 @@ describe("auth commands", () => {
       } as never);
       client.rawRequest
         .mockResolvedValueOnce(
-          mockResponse({ accessToken: "tok-a", tenantId: "tid-aaa", availableTenants: tenants }),
+          mockResponse({  accessToken: "tok-a",  availableTenants: tenants, user: { id: "u1", email: "user@example.com", role: "user", tenantId: "tid-aaa" } }),
         )
         .mockResolvedValueOnce(
-          mockResponse({ accessToken: "tok-b", refreshToken: "ref-b", tenantId: "tid-bbb" }),
+          mockResponse({  accessToken: "tok-b", refreshToken: "ref-b", user: { id: "u1", email: "user@example.com", role: "user", tenantId: "tid-bbb" } }),
         );
       const program = makeProgram();
       await runCommand(program, ["auth", "login"]);
@@ -812,10 +896,10 @@ describe("auth commands", () => {
       } as never);
       client.rawRequest
         .mockResolvedValueOnce(
-          mockResponse({ accessToken: "tok-a", tenantId: "city_a", availableTenants: tenants }),
+          mockResponse({  accessToken: "tok-a",  availableTenants: tenants, user: { id: "u1", email: "user@example.com", role: "user", tenantId: "city_a" } }),
         )
         .mockResolvedValueOnce(
-          mockResponse({ accessToken: "tok-b", tenantId: "city_b" }),
+          mockResponse({  accessToken: "tok-b", user: { id: "u1", email: "user@example.com", role: "user", tenantId: "city_b" } }),
         );
       const program = makeProgram();
       await runCommand(program, ["auth", "login"]);
@@ -843,7 +927,7 @@ describe("auth commands", () => {
         service: "nonexistent",
       } as never);
       client.rawRequest.mockResolvedValue(
-        mockResponse({ accessToken: "tok", tenantId: "city_a", availableTenants: tenants }),
+        mockResponse({  accessToken: "tok",  availableTenants: tenants, user: { id: "u1", email: "user@example.com", role: "user", tenantId: "city_a" } }),
       );
       const program = makeProgram();
       await expect(
@@ -868,7 +952,7 @@ describe("auth commands", () => {
       } as never);
       client.rawRequest
         .mockResolvedValueOnce(
-          mockResponse({ accessToken: "tok-a", tenantId: "city_a", availableTenants: tenants }),
+          mockResponse({  accessToken: "tok-a",  availableTenants: tenants, user: { id: "u1", email: "user@example.com", role: "user", tenantId: "city_a" } }),
         )
         .mockResolvedValueOnce(
           mockResponse({ message: "ok" }), // no token
@@ -886,7 +970,7 @@ describe("auth commands", () => {
         { tenantId: "city_a", tenantName: "Smart City A", role: "tenant_admin" },
       ];
       client.rawRequest.mockResolvedValue(
-        mockResponse({ accessToken: "tok", tenantId: "city_a", availableTenants: tenants }),
+        mockResponse({  accessToken: "tok",  availableTenants: tenants, user: { id: "u1", email: "user@example.com", role: "user", tenantId: "city_a" } }),
       );
       const program = makeProgram();
       await runCommand(program, ["auth", "login"]);

--- a/tests/commands-profile.test.ts
+++ b/tests/commands-profile.test.ts
@@ -10,6 +10,8 @@ vi.mock("../src/config.js", () => ({
   loadConfig: vi.fn(() => ({})),
   saveConfig: vi.fn(),
   validateUrl: vi.fn((url: string) => url.replace(/\/+$/, "") + "/"),
+  TENANT_SERVICE_NAME_RE: /^[a-z0-9_]+$/,
+  isTenantServiceName: (value: string) => /^[a-z0-9_]+$/.test(value),
 }));
 
 vi.mock("../src/output.js", () => ({
@@ -224,6 +226,18 @@ describe("profile commands", () => {
         tenantId: "miya",
       });
       expect(printSuccess).toHaveBeenCalledWith('Profile "miya" created (tenant: miya).');
+    });
+
+    it("binds tenantId only when --tenant is a UUID (not a service name)", async () => {
+      const uuid = "ed945710-fb96-4d17-811b-425abcb9b70e";
+      const program = makeProgram();
+      await runCommand(program, ["profile", "create", "miya", "--tenant", uuid]);
+      expect(createProfile).toHaveBeenCalledWith("miya", {
+        tenantId: uuid,
+      });
+      const init = vi.mocked(createProfile).mock.calls[0][1] as Record<string, unknown>;
+      expect(init).not.toHaveProperty("service");
+      expect(printSuccess).toHaveBeenCalledWith(`Profile "miya" created (tenant: ${uuid}).`);
     });
 
     it("creates a profile with both tenant and url", async () => {


### PR DESCRIPTION
## Summary

- `auth login` が `config.service` に tenantId (UUID) を書いていたため、以降の全コマンドが `NGSILD-Tenant` 検証で 400 になっていたのを修正した (Closes #213)
- `NGSILD-Tenant` にはテナント**名**だけを載せる。UUID は `config.tenantId` に残す

## 原因

- `src/commands/auth.ts` が `config.service = finalTenantId`（UUID）を保存していた
- `GdbClient.buildHeaders()` がそれをそのまま `NGSILD-Tenant` に載せる
- 本体は `TENANT.NAME_REGEX = /^[a-z0-9_]+$/` で検証するため、ハイフン付き UUID は必ず 400
- staging 実測: UUID ヘッダー = 400 / テナント名 = 200 / ヘッダー省略 = 200（JWT リマップ）

## 修正内容

- `availableTenants[].tenantName` が name 形のときだけ `config.service` に保存
- 名前が取れない場合の扱いを整理（後述の code-review 反映）

### code-review で直した 5 点

1. **`user.tenantId` への修正** — 本体 `LoginResponse` に top-level `tenantId` は無く `user.tenantId`。`finalTenantId` の取得元を直し、テストモックも実レスポンス形に合わせた
2. **`delete config.service` 分岐の変異検出テスト** — 既存 `service:<UUID>` を返す `loadConfig` モックを足し、`tenantName` 無しで UUID が消えることを検証。分岐を空にするとテストが赤くなることを確認
3. **`NAME_REGEX` 検証** — `service` に書く前に `/^[a-z0-9_]+$/`（本体 `TENANT.NAME_REGEX` と同形）で検証。通らなければ書かない（レガシー名での再発防止）
4. **`service` 温存条件** — name 解決できたら書く / 未解決かつ既存 `service` が name 形なら温存 / それ以外は削除。`profile create --tenant miya` の束縛を login が消さない
5. **`profile create` の UUID** — `init.tenantId` は常に、`init.service` は name 形のときだけ書く（#213 と同症状）

## テスト

- unit: 回帰（UUID を service に書かない）/ near-miss（`city_a` へのフォールバック禁止、`legacy-name` の NAME_REGEX 拒否）/ 変異ガード（UUID 削除分岐）/ name 形温存 / profile create UUID
- 変異注入: `delete config.service` を no-op 化 → mutation guard テスト赤 → 復元緑
- ローカル: `lint` / `typecheck` / `build` / `npm test` (1089) 緑
- E2E: 未実行（本体ローカル起動が必要。CI に委ねる）

## スコープ外

- 既存プロファイルの自動マイグレーション（次回 login で直る、で可）
- #215（auth ピッカー廃止）との `auth.ts` 衝突は、先マージ側を後から取り込む前提

## Test plan

- [ ] `auth login` 後の `config.service` がテナント名である（UUID でない）
- [ ] `auth login` 直後に `geonic entities list --type <T>` が 200
- [ ] `tenantName` が取れないレスポンスでは、既存 name 形 `service` は温存・UUID は削除
- [ ] `profile create --tenant <UUID>` で `service` が付かない
- [ ] CI 全緑


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * ログイン時、サービス設定には検証済みのテナント名のみ保存されるようになりました。
  * テナント名を解決できない場合は、既存の名前形式の設定を維持し、不適切な値は削除します。
  * `profile create --tenant` では、UUIDをテナント識別子として扱い、サービス名として保存しないようになりました。
  * サービス名は小文字英数字とアンダースコアのみで構成される場合に有効として扱われます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->