### PR TITLE
fix(temporal): entities list に --local を追加 (closes #216)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ## [Unreleased]
 
 ### 2026-08-18
-- **Fix**: `temporal entities list` に `--local` (`?local=true`) を追加し、本体の too-wide query 検証の逃げ道を送れるようにした (closes #216)。ヘルプ例のセレクタ無しコピペで 400 になる例も修正
+- **Fix**: `temporal entities list` に `--local` (`?local=true`) を追加し、本体の too-wide query 検証の逃げ道を送れるようにした (closes #216)。ヘルプ例のセレクタ無しコピペで 400 になる例も修正 (#221)
 
 ## [0.25.0] - 2026-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## [Unreleased]
 
+### 2026-08-18
+- **Fix**: `temporal entities list` に `--local` (`?local=true`) を追加し、本体の too-wide query 検証の逃げ道を送れるようにした (closes #216)。ヘルプ例のセレクタ無しコピペで 400 になる例も修正
+
 ## [0.25.0] - 2026-08-17
 
 ### 2026-08-17

--- a/README.md
+++ b/README.md
@@ -475,7 +475,7 @@ Notes:
 | `temporal entities create [json]` | Create a temporal entity |
 | `temporal entities delete <id>` | Delete a temporal entity |
 
-Temporal entities list supports: `--time-rel`, `--time-at`, `--end-time-at`, `--time-property`, `--last-n`, `--order-by`, `--options`, `--aggr-methods`, `--aggr-period`.
+Temporal entities list supports: `--time-rel`, `--time-at`, `--end-time-at`, `--time-property`, `--last-n`, `--order-by`, `--options`, `--aggr-methods`, `--aggr-period`, `--local` (`?local=true`). After geolonia/geonicdb#2290 (ETSI GS CIM 009 clause 5.7.4.4), a **too-wide** GET returns **400 BadRequestData** unless at least one of `--type`, non-system `--attrs`, non-system `--query`, or a geoquery is present — `--time-rel` / `--time-at` alone are not enough. Use `--local` for a local-scope scan.
 
 Temporal entities get supports: `--time-rel`, `--time-at`, `--end-time-at`, `--time-property`, `--last-n`, `--options`, `--aggr-methods`, `--aggr-period`.
 

--- a/src/commands/temporal.ts
+++ b/src/commands/temporal.ts
@@ -297,6 +297,7 @@ export function registerTemporalCommand(program: Command): void {
   const entitiesList = addTemporalListOptions(
     entities
       .command("list")
+      .summary("List temporal entities with optional filters")
       .description(
         "List temporal entities with optional filters\n\n" +
           "Too-wide queries return 400 BadRequestData (ETSI GS CIM 009 clause 5.7.4.4;\n" +

--- a/src/commands/temporal.ts
+++ b/src/commands/temporal.ts
@@ -125,7 +125,11 @@ function addTemporalListOptions(cmd: Command): Command {
       "--order-by <spec>",
       "Order by NGSI-LD v1.9.1 grammar (e.g. observedAt;desc). Server rejects dist-*/geo:distance, nested paths, aggrMethods combos.",
     )
-    .option("--count", "Include total count in response");
+    .option("--count", "Include total count in response")
+    .option(
+      "--local",
+      "Limit to local scope (?local=true). Exempts the too-wide query check",
+    );
 }
 
 function createListAction() {
@@ -155,6 +159,9 @@ function createListAction() {
     if (cmdOpts.offset !== undefined) params["offset"] = String(cmdOpts.offset);
     if (cmdOpts.orderBy) params["orderBy"] = cmdOpts.orderBy;
     if (cmdOpts.count) params["count"] = "true";
+    // geolonia/geonicdb#2290 / clause 5.7.4.4: local scope exempts the too-wide
+    // check (timerel/timeAt alone are not enough). Same as entityOperations query.
+    if (cmdOpts.local) params.local = "true";
     Object.assign(params, buildRepresentationParams(cmdOpts));
     // The aggregation pipeline sorts by entityId and cannot honor orderBy; the
     // server rejects the combination with 400 — fail fast like the other
@@ -288,7 +295,16 @@ export function registerTemporalCommand(program: Command): void {
 
   // temporal entities list
   const entitiesList = addTemporalListOptions(
-    entities.command("list").description("List temporal entities with optional filters"),
+    entities
+      .command("list")
+      .description(
+        "List temporal entities with optional filters\n\n" +
+          "Too-wide queries return 400 BadRequestData (ETSI GS CIM 009 clause 5.7.4.4;\n" +
+          "geolonia/geonicdb#2290). At least one of --type, non-system --attrs,\n" +
+          "non-system --query, or a geoquery is required — --time-rel / --time-at\n" +
+          "alone are not enough. For an unrestricted local scan, pass --local\n" +
+          "(?local=true).",
+      ),
   );
   entitiesList.action(createListAction());
 
@@ -303,14 +319,19 @@ export function registerTemporalCommand(program: Command): void {
       command: "geonic temporal entities list --type Sensor --last-n 5",
     },
     {
-      description: "Filter by time (after a point)",
+      description: "Filter by time (after a point; --type required — time alone is too-wide)",
       command:
-        "geonic temporal entities list --time-rel after --time-at 2025-06-01T00:00:00Z",
+        "geonic temporal entities list --type Sensor --time-rel after --time-at 2025-06-01T00:00:00Z",
     },
     {
       description: "Filter by creation time (timeproperty=createdAt)",
       command:
-        "geonic temporal entities list --time-rel after --time-at 2025-06-01T00:00:00Z --time-property createdAt",
+        "geonic temporal entities list --type Sensor --time-rel after --time-at 2025-06-01T00:00:00Z --time-property createdAt",
+    },
+    {
+      description: "Local-scope scan (exempts the too-wide query check)",
+      command:
+        "geonic temporal entities list --local --time-rel after --time-at 2025-06-01T00:00:00Z",
     },
     {
       description: "Order temporal entities (NGSI-LD v1.9.1 grammar)",

--- a/tests/temporal.test.ts
+++ b/tests/temporal.test.ts
@@ -119,6 +119,50 @@ describe("temporal commands", () => {
       expect(outputResponse).toHaveBeenCalledWith(expect.anything(), "json", true);
     });
 
+    // #216 / geonicdb#2290: GET /temporal/entities too-wide check exempts local=true.
+    it("passes --local as local=true query param (#216)", async () => {
+      client.get.mockResolvedValue(mockResponse([]));
+      const program = makeProgram();
+      await runCommand(program, [
+        "temporal",
+        "entities",
+        "list",
+        "--local",
+        "--time-rel",
+        "after",
+        "--time-at",
+        "2025-06-01T00:00:00Z",
+      ]);
+      expect(client.get).toHaveBeenCalledWith("/temporal/entities", {
+        local: "true",
+        timerel: "after",
+        timeAt: "2025-06-01T00:00:00Z",
+      });
+    });
+
+    // near-miss: omitting --local must not inject local=true (federation semantics).
+    it("does not send local when --local is omitted (near-miss #216)", async () => {
+      client.get.mockResolvedValue(mockResponse([]));
+      const program = makeProgram();
+      await runCommand(program, [
+        "temporal",
+        "entities",
+        "list",
+        "--type",
+        "Sensor",
+        "--time-rel",
+        "after",
+        "--time-at",
+        "2025-06-01T00:00:00Z",
+      ]);
+      expect(client.get).toHaveBeenCalledWith("/temporal/entities", {
+        type: "Sensor",
+        timerel: "after",
+        timeAt: "2025-06-01T00:00:00Z",
+      });
+      expect(client.get.mock.calls[0]?.[1]).not.toHaveProperty("local");
+    });
+
     // #202 / geolonia/geonicdb#2267: --time-property → timeproperty query param
     it("passes --time-property createdAt as timeproperty (#202)", async () => {
       client.get.mockResolvedValue(mockResponse([]));


### PR DESCRIPTION
## Summary

- **原因**: `GET /temporal/entities` は本体の too-wide query 検証 (`assertQueryRestrictionPresent`) の対象で、免除は `local=true` のみ。CLI の `temporal entities list` に `--local` が無く逃げ道を送れなかった（`temporal entityOperations query` の POST 側だけ #207 で埋まっていた）。ヘルプ例も `--time-rel` / `--time-at` のみでセレクタ無しのため、コピペすると 400 になる。issue の見立てどおり。
- **修正**: `addTemporalListOptions` / `createListAction` に `--local` → `?local=true` を追加。説明文・ヘルプ例・README を `entityOperations query` と揃え、複数行 `.description()` 用に `.summary()` も追加。
- **スコープ外**: `entities list` の `--local` は #214（別ブランチ）。本 PR では触っていない。

Closes #216

## Test plan

- [x] 修正前: `temporal entities list --local` → `unknown option '--local'`（回帰テスト赤）
- [x] 修正後: `--dry-run` で `local=true` が載る / 未指定時は載らない
- [x] 変異注入: 配線無効化 → 正のテスト赤 / 常時 local → near-miss 赤 → 復元緑
- [x] `npm run lint && npm run typecheck && npm run build && npm test`（1084）
- [ ] `npm run test:e2e`（未実行・本体サーバー未起動。CI に委ねる）


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - `temporal entities list` に `--local` オプションを追加しました。ローカルスコープのデータを検索できます。
  - `--local` 指定時のみ、ローカル検索としてリクエストされます。

- **バグ修正**
  - セレクタ未指定でヘルプの例を実行した際、不要に400エラーとなる問題を修正しました。

- **ドキュメント**
  - 広すぎる検索が400エラーになる条件と、`--local` の利用方法を追記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->