### PR TITLE
fix(entities): list に --local を追加 (closes #214)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ## [Unreleased]
 
 ### 2026-08-18
-- **Fix**: `entities list` に `--local` を追加し、セレクタ無し一覧の too-wide query 逃げ道 (`?local=true`) を CLI から送れるようにした (closes #214)
+- **Fix**: `entities list` に `--local` を追加し、セレクタ無し一覧の too-wide query 逃げ道 (`?local=true`) を CLI から送れるようにした (closes #214) (#219)
 
 ## [0.25.0] - 2026-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,8 @@
 ## [Unreleased]
 
 ### 2026-08-18
-<<<<<<< HEAD
 - **Fix**: `entities list` に `--local` を追加し、セレクタ無し一覧の too-wide query 逃げ道 (`?local=true`) を CLI から送れるようにした (closes #214) (#219)
-=======
 - **Fix**: `temporal entities list` に `--local` (`?local=true`) を追加し、本体の too-wide query 検証の逃げ道を送れるようにした (closes #216)。ヘルプ例のセレクタ無しコピペで 400 になる例も修正 (#221)
->>>>>>> origin/main
 
 ## [0.25.0] - 2026-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ## [Unreleased]
 
-### 2026-08-17
+### 2026-08-18
 - **Fix**: `entities list` に `--local` を追加し、セレクタ無し一覧の too-wide query 逃げ道 (`?local=true`) を CLI から送れるようにした (closes #214)
 
 ## [0.25.0] - 2026-08-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## [Unreleased]
 
+### 2026-08-17
+- **Fix**: `entities list` に `--local` を追加し、セレクタ無し一覧の too-wide query 逃げ道 (`?local=true`) を CLI から送れるようにした (closes #214)
+
 ## [0.25.0] - 2026-08-17
 
 ### 2026-08-17

--- a/README.md
+++ b/README.md
@@ -335,7 +335,9 @@ geonic me oauth-clients update <client-id> --policy-id my-readonly
 | `entities delete <id>` | Delete an entity by ID |
 | `entities purge <selectors> [--keep\|--drop] --yes` | Purge entities/attributes by selector (destructive) |
 
-`entities list` supports filtering options: `--type`, `--id-pattern`, `--query`, `--attrs`, `--georel`, `--geometry`, `--coords`, `--spatial-id`, `--limit`, `--offset`, `--order-by`, `--count`.
+`entities list` supports filtering options: `--type`, `--id-pattern`, `--query`, `--attrs`, `--georel`, `--geometry`, `--coords`, `--spatial-id`, `--limit`, `--offset`, `--order-by`, `--count`, `--local`.
+
+`--local` (`?local=true`) limits the request to local scope and exempts the too-wide query check, so a selector-less `geonic entities list --local` is allowed.
 
 `entities purge` requires **at least one primary selector** — `--type`, `--attrs`, `--query`, or `--georel` (the latter together with `--geometry`/`--coords`). These can be narrowed with the refinement filters `--id`, `--id-pattern`, `--scope-q`, `--local`. A refinement filter **on its own is not sufficient**: `--id`/`--id-pattern`/`--scope-q` alone are rejected by both the CLI and the server — to remove a single entity use `entities delete <id>`. Mutation flags `--keep`/`--drop` (mutually exclusive) remove/retain attributes on matched entities instead of deleting the entities. `--attrs` on purge is a selector ("entities having any listed attributes"), not an output projection.
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ geonic config set url http://localhost:3000
 # Create an entity
 geonic entities create '{"id":"Room1","type":"Room","temperature":{"value":23,"type":"Number"}}'
 
-# List entities
-geonic entities list
+# List entities (local scope — exempts too-wide query check)
+geonic entities list --local
 
 # Get an entity by ID
 geonic entities get Room1
@@ -914,10 +914,10 @@ API keys provide an alternative to JWT tokens for authentication. When configure
 geonic config set api-key gdb_your_api_key_here
 
 # Or pass via CLI flag
-geonic entities list --api-key gdb_your_api_key_here
+geonic entities list --local --api-key gdb_your_api_key_here
 
 # Or use environment variable
-GDB_API_KEY=gdb_your_api_key_here geonic entities list
+GDB_API_KEY=gdb_your_api_key_here geonic entities list --local
 ```
 
 When both a Bearer token and an API key are configured, headers are sent exclusively — the API key takes precedence when present.

--- a/README.md
+++ b/README.md
@@ -902,7 +902,7 @@ geonic config list
 Override the config directory with the `GEONIC_CONFIG_DIR` environment variable:
 
 ```bash
-GEONIC_CONFIG_DIR=/path/to/config geonic entities list
+GEONIC_CONFIG_DIR=/path/to/config geonic entities list --local
 ```
 
 ## API Key Authentication

--- a/src/commands/entities.ts
+++ b/src/commands/entities.ts
@@ -36,6 +36,10 @@ export function registerEntitiesCommand(program: Command): void {
     .option("--count-only", "Only show the total count without listing entities")
     .option("--key-values", "Request simplified key-value format")
     .option("--sys-attrs", "Include system attributes (createdAt, modifiedAt)")
+    .option(
+      "--local",
+      "Limit to local scope (?local=true). Exempts the too-wide query check",
+    )
     .action(
       withErrorHandler(async (opts: Record<string, unknown>, cmd: Command) => {
         const client = createClient(cmd);
@@ -55,6 +59,7 @@ export function registerEntitiesCommand(program: Command): void {
         if (opts.offset !== undefined) params.offset = String(opts.offset);
         if (opts.orderBy) params.orderBy = String(opts.orderBy);
         if (opts.scopeQ) params.scopeQ = String(opts.scopeQ);
+        if (opts.local) params.local = "true";
         if (opts.count || opts.countOnly) params.count = "true";
         if (opts.countOnly) params.limit = "0";
 
@@ -150,6 +155,10 @@ export function registerEntitiesCommand(program: Command): void {
     {
       description: "Filter by scope (one level below)",
       command: "geonic entities list --scope-q '/Japan/+'",
+    },
+    {
+      description: "List all local entities (exempts too-wide query check)",
+      command: "geonic entities list --local",
     },
   ]);
 

--- a/tests/entities.test.ts
+++ b/tests/entities.test.ts
@@ -189,6 +189,35 @@ describe("entities command", () => {
 
       expect(mockClient.get).toHaveBeenCalledWith("/entities", expect.objectContaining({ scopeQ: "/restaurants/#" }));
     });
+
+    // #214: selector-less list is a too-wide 400 unless ?local=true.
+    it("passes --local as local=true query param (#214)", async () => {
+      mockClient.get.mockResolvedValue(mockResponse([]));
+      await runCommand(program, ["entities", "list", "--local"]);
+
+      expect(mockClient.get).toHaveBeenCalledWith("/entities", { local: "true" });
+    });
+
+    // near-miss: without --local the params must stay empty —
+    // accidentally always sending local=true would change federation semantics.
+    it("does not send local when --local is omitted (near-miss)", async () => {
+      mockClient.get.mockResolvedValue(mockResponse([]));
+      await runCommand(program, ["entities", "list"]);
+
+      expect(mockClient.get).toHaveBeenCalledWith("/entities", {});
+      expect(mockClient.get.mock.calls[0]?.[1]).not.toHaveProperty("local");
+    });
+
+    // near-miss: --local must compose with other filters, not replace them.
+    it("composes --local with type filter (near-miss)", async () => {
+      mockClient.get.mockResolvedValue(mockResponse([]));
+      await runCommand(program, ["entities", "list", "--type", "Sensor", "--local"]);
+
+      expect(mockClient.get).toHaveBeenCalledWith("/entities", {
+        type: "Sensor",
+        local: "true",
+      });
+    });
   });
 
   describe("get", () => {


### PR DESCRIPTION
## Summary
- `entities list` に `--local` (`?local=true`) を追加し、セレクタ無し一覧の too-wide query 逃げ道を CLI から送れるようにした
- README の素の `entities list` 例も `--local` 付きに修正（Quick Start / API Key / `GEONIC_CONFIG_DIR`）
- unit test（#214 + near-miss 2）と CHANGELOG を追加

Closes #214

## 原因
issue の見立てどおり。`entities purge` / `batch` / `temporal entityOperations query` には `--local` があるが、`entities list` だけオプション定義と `params.local` 配線が欠けていた。

## 修正内容
- `src/commands/entities.ts`: list に `--local`（説明文は batch/temporal と同文）と `local=true` クエリ配線、example 1 件
- `README.md`: オプション表追記 + 素の list 例を `--local` 付きに
- `CHANGELOG.md`: Unreleased / 2026-08-18

## テスト
- 修正前: `#214` / compose near-miss が `unknown option '--local'` で赤
- 修正後: 3 passed
- 変異注入: `if (opts.local) params.local = "true";` 削除 → `#214` と compose が赤（hollow ではない）
- ローカルゲート: lint / typecheck / build / vitest 1085 pass。E2E 未実行（本体ローカル起動が必要）

## スコープ外
- `temporal entities list` の `--local` 欠落（別 issue 起票予定）
- `entities purge` の `--local` 説明文の統一（短い文言のまま）

## Test plan
- [ ] `geonic entities list --local --dry-run` に `local=true` が含まれる
- [ ] `geonic entities list --help` に `--local` が出る
- [ ] unit: `tests/entities.test.ts` の `#214` / near-miss が緑
- [ ] CI 全緑


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - `entities list` と `temporal entities list` に `--local` オプションを追加しました。
  - セレクターなしで、ローカルスコープのエンティティを一覧表示できます。
  - `type` フィルターと組み合わせて利用できます。

- **ドキュメント**
  - クイックスタートや各種利用例に、`--local` の使い方を追加しました。

- **テスト**
  - `--local` 指定時・未指定時のAPIパラメータと、既存フィルターとの併用を確認しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->