### PR TITLE
fix(auth): require explicit tenant flag on multi-tenant login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## [Unreleased]
 
+### 2026-08-17
+- **Fix**: マルチテナント `auth login` の対話ピッカーを廃止し、フラグ未指定時は TTY の有無にかかわらず一覧を出してエラー終了するよう README に揃えた (closes #215)。`promptTenantSelection` の `default: 1` による primary テナントの無言確定を構造的に排除。保存済み `config.service` による暗黙解決は維持
+
 ## [0.25.0] - 2026-08-17
 
 ### 2026-08-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
 
 ## [Unreleased]
 
-### 2026-08-17
-- **Fix**: マルチテナント `auth login` の対話ピッカーを廃止し、フラグ未指定時は TTY の有無にかかわらず一覧を出してエラー終了するよう README に揃えた (closes #215)。`promptTenantSelection` の `default: 1` による primary テナントの無言確定を構造的に排除。保存済み `config.service` による暗黙解決は維持
+### 2026-08-18
+- **Fix**: マルチテナント `auth login` の対話ピッカーを廃止し、フラグ未指定時は TTY の有無にかかわらず一覧を出してエラー終了するよう README に揃えた (closes #215)。`promptTenantSelection` の `default: 1` による primary テナントの無言確定を構造的に排除。保存済み `config.service` による暗黙解決は維持 (#220)
 
 ## [0.25.0] - 2026-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,8 @@
 ## [Unreleased]
 
 ### 2026-08-18
-<<<<<<< HEAD
-- **Fix**: マルチテナント `auth login` の対話ピッカーを廃止し、フラグ未指定時は TTY の有無にかかわらず一覧を出してエラー終了するよう README に揃えた (closes #215)。`promptTenantSelection` の `default: 1` による primary テナントの無言確定を構造的に排除。保存済み `config.service` による暗黙解決は維持 (#220)
-=======
+- **Fix**: マルチテナント `auth login` の対話ピッカーを廃止し、フラグ未指定時は TTY の有無にかかわらず一覧を出してエラー終了するよう README に揃えた (closes #215)。`promptTenantSelection` の `default: 1` による primary テナントの無言確定を構造的に排除。login 時のテナント指定は明示 CLI フラグのみ（`config.service` back-fill は #217 で対象外） (#220)
 - **Fix**: `entities list` に `--local` を追加し、セレクタ無し一覧の too-wide query 逃げ道 (`?local=true`) を CLI から送れるようにした (closes #214) (#219)
->>>>>>> origin/main
 - **Fix**: 単一メンバーシップのアカウントで `auth login --tenant` / `--tenant-id` が黙って無視されないようにした (closes #217)。`availableTenants` が無いときは明示フラグだけを `tenantName` / `tenantId` として再ログイン body に載せ、サーバー側の 400/403 で fail-loud にする。`--tenant` は NAME_REGEX で name/id を振り分け、config.service の back-fill は無視する (#222)
 - **Fix**: `temporal entities list` に `--local` (`?local=true`) を追加し、本体の too-wide query 検証の逃げ道を送れるようにした (closes #216)。ヘルプ例のセレクタ無しコピペで 400 になる例も修正 (#221)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ## [Unreleased]
 
 ### 2026-08-18
-- **Fix**: マルチテナント `auth login` の対話ピッカーを廃止し、フラグ未指定時は TTY の有無にかかわらず一覧を出してエラー終了するよう README に揃えた (closes #215)。`promptTenantSelection` の `default: 1` による primary テナントの無言確定を構造的に排除。login 時のテナント指定は明示 CLI フラグのみ（`config.service` back-fill は #217 で対象外） (#220)
+- **Fix**: マルチテナント `auth login` の対話ピッカーを廃止し、`--tenant` / `--tenant-id` / `-s` のいずれも無いときは TTY の有無にかかわらず利用可能テナント一覧を出してエラー終了するよう README に揃えた (closes #215)。`promptTenantSelection` の `default: 1` による primary テナントの無言確定を構造的に排除 (#220)
 - **Fix**: `auth login` が `config.service` に tenantId (UUID) ではなくテナント名を保存するようにした (closes #213)。`LoginResponse.user.tenantId` から解決し、`availableTenants[].tenantName` が `^[a-z0-9_]+$` を満たすときだけ `service` に書く。名前が取れない場合は既存の name 形 `service`（`profile create --tenant` 束縛）を温存し、UUID 等は削除する。`profile create --tenant` も name 形のときだけ `service` を書く (#218)
 - **Fix**: `entities list` に `--local` を追加し、セレクタ無し一覧の too-wide query 逃げ道 (`?local=true`) を CLI から送れるようにした (closes #214) (#219)
 - **Fix**: 単一メンバーシップのアカウントで `auth login --tenant` / `--tenant-id` が黙って無視されないようにした (closes #217)。`availableTenants` が無いときは明示フラグだけを `tenantName` / `tenantId` として再ログイン body に載せ、サーバー側の 400/403 で fail-loud にする。`--tenant` は NAME_REGEX で name/id を振り分け、config.service の back-fill は無視する (#222)

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ geonic auth login
 | `--tenant-id <id>` | Log in to a specific tenant by ID only. Resolved client-side against the account's available tenants (rejects names — use `--tenant` for names). Wins when both `--tenant` and `--tenant-id` are supplied |
 | `-s, --service <id\|name>` | Same resolution as `--tenant` (name or ID). Also applied when the profile has a saved `service` and no explicit tenant flag is given |
 
-**Multi-tenant support**: When you belong to multiple tenants, `auth login` requires explicit tenant selection via `--tenant`, `--tenant-id`, or `-s/--service`. There is no interactive picker — if neither flag is provided and the account has multiple tenants, the command lists the available tenants and exits with an error.
+**Multi-tenant support**: When you belong to multiple tenants, `auth login` requires an explicit tenant via `--tenant`, `--tenant-id`, or `-s/--service`, **or** a `service` already saved on the profile. There is no interactive picker — if none of these are available and the account has multiple tenants, the command lists the available tenants and exits with an error.
 
 A common workflow is to create one profile per tenant (`geonic profile create <name> --tenant <tenant>`); the tenant binding is persisted on the profile, so plain `geonic --profile <name> auth login` resolves to the correct tenant automatically.
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ geonic profile use miya       # operate as miya tenant
 geonic profile use geolonia   # operate as geolonia tenant
 ```
 
-`--tenant <id>` accepts either a tenant ID or a tenant name. The value is stored as both `service` (sent in `NGSILD-Tenant` headers) and `tenantId` on the profile. For multi-tenant accounts, pass the tenant again on `auth login` via `--tenant` / `-s` — a saved `service` is not used as an implicit login tenant.
+`--tenant <name|id>` accepts either a tenant ID or a tenant name. The value is stored as both `service` (sent in `NGSILD-Tenant` headers) and `tenantId` on the profile. For multi-tenant accounts, pass the tenant again on `auth login` via `--tenant` / `-s` — a saved `service` is not used as an implicit login tenant.
 
 ### auth — Authentication
 
@@ -161,8 +161,8 @@ geonic auth login
 
 | Option | Description |
 |---|---|
-| `--tenant <name\|id>` | Log in to a specific tenant. Resolved client-side against the account's available tenants by name or ID |
-| `--tenant-id <id>` | Log in to a specific tenant by ID only. Resolved client-side against the account's available tenants (rejects names — use `--tenant` for names). Wins when both `--tenant` and `--tenant-id` are supplied |
+| `--tenant <name\|id>` | Log in to a specific tenant. When the account returns `availableTenants` (multi-tenant), resolved client-side by name or ID; otherwise the value is sent to the server for validation (`tenantName` or `tenantId`) |
+| `--tenant-id <id>` | Log in by tenant ID only. Multi-tenant: resolved client-side against `availableTenants` (rejects names — use `--tenant`). Single-membership: sent to the server as `tenantId`. Wins when both `--tenant` and `--tenant-id` are supplied |
 | `-s, --service <id\|name>` | Same resolution as `--tenant` (name or ID). Must be passed explicitly on the CLI — a profile-saved `service` is not used as an implicit login tenant |
 
 **Multi-tenant support**: When you belong to multiple tenants, `auth login` requires explicit tenant selection via `--tenant`, `--tenant-id`, or `-s/--service`. There is no interactive picker — if neither flag is provided and the account has multiple tenants, the command lists the available tenants and exits with an error. A profile-saved `service` is not treated as an implicit login tenant (explicit CLI flag required).

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ geonic help [<command>] [<subcommand>]
 |---|---|
 | `profile list` | List all profiles |
 | `profile use <name>` | Switch active profile |
-| `profile create <name> [--tenant <id\|name>] [--url <url>]` | Create a new profile, optionally bound to a tenant and URL |
+| `profile create <name> [--tenant <id\|name>] [--url <url>]` | Create a new profile. `--tenant` always sets `tenantId`; `service` (`NGSILD-Tenant`) is set only when the value is a tenant name (`^[a-z0-9_]+$`) |
 | `profile delete <name>` | Delete a profile |
 | `profile show [name]` | Show profile settings |
 
@@ -140,7 +140,7 @@ geonic profile use miya       # operate as miya tenant
 geonic profile use geolonia   # operate as geolonia tenant
 ```
 
-`--tenant <name|id>` accepts either a tenant ID or a tenant name. The value is stored as both `service` (sent in `NGSILD-Tenant` headers) and `tenantId` on the profile. For multi-tenant accounts, pass the tenant again on `auth login` via `--tenant` / `-s` — a saved `service` is not used as an implicit login tenant.
+`--tenant <name|id>` accepts either a tenant ID or a tenant name. The value is always stored as `tenantId` on the profile. `service` (sent in `NGSILD-Tenant` headers) is set **only when the value matches the tenant-name pattern `^[a-z0-9_]+$`** — UUIDs and other ID forms are never written to `service` (they would make subsequent API calls return 400). The same rule applies to `auth login` when it persists `config.service` from `availableTenants[].tenantName`. For multi-tenant accounts, pass the tenant again on `auth login` via `--tenant` / `-s` — a saved `service` is not used as an implicit login tenant.
 
 ### auth — Authentication
 

--- a/README.md
+++ b/README.md
@@ -161,8 +161,9 @@ geonic auth login
 
 | Option | Description |
 |---|---|
-| `--tenant-id <id>` | Log in to a specific tenant. Value is sent to the server as-is (server resolves) |
-| `-s, --service <id\|name>` | Log in to a specific tenant. Resolved client-side against the account's available tenants by ID or name |
+| `--tenant <name\|id>` | Log in to a specific tenant. Resolved client-side against the account's available tenants by name or ID |
+| `--tenant-id <id>` | Log in to a specific tenant by ID only. Resolved client-side against the account's available tenants (rejects names — use `--tenant` for names). Wins when both `--tenant` and `--tenant-id` are supplied |
+| `-s, --service <id\|name>` | Same resolution as `--tenant` (name or ID). Also applied when the profile has a saved `service` and no explicit tenant flag is given |
 
 **Multi-tenant support**: When you belong to multiple tenants, `auth login` requires explicit tenant selection via `--tenant`, `--tenant-id`, or `-s/--service`. There is no interactive picker — if neither flag is provided and the account has multiple tenants, the command lists the available tenants and exits with an error.
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ geonic auth login
 | `--tenant-id <id>` | Log in to a specific tenant. Value is sent to the server as-is (server resolves) |
 | `-s, --service <id\|name>` | Log in to a specific tenant. Resolved client-side against the account's available tenants by ID or name |
 
-**Multi-tenant support**: When you belong to multiple tenants, `auth login` requires explicit tenant selection via `--tenant-id` or `-s/--service`. There is no interactive picker — if neither flag is provided and the account has multiple tenants, the command lists the available tenants and exits with an error.
+**Multi-tenant support**: When you belong to multiple tenants, `auth login` requires explicit tenant selection via `--tenant`, `--tenant-id`, or `-s/--service`. There is no interactive picker — if neither flag is provided and the account has multiple tenants, the command lists the available tenants and exits with an error.
 
 A common workflow is to create one profile per tenant (`geonic profile create <name> --tenant <tenant>`); the tenant binding is persisted on the profile, so plain `geonic --profile <name> auth login` resolves to the correct tenant automatically.
 
@@ -172,11 +172,11 @@ A common workflow is to create one profile per tenant (`geonic profile create <n
 $ geonic auth login
 Email: user@example.com
 Password: ********
-Error: Multiple tenants are available for this account. Specify one with --tenant-id <id> or -s/--service <name>:
+Error: Multiple tenants are available for this account. Specify one with --tenant <name|id>, --tenant-id <id>, or -s/--service <name|id>:
   - my_city (tid-aaa) [tenant_admin]
   - another_city (tid-bbb) [user]
 
-$ geonic auth login --tenant-id tid-aaa
+$ geonic auth login --tenant my_city
 Login successful (tenant: my_city). Token saved to config.
 ```
 

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -10,7 +10,7 @@ import {
 import { GdbClientError } from "../client.js";
 import { loadConfig, saveConfig, getCurrentProfile, validateUrl } from "../config.js";
 import { printSuccess, printError, printInfo, printWarning } from "../output.js";
-import { isInteractive, promptEmail, promptPassword, promptTenantSelection } from "../prompt.js";
+import { isInteractive, promptEmail, promptPassword } from "../prompt.js";
 import type { TenantInfo } from "../types.js";
 import { getTokenStatus, formatDuration } from "../token.js";
 import { clientCredentialsGrant } from "../oauth.js";
@@ -166,7 +166,8 @@ function createLoginCommand(): Command {
         const availableTenants = data.availableTenants as TenantInfo[] | undefined;
         let finalTenantId = data.tenantId as string | undefined;
 
-        // Multi-tenant: resolve target tenant from flag, interactive prompt, or fall back to primary
+        // Multi-tenant: require an explicit tenant flag (or saved config.service via resolveOptions).
+        // No interactive picker — Enter-default would silently bind the primary tenant (#215 / README).
         if (availableTenants && availableTenants.length > 1) {
           let selected: TenantInfo | undefined;
 
@@ -200,8 +201,6 @@ function createLoginCommand(): Command {
               );
               process.exit(1);
             }
-          } else if (isInteractive()) {
-            selected = await promptTenantSelection(availableTenants);
           } else {
             const list = availableTenants
               .map((t) => `  - ${t.tenantName ?? t.tenantId} (${t.tenantId}) [${t.role}]`)

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -1,6 +1,5 @@
 import { createInterface } from "node:readline/promises";
 import { Writable } from "node:stream";
-import type { TenantInfo } from "./types.js";
 
 export function isInteractive(): boolean {
   return process.stdin.isTTY === true && process.stdout.isTTY === true;
@@ -21,37 +20,6 @@ export async function promptConfirm(message: string): Promise<boolean> {
   try {
     const answer = (await rl.question(`${message} [y/N]: `)).trim().toLowerCase();
     return answer === "y" || answer === "yes";
-  } finally {
-    rl.close();
-  }
-}
-
-export async function promptTenantSelection(
-  tenants: TenantInfo[],
-): Promise<TenantInfo> {
-  if (tenants.length === 0) {
-    throw new Error("No tenants to choose from.");
-  }
-  const stdout = process.stdout;
-  stdout.write("Multiple tenants available. Select one:\n");
-  for (let i = 0; i < tenants.length; i++) {
-    const t = tenants[i];
-    const label = t.tenantName ? `${t.tenantName} (${t.tenantId})` : t.tenantId;
-    stdout.write(`  ${i + 1}) ${label} [${t.role}]\n`);
-  }
-  const rl = createInterface({ input: process.stdin, output: process.stdout });
-  try {
-    while (true) {
-      const answer = (await rl.question(`Select [1-${tenants.length}] (default: 1): `)).trim();
-      if (answer === "") {
-        return tenants[0];
-      }
-      const idx = Number.parseInt(answer, 10);
-      if (Number.isInteger(idx) && idx >= 1 && idx <= tenants.length) {
-        return tenants[idx - 1];
-      }
-      stdout.write(`Invalid selection "${answer}". Please enter a number between 1 and ${tenants.length}.\n`);
-    }
   } finally {
     rl.close();
   }

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -49,7 +49,6 @@ vi.mock("../src/prompt.js", () => ({
   isInteractive: vi.fn(),
   promptEmail: vi.fn(),
   promptPassword: vi.fn(),
-  promptTenantSelection: vi.fn(),
 }));
 
 vi.mock("../src/token.js", () => ({
@@ -64,7 +63,7 @@ vi.mock("../src/oauth.js", () => ({
 import { createClient, getFormat, outputResponse, resolveOptions } from "../src/helpers.js";
 import { printSuccess, printError, printInfo, printWarning } from "../src/output.js";
 import { loadConfig, saveConfig, getCurrentProfile, validateUrl } from "../src/config.js";
-import { isInteractive, promptEmail, promptPassword, promptTenantSelection } from "../src/prompt.js";
+import { isInteractive, promptEmail, promptPassword } from "../src/prompt.js";
 import { getTokenStatus, formatDuration } from "../src/token.js";
 import { clientCredentialsGrant } from "../src/oauth.js";
 import { registerAuthCommands } from "../src/commands/auth.js";
@@ -492,8 +491,7 @@ describe("auth commands", () => {
     });
 
     it("errors out when multi-tenant, non-interactive, and no flag is specified", async () => {
-      // Interactive selection requires a TTY (but auth.login itself already required TTY for
-      // password prompt — this branch is reached when stdin is TTY-faked but isInteractive() is overridden).
+      // パスワード入力のため最初の isInteractive は true。テナント分岐は TTY を見ない (#215)。
       vi.mocked(isInteractive).mockReturnValueOnce(true).mockReturnValue(false);
       const tenants = [
         { tenantId: "city_a", role: "tenant_admin" },
@@ -632,30 +630,35 @@ describe("auth commands", () => {
       );
     });
 
-    it("prompts interactively when multi-tenant and no flag is provided (TTY)", async () => {
+    it("errors out when multi-tenant and no flag is provided (TTY — no interactive picker)", async () => {
+      // #215: README どおりフラグ必須。TTY があっても対話ピッカーは出さない。
       const tenants = [
         { tenantId: "tid-aaa", tenantName: "demo_smartcity", role: "tenant_admin" },
         { tenantId: "tid-bbb", tenantName: "demo_bousai", role: "user" },
       ];
-      vi.mocked(promptTenantSelection).mockResolvedValue(tenants[1]);
-      client.rawRequest
-        .mockResolvedValueOnce(
-          mockResponse({ accessToken: "tok-a", tenantId: "tid-aaa", availableTenants: tenants }),
-        )
-        .mockResolvedValueOnce(
-          mockResponse({ accessToken: "tok-b", tenantId: "tid-bbb" }),
-        );
-      const program = makeProgram();
-      await runCommand(program, ["auth", "login"]);
-      expect(promptTenantSelection).toHaveBeenCalledWith(tenants);
-      expect(client.rawRequest).toHaveBeenLastCalledWith("POST", "/auth/login", {
-        body: { email: "user@example.com", password: "pass123", tenantId: "tid-bbb" },
-        skipTenantHeader: true,
-      });
-      expect(saveConfig).toHaveBeenCalledWith(
-        expect.objectContaining({ token: "tok-b", tenantId: "tid-bbb" }),
-        "default",
+      client.rawRequest.mockResolvedValue(
+        mockResponse({ accessToken: "tok-a", tenantId: "tid-aaa", availableTenants: tenants }),
       );
+      const program = makeProgram();
+      await expect(
+        runCommand(program, ["auth", "login"]),
+      ).rejects.toThrow("process.exit");
+      expect(printError).toHaveBeenCalledWith(
+        expect.stringContaining("Multiple tenants are available"),
+      );
+      expect(printError).toHaveBeenCalledWith(
+        expect.stringContaining("demo_smartcity"),
+      );
+      expect(printError).toHaveBeenCalledWith(
+        expect.stringContaining("demo_bousai"),
+      );
+      expect(printError).toHaveBeenCalledWith(
+        expect.stringContaining("--tenant"),
+      );
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(saveConfig).not.toHaveBeenCalled();
+      // 初回 tenantless login のみ。再ログインも保存もしない
+      expect(client.rawRequest).toHaveBeenCalledTimes(1);
     });
 
     it("succeeds without explicit tenant when only one tenant is available", async () => {

--- a/tests/prompt.test.ts
+++ b/tests/prompt.test.ts
@@ -11,7 +11,7 @@ vi.mock("node:readline/promises", () => ({
   })),
 }));
 
-import { isInteractive, promptConfirm, promptEmail, promptPassword, promptTenantSelection } from "../src/prompt.js";
+import { isInteractive, promptConfirm, promptEmail, promptPassword } from "../src/prompt.js";
 
 describe("prompt", () => {
   const originalStdinIsTTY = process.stdin.isTTY;
@@ -299,78 +299,6 @@ describe("prompt", () => {
         stdinListeners["error"]?.forEach((cb) => cb(error));
         await expect(promise).rejects.toThrow("pipe error");
       });
-    });
-  });
-
-  describe("promptTenantSelection", () => {
-    let stdoutWriteSpy: ReturnType<typeof vi.spyOn>;
-
-    beforeEach(() => {
-      stdoutWriteSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-    });
-
-    afterEach(() => {
-      stdoutWriteSpy.mockRestore();
-    });
-
-    it("returns the selected tenant by index", async () => {
-      mockQuestion.mockResolvedValueOnce("2");
-      const tenants = [
-        { tenantId: "tid-a", tenantName: "alpha", role: "tenant_admin" },
-        { tenantId: "tid-b", tenantName: "beta", role: "user" },
-      ];
-      const result = await promptTenantSelection(tenants);
-      expect(result).toEqual(tenants[1]);
-      expect(stdoutWriteSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Multiple tenants available"),
-      );
-      expect(stdoutWriteSpy).toHaveBeenCalledWith(
-        expect.stringContaining("alpha (tid-a)"),
-      );
-      expect(stdoutWriteSpy).toHaveBeenCalledWith(
-        expect.stringContaining("beta (tid-b)"),
-      );
-    });
-
-    it("defaults to the first tenant on empty input", async () => {
-      mockQuestion.mockResolvedValueOnce("");
-      const tenants = [
-        { tenantId: "tid-a", tenantName: "alpha", role: "tenant_admin" },
-        { tenantId: "tid-b", role: "user" },
-      ];
-      const result = await promptTenantSelection(tenants);
-      expect(result).toEqual(tenants[0]);
-    });
-
-    it("re-prompts on invalid input until a valid index is given", async () => {
-      mockQuestion
-        .mockResolvedValueOnce("xyz")
-        .mockResolvedValueOnce("99")
-        .mockResolvedValueOnce("1");
-      const tenants = [
-        { tenantId: "tid-a", role: "tenant_admin" },
-        { tenantId: "tid-b", role: "user" },
-      ];
-      const result = await promptTenantSelection(tenants);
-      expect(result).toEqual(tenants[0]);
-      expect(mockQuestion).toHaveBeenCalledTimes(3);
-      expect(stdoutWriteSpy).toHaveBeenCalledWith(
-        expect.stringContaining('Invalid selection "xyz"'),
-      );
-    });
-
-    it("falls back to tenantId in the label when tenantName is missing", async () => {
-      mockQuestion.mockResolvedValueOnce("1");
-      const tenants = [{ tenantId: "tid-only", role: "user" }];
-      const result = await promptTenantSelection(tenants);
-      expect(result).toEqual(tenants[0]);
-      expect(stdoutWriteSpy).toHaveBeenCalledWith(
-        expect.stringContaining("tid-only [user]"),
-      );
-    });
-
-    it("throws when no tenants are provided", async () => {
-      await expect(promptTenantSelection([])).rejects.toThrow(/No tenants/);
     });
   });
 


### PR DESCRIPTION
## Summary

- マルチテナント `auth login` で TTY 時に出ていた対話ピッカーを廃止し、フラグ未指定時は TTY の有無にかかわらず一覧 + エラー終了するよう README に揃えた (closes #215)
- `promptTenantSelection` の `default: 1` による primary テナント無言確定を構造的に排除。保存済み `config.service` による暗黙解決は維持
- README のオプション表に `--tenant` を追加し、`--tenant-id` の説明をクライアント側 `availableTenants` 突合に修正

## 原因

issue の見立てどおり。`auth.ts` が `isInteractive()` のときピッカーを呼び、空 Enter で primary テナントを無言確定して `config.service` に固着していた。CHANGELOG #123 はピッカー廃止を謳っていたが、実装が再導入されたまま README と乖離していた。

## テスト

- 修正前: TTY + マルチテナント + フラグ無しの新テストが赤（成功してしまい reject しない）
- 修正後: 緑。全 unit 1077 pass
- 変異注入: フラグ未指定を `selected = availableTenants[0]` に戻すと追加テストが赤。復元後緑
- near-miss: 保存済み `--service` / `config.service` 経路は緑のまま
- E2E: 未実行（本体ローカル起動が必要。CI に委ねる）

## スコープ外

- 単一メンバーシップ時に `--tenant` が黙って無視される件（別 issue 起票予定）
- #213（同ファイルの `config.service` にテナント名保存）とのコンフリクトは取り込み時に解消する。相手変更は巻き戻さない

Closes #215

## Test plan

- [ ] マルチテナントで `geonic auth login`（フラグ無し）→ 一覧 + エラー終了
- [ ] `geonic auth login --tenant <name>` で成功
- [ ] プロファイルに `service` 保存済みならフラグ無しでもそのテナントに解決
- [ ] 単一テナントアカウントの login は従来どおり
- [ ] CI 全緑


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **変更**
  * `auth login` でテナント未指定の場合、TTY環境でも対話的な選択を行わず、利用可能なテナント一覧と指定方法を表示してエラー終了するよう変更しました。
  * ログイン時は `--tenant`、`--tenant-id`、または `--service` でテナントを明示指定できます。
  * `--tenant-id` は他の指定より優先されます。
  * 保存済み設定の `service` は、暗黙的なテナント指定には使用されません。

* **ドキュメント**
  * テナント指定方法、優先順位、エラー案内、ログイン例を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->