### PR TITLE
fix(auth): single-membership --tenant fail-loud via server (closes #217)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ## [Unreleased]
 
 ### 2026-08-18
-- **Fix**: 単一メンバーシップのアカウントで `auth login --tenant` / `--tenant-id` が黙って無視されないようにした (closes #217)。`availableTenants` が無いときは明示フラグだけを `tenantName` / `tenantId` として再ログイン body に載せ、サーバー側の 400/403 で fail-loud にする。`--tenant` は NAME_REGEX で name/id を振り分け、config.service の back-fill は無視する (#PR)
+- **Fix**: 単一メンバーシップのアカウントで `auth login --tenant` / `--tenant-id` が黙って無視されないようにした (closes #217)。`availableTenants` が無いときは明示フラグだけを `tenantName` / `tenantId` として再ログイン body に載せ、サーバー側の 400/403 で fail-loud にする。`--tenant` は NAME_REGEX で name/id を振り分け、config.service の back-fill は無視する (#222)
 
 ## [0.25.0] - 2026-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## [Unreleased]
 
+### 2026-08-18
+- **Fix**: 単一メンバーシップのアカウントで `auth login --tenant` / `--tenant-id` が黙って無視されないようにした (closes #217)。`availableTenants` が無いときはフラグを `tenantName` / `tenantId` として再ログイン body に載せ、サーバー側の 400/403 で fail-loud にする
+
 ## [0.25.0] - 2026-08-17
 
 ### 2026-08-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ## [Unreleased]
 
 ### 2026-08-18
-- **Fix**: 単一メンバーシップのアカウントで `auth login --tenant` / `--tenant-id` が黙って無視されないようにした (closes #217)。`availableTenants` が無いときはフラグを `tenantName` / `tenantId` として再ログイン body に載せ、サーバー側の 400/403 で fail-loud にする
+- **Fix**: 単一メンバーシップのアカウントで `auth login --tenant` / `--tenant-id` が黙って無視されないようにした (closes #217)。`availableTenants` が無いときは明示フラグだけを `tenantName` / `tenantId` として再ログイン body に載せ、サーバー側の 400/403 で fail-loud にする。`--tenant` は NAME_REGEX で name/id を振り分け、config.service の back-fill は無視する (#PR)
 
 ## [0.25.0] - 2026-08-17
 

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -20,6 +20,15 @@ import { addMeApiKeysSubcommand } from "./me-api-keys.js";
 import { addMePasswordSubcommand } from "./me-password.js";
 import { addMePoliciesSubcommand } from "./me-policies.js";
 
+/** 本体 TENANT.NAME_REGEX と同じ。--tenant の name|id 判定に使う (#217)。 */
+const TENANT_SERVICE_NAME_RE = /^[a-z0-9_]+$/;
+
+function loginResponseTenantId(data: Record<string, unknown>): string | undefined {
+  // LoginResponse の tenantId は top-level ではなく user 配下 (#213 / #217)。
+  const user = data.user as { tenantId?: string | null } | undefined;
+  return user?.tenantId ?? undefined;
+}
+
 function createLoginCommand(): Command {
   return new Command("login")
     .description("Authenticate and save token")
@@ -102,8 +111,10 @@ function createLoginCommand(): Command {
 
         // --tenant-id matches by ID only. --tenant and -s/--service match by name or ID.
         // --tenant-id wins when both are supplied.
+        // config.service の back-fill (resolveOptions) は使わない — 明示フラグのみ (#217)。
+        const cliGlobals = cmd.optsWithGlobals() as { service?: string };
         const tenantIdFlag = loginOpts.tenantId;
-        const tenantNameOrIdFlag = loginOpts.tenant ?? globalOpts.service;
+        const tenantNameOrIdFlag = loginOpts.tenant ?? cliGlobals.service;
         const tenantFlag = tenantIdFlag ?? tenantNameOrIdFlag;
 
         // Step 1: tenantless login. Server returns either a single-tenant token
@@ -164,7 +175,7 @@ function createLoginCommand(): Command {
         }
 
         const availableTenants = data.availableTenants as TenantInfo[] | undefined;
-        let finalTenantId = data.tenantId as string | undefined;
+        let finalTenantId = loginResponseTenantId(data);
 
         // Multi-tenant: resolve target tenant from flag, interactive prompt, or fall back to primary
         if (availableTenants && availableTenants.length > 1) {
@@ -232,10 +243,13 @@ function createLoginCommand(): Command {
         } else if (tenantFlag) {
           // Single-membership (サーバーは memberships.length > 1 のときだけ availableTenants を返す):
           // クライアントでは検証できないため、フラグを body に載せてサーバーに判定させる (#217)。
-          // --tenant-id → tenantId / --tenant・-s → tenantName。
+          // --tenant-id → 常に tenantId。
+          // --tenant / -s → 本体 NAME_REGEX に合うなら tenantName、合わなければ tenantId（UUID 等）。
           const tenantBody = tenantIdFlag
             ? { tenantId: tenantIdFlag }
-            : { tenantName: tenantNameOrIdFlag as string };
+            : TENANT_SERVICE_NAME_RE.test(tenantNameOrIdFlag as string)
+              ? { tenantName: tenantNameOrIdFlag as string }
+              : { tenantId: tenantNameOrIdFlag as string };
           const reloginResponse = await client.rawRequest("POST", "/auth/login", {
             // #1532: 強制パスワード変更後は effectivePassword で再ログインする。
             body: { email, password: effectivePassword, ...tenantBody },
@@ -249,7 +263,7 @@ function createLoginCommand(): Command {
           }
           token = newToken;
           refreshToken = reloginData.refreshToken as string | undefined;
-          finalTenantId = (reloginData.tenantId as string | undefined) ?? finalTenantId;
+          finalTenantId = loginResponseTenantId(reloginData) ?? finalTenantId;
         }
 
         const config = loadConfig(globalOpts.profile);

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -229,18 +229,27 @@ function createLoginCommand(): Command {
             refreshToken = reloginData.refreshToken as string | undefined;
             finalTenantId = selected.tenantId;
           }
-        } else if (tenantFlag && availableTenants && availableTenants.length === 1) {
-          // Single-tenant account but flag was provided — validate it matches
-          const only = availableTenants[0];
-          const matches = tenantIdFlag
-            ? only.tenantId === tenantIdFlag
-            : only.tenantName === tenantFlag || only.tenantId === tenantFlag;
-          if (!matches) {
-            printError(
-              `Tenant "${tenantFlag}" not found. The only available tenant is "${only.tenantName ?? only.tenantId}" (${only.tenantId}).`,
-            );
+        } else if (tenantFlag) {
+          // Single-membership (サーバーは memberships.length > 1 のときだけ availableTenants を返す):
+          // クライアントでは検証できないため、フラグを body に載せてサーバーに判定させる (#217)。
+          // --tenant-id → tenantId / --tenant・-s → tenantName。
+          const tenantBody = tenantIdFlag
+            ? { tenantId: tenantIdFlag }
+            : { tenantName: tenantNameOrIdFlag as string };
+          const reloginResponse = await client.rawRequest("POST", "/auth/login", {
+            // #1532: 強制パスワード変更後は effectivePassword で再ログインする。
+            body: { email, password: effectivePassword, ...tenantBody },
+            skipTenantHeader: true,
+          });
+          const reloginData = reloginResponse.data as Record<string, unknown>;
+          const newToken = (reloginData.accessToken ?? reloginData.token) as string | undefined;
+          if (!newToken) {
+            printError("Re-login failed: no token received for selected tenant.");
             process.exit(1);
           }
+          token = newToken;
+          refreshToken = reloginData.refreshToken as string | undefined;
+          finalTenantId = (reloginData.tenantId as string | undefined) ?? finalTenantId;
         }
 
         const config = loadConfig(globalOpts.profile);
@@ -270,7 +279,13 @@ function createLoginCommand(): Command {
         saveConfig(config, globalOpts.profile);
 
         const tenantLabel = finalTenantId
-          ? ` (tenant: ${availableTenants?.find((t) => t.tenantId === finalTenantId)?.tenantName ?? finalTenantId})`
+          ? ` (tenant: ${
+              availableTenants?.find((t) => t.tenantId === finalTenantId)?.tenantName
+              // 単一メンバーシップで --tenant <name> をサーバー検証した場合、availableTenants が無いため
+              // フラグの名前を表示する（--tenant-id は ID のまま）。
+              ?? (!tenantIdFlag && tenantNameOrIdFlag ? tenantNameOrIdFlag : undefined)
+              ?? finalTenantId
+            })`
           : "";
         printSuccess(`Login successful${tenantLabel}. Token saved to config.`);
       }),

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -326,19 +326,115 @@ describe("auth commands", () => {
     });
 
     it("first request is tenantless even when --tenant-id is provided", async () => {
-      // New flow: always do tenantless first to receive availableTenants for name->ID resolution.
+      // 初回は tenantless で availableTenants の有無を確認し、単一メンバーシップなら
+      // 2 回目で tenantId を載せてサーバー検証する (#217)。
       vi.mocked(isInteractive).mockReturnValue(true);
       vi.mocked(promptEmail).mockResolvedValue("user@example.com");
       vi.mocked(promptPassword).mockResolvedValue("pass123");
-      client.rawRequest.mockResolvedValue(
-        mockResponse({ accessToken: "tenant-token", tenantId: "my-tenant" }),
-      );
+      client.rawRequest
+        .mockResolvedValueOnce(
+          mockResponse({ accessToken: "primary-token", tenantId: "my-tenant" }),
+        )
+        .mockResolvedValueOnce(
+          mockResponse({ accessToken: "tenant-token", tenantId: "my-tenant" }),
+        );
       const program = makeProgram();
       await runCommand(program, ["auth", "login", "--tenant-id", "my-tenant"]);
       expect(client.rawRequest).toHaveBeenNthCalledWith(1, "POST", "/auth/login", {
         body: { email: "user@example.com", password: "pass123" },
         skipTenantHeader: true,
       });
+      expect(client.rawRequest).toHaveBeenNthCalledWith(2, "POST", "/auth/login", {
+        body: { email: "user@example.com", password: "pass123", tenantId: "my-tenant" },
+        skipTenantHeader: true,
+      });
+    });
+
+    it("re-logins with tenantName when --tenant is set and availableTenants is absent (#217)", async () => {
+      // 本体は memberships.length > 1 のときだけ availableTenants を返す。単一所属では undefined。
+      vi.mocked(isInteractive).mockReturnValue(true);
+      vi.mocked(promptEmail).mockResolvedValue("user@example.com");
+      vi.mocked(promptPassword).mockResolvedValue("pass12345678");
+      client.rawRequest
+        .mockResolvedValueOnce(
+          mockResponse({ accessToken: "primary-tok", tenantId: "tid-primary" }),
+        )
+        .mockResolvedValueOnce(
+          mockResponse({ accessToken: "scoped-tok", tenantId: "tid-primary" }),
+        );
+      const program = makeProgram();
+      await runCommand(program, ["auth", "login", "--tenant", "miya"]);
+      expect(client.rawRequest).toHaveBeenNthCalledWith(2, "POST", "/auth/login", {
+        body: { email: "user@example.com", password: "pass12345678", tenantName: "miya" },
+        skipTenantHeader: true,
+      });
+      expect(saveConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ token: "scoped-tok", tenantId: "tid-primary" }),
+        "default",
+      );
+      expect(printSuccess).toHaveBeenCalledWith(
+        "Login successful (tenant: miya). Token saved to config.",
+      );
+    });
+
+    it("does not succeed when --tenant is wrong and availableTenants is absent (#217)", async () => {
+      vi.mocked(isInteractive).mockReturnValue(true);
+      vi.mocked(promptEmail).mockResolvedValue("user@example.com");
+      vi.mocked(promptPassword).mockResolvedValue("pass12345678");
+      client.rawRequest
+        .mockResolvedValueOnce(
+          mockResponse({ accessToken: "primary-tok", tenantId: "tid-primary" }),
+        )
+        .mockRejectedValueOnce(
+          new GdbClientError("Tenant not found: miyaa", 400, {
+            error: "BadRequest",
+            description: "Tenant not found: miyaa",
+          }),
+        );
+      const program = makeProgram();
+      await expect(
+        runCommand(program, ["auth", "login", "--tenant", "miyaa"]),
+      ).rejects.toThrow("Tenant not found: miyaa");
+      expect(saveConfig).not.toHaveBeenCalled();
+      expect(printSuccess).not.toHaveBeenCalled();
+    });
+
+    it("does not succeed when --tenant-id is outside membership and availableTenants is absent (#217)", async () => {
+      vi.mocked(isInteractive).mockReturnValue(true);
+      vi.mocked(promptEmail).mockResolvedValue("user@example.com");
+      vi.mocked(promptPassword).mockResolvedValue("pass12345678");
+      client.rawRequest
+        .mockResolvedValueOnce(
+          mockResponse({ accessToken: "primary-tok", tenantId: "tid-primary" }),
+        )
+        .mockRejectedValueOnce(
+          new GdbClientError("You are not a member of the requested tenant", 403, {
+            error: "Forbidden",
+            description: "You are not a member of the requested tenant",
+          }),
+        );
+      const program = makeProgram();
+      await expect(
+        runCommand(program, ["auth", "login", "--tenant-id", "tid-other"]),
+      ).rejects.toThrow("You are not a member of the requested tenant");
+      expect(saveConfig).not.toHaveBeenCalled();
+    });
+
+    it("near-miss: without tenant flag, single-membership login stays one request (#217)", async () => {
+      // フラグ無しなら従来どおり tenantless 1 回のみ（サーバー検証の再ログインを起こさない）
+      vi.mocked(isInteractive).mockReturnValue(true);
+      vi.mocked(promptEmail).mockResolvedValue("user@example.com");
+      vi.mocked(promptPassword).mockResolvedValue("pass12345678");
+      client.rawRequest.mockResolvedValue(
+        mockResponse({ accessToken: "primary-tok", tenantId: "tid-primary" }),
+      );
+      const program = makeProgram();
+      await runCommand(program, ["auth", "login"]);
+      expect(client.rawRequest).toHaveBeenCalledTimes(1);
+      expect(saveConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ token: "primary-tok", tenantId: "tid-primary" }),
+        "default",
+      );
     });
 
     it("sends skipTenantHeader to prevent NGSILD-Tenant on login", async () => {

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -70,6 +70,16 @@ import { clientCredentialsGrant } from "../src/oauth.js";
 import { registerAuthCommands } from "../src/commands/auth.js";
 import { GdbClientError } from "../src/client.js";
 
+function loginUser(tenantId: string, overrides: Record<string, string> = {}) {
+  return {
+    id: "u1",
+    email: "user@example.com",
+    role: "user",
+    tenantId,
+    ...overrides,
+  };
+}
+
 describe("auth commands", () => {
   let client: MockClient;
   let exitSpy: ReturnType<typeof vi.spyOn>;
@@ -333,10 +343,10 @@ describe("auth commands", () => {
       vi.mocked(promptPassword).mockResolvedValue("pass123");
       client.rawRequest
         .mockResolvedValueOnce(
-          mockResponse({ accessToken: "primary-token", tenantId: "my-tenant" }),
+          mockResponse({ accessToken: "primary-token", user: loginUser("my-tenant")}),
         )
         .mockResolvedValueOnce(
-          mockResponse({ accessToken: "tenant-token", tenantId: "my-tenant" }),
+          mockResponse({ accessToken: "tenant-token", user: loginUser("my-tenant")}),
         );
       const program = makeProgram();
       await runCommand(program, ["auth", "login", "--tenant-id", "my-tenant"]);
@@ -357,10 +367,11 @@ describe("auth commands", () => {
       vi.mocked(promptPassword).mockResolvedValue("pass12345678");
       client.rawRequest
         .mockResolvedValueOnce(
-          mockResponse({ accessToken: "primary-tok", tenantId: "tid-primary" }),
+          mockResponse({ accessToken: "primary-tok", user: loginUser("tid-primary")}),
         )
         .mockResolvedValueOnce(
-          mockResponse({ accessToken: "scoped-tok", tenantId: "tid-primary" }),
+          // レスポンスの tenantId は user 配下。top-level を読む実装だと primary のまま残る。
+          mockResponse({ accessToken: "scoped-tok", user: loginUser("tid-scoped")}),
         );
       const program = makeProgram();
       await runCommand(program, ["auth", "login", "--tenant", "miya"]);
@@ -369,7 +380,7 @@ describe("auth commands", () => {
         skipTenantHeader: true,
       });
       expect(saveConfig).toHaveBeenCalledWith(
-        expect.objectContaining({ token: "scoped-tok", tenantId: "tid-primary" }),
+        expect.objectContaining({ token: "scoped-tok", tenantId: "tid-scoped" }),
         "default",
       );
       expect(printSuccess).toHaveBeenCalledWith(
@@ -383,7 +394,7 @@ describe("auth commands", () => {
       vi.mocked(promptPassword).mockResolvedValue("pass12345678");
       client.rawRequest
         .mockResolvedValueOnce(
-          mockResponse({ accessToken: "primary-tok", tenantId: "tid-primary" }),
+          mockResponse({ accessToken: "primary-tok", user: loginUser("tid-primary")}),
         )
         .mockRejectedValueOnce(
           new GdbClientError("Tenant not found: miyaa", 400, {
@@ -405,7 +416,7 @@ describe("auth commands", () => {
       vi.mocked(promptPassword).mockResolvedValue("pass12345678");
       client.rawRequest
         .mockResolvedValueOnce(
-          mockResponse({ accessToken: "primary-tok", tenantId: "tid-primary" }),
+          mockResponse({ accessToken: "primary-tok", user: loginUser("tid-primary")}),
         )
         .mockRejectedValueOnce(
           new GdbClientError("You are not a member of the requested tenant", 403, {
@@ -426,13 +437,72 @@ describe("auth commands", () => {
       vi.mocked(promptEmail).mockResolvedValue("user@example.com");
       vi.mocked(promptPassword).mockResolvedValue("pass12345678");
       client.rawRequest.mockResolvedValue(
-        mockResponse({ accessToken: "primary-tok", tenantId: "tid-primary" }),
+        mockResponse({ accessToken: "primary-tok", user: loginUser("tid-primary")}),
       );
       const program = makeProgram();
       await runCommand(program, ["auth", "login"]);
       expect(client.rawRequest).toHaveBeenCalledTimes(1);
       expect(saveConfig).toHaveBeenCalledWith(
         expect.objectContaining({ token: "primary-tok", tenantId: "tid-primary" }),
+        "default",
+      );
+    });
+
+    it("sends --tenant UUID as tenantId when it does not match NAME_REGEX (#217)", async () => {
+      vi.mocked(isInteractive).mockReturnValue(true);
+      vi.mocked(promptEmail).mockResolvedValue("user@example.com");
+      vi.mocked(promptPassword).mockResolvedValue("pass12345678");
+      const uuid = "ed945710-fb96-4d17-811b-425abcb9b70e";
+      client.rawRequest
+        .mockResolvedValueOnce(
+          mockResponse({ accessToken: "primary-tok", user: loginUser(uuid) }),
+        )
+        .mockResolvedValueOnce(
+          mockResponse({ accessToken: "scoped-tok", user: loginUser(uuid) }),
+        );
+      const program = makeProgram();
+      await runCommand(program, ["auth", "login", "--tenant", uuid]);
+      expect(client.rawRequest).toHaveBeenNthCalledWith(2, "POST", "/auth/login", {
+        body: { email: "user@example.com", password: "pass12345678", tenantId: uuid },
+        skipTenantHeader: true,
+      });
+      expect(saveConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ token: "scoped-tok", tenantId: uuid }),
+        "default",
+      );
+    });
+
+    it("ignores config.service back-fill and does not re-login without an explicit flag (#217)", async () => {
+      // resolveOptions は config.service (UUID) を back-fill するが、明示 -s/--tenant が無い限り
+      // 単一メンバーシップ経路に入ってはならない。
+      vi.mocked(isInteractive).mockReturnValue(true);
+      vi.mocked(promptEmail).mockResolvedValue("user@example.com");
+      vi.mocked(promptPassword).mockResolvedValue("pass12345678");
+      vi.mocked(resolveOptions).mockReturnValue({
+        url: "http://localhost:3000",
+        profile: "default",
+        token: "test-token",
+        format: "json",
+        service: "ed945710-fb96-4d17-811b-425abcb9b70e",
+      } as never);
+      client.rawRequest.mockResolvedValue(
+        mockResponse({
+          accessToken: "primary-tok",
+          user: loginUser("ed945710-fb96-4d17-811b-425abcb9b70e"),
+        }),
+      );
+      const program = makeProgram();
+      await runCommand(program, ["auth", "login"]);
+      expect(client.rawRequest).toHaveBeenCalledTimes(1);
+      expect(client.rawRequest).toHaveBeenCalledWith("POST", "/auth/login", {
+        body: { email: "user@example.com", password: "pass12345678" },
+        skipTenantHeader: true,
+      });
+      expect(saveConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          token: "primary-tok",
+          tenantId: "ed945710-fb96-4d17-811b-425abcb9b70e",
+        }),
         "default",
       );
     });
@@ -498,7 +568,7 @@ describe("auth commands", () => {
       vi.mocked(promptEmail).mockResolvedValue("user@example.com");
       vi.mocked(promptPassword).mockResolvedValue("pass123");
       client.rawRequest.mockResolvedValue(
-        mockResponse({ accessToken: "tok", tenantId: "ed945710-fb96-4d17-811b-425abcb9b70e" }),
+        mockResponse({ accessToken: "tok", user: loginUser("ed945710-fb96-4d17-811b-425abcb9b70e")}),
       );
       const program = makeProgram();
       await runCommand(program, ["auth", "login"]);
@@ -596,7 +666,7 @@ describe("auth commands", () => {
         { tenantId: "city_b", role: "user" },
       ];
       client.rawRequest.mockResolvedValue(
-        mockResponse({ accessToken: "tok", tenantId: "city_a", availableTenants: tenants }),
+        mockResponse({ accessToken: "tok", availableTenants: tenants, user: loginUser("city_a")}),
       );
       const program = makeProgram();
       await expect(
@@ -623,7 +693,7 @@ describe("auth commands", () => {
         { tenantId: "city_b", role: "user" },
       ];
       client.rawRequest.mockResolvedValue(
-        mockResponse({ accessToken: "tok", tenantId: "city_a", availableTenants: tenants }),
+        mockResponse({ accessToken: "tok", availableTenants: tenants, user: loginUser("city_a")}),
       );
       const program = makeProgram();
       await runCommand(program, ["auth", "login", "--tenant-id", "city_a"]);
@@ -646,10 +716,10 @@ describe("auth commands", () => {
       ];
       client.rawRequest
         .mockResolvedValueOnce(
-          mockResponse({ accessToken: "tok-a", tenantId: "tid-aaa", availableTenants: tenants }),
+          mockResponse({ accessToken: "tok-a", availableTenants: tenants, user: loginUser("tid-aaa")}),
         )
         .mockResolvedValueOnce(
-          mockResponse({ accessToken: "tok-b", tenantId: "tid-bbb" }),
+          mockResponse({ accessToken: "tok-b", user: loginUser("tid-bbb")}),
         );
       const program = makeProgram();
       await runCommand(program, ["auth", "login", "--tenant-id", "tid-bbb"]);
@@ -669,7 +739,7 @@ describe("auth commands", () => {
         { tenantId: "tid-bbb", tenantName: "demo_bousai", role: "user" },
       ];
       client.rawRequest.mockResolvedValueOnce(
-        mockResponse({ accessToken: "tok-a", tenantId: "tid-aaa", availableTenants: tenants }),
+        mockResponse({ accessToken: "tok-a", availableTenants: tenants, user: loginUser("tid-aaa")}),
       );
       const program = makeProgram();
       await expect(
@@ -691,10 +761,10 @@ describe("auth commands", () => {
       ];
       client.rawRequest
         .mockResolvedValueOnce(
-          mockResponse({ accessToken: "tok-a", tenantId: "tid-aaa", availableTenants: tenants }),
+          mockResponse({ accessToken: "tok-a", availableTenants: tenants, user: loginUser("tid-aaa")}),
         )
         .mockResolvedValueOnce(
-          mockResponse({ accessToken: "tok-b", tenantId: "tid-bbb" }),
+          mockResponse({ accessToken: "tok-b", user: loginUser("tid-bbb")}),
         );
       const program = makeProgram();
       await runCommand(program, ["auth", "login", "--tenant", "demo_bousai"]);
@@ -715,10 +785,10 @@ describe("auth commands", () => {
       ];
       client.rawRequest
         .mockResolvedValueOnce(
-          mockResponse({ accessToken: "tok-a", tenantId: "tid-aaa", availableTenants: tenants }),
+          mockResponse({ accessToken: "tok-a", availableTenants: tenants, user: loginUser("tid-aaa")}),
         )
         .mockResolvedValueOnce(
-          mockResponse({ accessToken: "tok-b", tenantId: "tid-bbb" }),
+          mockResponse({ accessToken: "tok-b", user: loginUser("tid-bbb")}),
         );
       const program = makeProgram();
       await runCommand(program, ["auth", "login", "--tenant", "tid-bbb"]);
@@ -736,10 +806,10 @@ describe("auth commands", () => {
       vi.mocked(promptTenantSelection).mockResolvedValue(tenants[1]);
       client.rawRequest
         .mockResolvedValueOnce(
-          mockResponse({ accessToken: "tok-a", tenantId: "tid-aaa", availableTenants: tenants }),
+          mockResponse({ accessToken: "tok-a", availableTenants: tenants, user: loginUser("tid-aaa")}),
         )
         .mockResolvedValueOnce(
-          mockResponse({ accessToken: "tok-b", tenantId: "tid-bbb" }),
+          mockResponse({ accessToken: "tok-b", user: loginUser("tid-bbb")}),
         );
       const program = makeProgram();
       await runCommand(program, ["auth", "login"]);
@@ -757,7 +827,7 @@ describe("auth commands", () => {
     it("succeeds without explicit tenant when only one tenant is available", async () => {
       const tenants = [{ tenantId: "city_a", role: "tenant_admin" }];
       client.rawRequest.mockResolvedValue(
-        mockResponse({ accessToken: "tok", tenantId: "city_a", availableTenants: tenants }),
+        mockResponse({ accessToken: "tok", availableTenants: tenants, user: loginUser("city_a")}),
       );
       const program = makeProgram();
       await runCommand(program, ["auth", "login"]);
@@ -772,7 +842,7 @@ describe("auth commands", () => {
         { tenantId: "city_a", tenantName: "Smart City A", role: "tenant_admin" },
       ];
       client.rawRequest.mockResolvedValue(
-        mockResponse({ accessToken: "tok", tenantId: "city_a", availableTenants: tenants }),
+        mockResponse({ accessToken: "tok", availableTenants: tenants, user: loginUser("city_a")}),
       );
       const program = makeProgram();
       await runCommand(program, ["auth", "login"]);
@@ -792,22 +862,15 @@ describe("auth commands", () => {
         { tenantId: "tid-aaa", tenantName: "demo_smartcity", role: "tenant_admin" },
         { tenantId: "tid-bbb", tenantName: "demo_bousai", role: "user" },
       ];
-      vi.mocked(resolveOptions).mockReturnValue({
-        url: "http://localhost:3000",
-        profile: "default",
-        token: "test-token",
-        format: "json",
-        service: "demo_bousai",
-      } as never);
       client.rawRequest
         .mockResolvedValueOnce(
-          mockResponse({ accessToken: "tok-a", tenantId: "tid-aaa", availableTenants: tenants }),
+          mockResponse({ accessToken: "tok-a", availableTenants: tenants, user: loginUser("tid-aaa")}),
         )
         .mockResolvedValueOnce(
-          mockResponse({ accessToken: "tok-b", refreshToken: "ref-b", tenantId: "tid-bbb" }),
+          mockResponse({ accessToken: "tok-b", refreshToken: "ref-b", user: loginUser("tid-bbb")}),
         );
       const program = makeProgram();
-      await runCommand(program, ["auth", "login"]);
+      await runCommand(program, ["auth", "login", "-s", "demo_bousai"]);
       expect(client.rawRequest).toHaveBeenLastCalledWith("POST", "/auth/login", {
         body: { email: "user@example.com", password: "pass123", tenantId: "tid-bbb" },
         skipTenantHeader: true,
@@ -823,22 +886,15 @@ describe("auth commands", () => {
         { tenantId: "city_a", role: "tenant_admin" },
         { tenantId: "city_b", role: "user" },
       ];
-      vi.mocked(resolveOptions).mockReturnValue({
-        url: "http://localhost:3000",
-        profile: "default",
-        token: "test-token",
-        format: "json",
-        service: "city_b",
-      } as never);
       client.rawRequest
         .mockResolvedValueOnce(
-          mockResponse({ accessToken: "tok-a", tenantId: "city_a", availableTenants: tenants }),
+          mockResponse({ accessToken: "tok-a", availableTenants: tenants, user: loginUser("city_a")}),
         )
         .mockResolvedValueOnce(
-          mockResponse({ accessToken: "tok-b", tenantId: "city_b" }),
+          mockResponse({ accessToken: "tok-b", user: loginUser("city_b")}),
         );
       const program = makeProgram();
-      await runCommand(program, ["auth", "login"]);
+      await runCommand(program, ["auth", "login", "-s", "city_b"]);
       expect(saveConfig).toHaveBeenCalledWith(
         expect.objectContaining({ token: "tok-b", service: "city_b" }),
         "default",
@@ -850,19 +906,12 @@ describe("auth commands", () => {
         { tenantId: "city_a", tenantName: "Smart City A", role: "tenant_admin" },
         { tenantId: "city_b", role: "user" },
       ];
-      vi.mocked(resolveOptions).mockReturnValue({
-        url: "http://localhost:3000",
-        profile: "default",
-        token: "test-token",
-        format: "json",
-        service: "nonexistent",
-      } as never);
       client.rawRequest.mockResolvedValue(
-        mockResponse({ accessToken: "tok", tenantId: "city_a", availableTenants: tenants }),
+        mockResponse({ accessToken: "tok", availableTenants: tenants, user: loginUser("city_a")}),
       );
       const program = makeProgram();
       await expect(
-        runCommand(program, ["auth", "login"]),
+        runCommand(program, ["auth", "login", "-s", "nonexistent"]),
       ).rejects.toThrow("process.exit");
       expect(printError).toHaveBeenCalledWith(
         expect.stringContaining('Tenant "nonexistent" not found'),
@@ -874,23 +923,16 @@ describe("auth commands", () => {
         { tenantId: "city_a", role: "tenant_admin" },
         { tenantId: "city_b", role: "user" },
       ];
-      vi.mocked(resolveOptions).mockReturnValue({
-        url: "http://localhost:3000",
-        profile: "default",
-        token: "test-token",
-        format: "json",
-        service: "city_b",
-      } as never);
       client.rawRequest
         .mockResolvedValueOnce(
-          mockResponse({ accessToken: "tok-a", tenantId: "city_a", availableTenants: tenants }),
+          mockResponse({ accessToken: "tok-a", availableTenants: tenants, user: loginUser("city_a")}),
         )
         .mockResolvedValueOnce(
           mockResponse({ message: "ok" }), // no token
         );
       const program = makeProgram();
       await expect(
-        runCommand(program, ["auth", "login"]),
+        runCommand(program, ["auth", "login", "-s", "city_b"]),
       ).rejects.toThrow("process.exit");
       expect(printError).toHaveBeenCalledWith("Re-login failed: no token received for selected tenant.");
       expect(exitSpy).toHaveBeenCalledWith(1);
@@ -901,7 +943,7 @@ describe("auth commands", () => {
         { tenantId: "city_a", tenantName: "Smart City A", role: "tenant_admin" },
       ];
       client.rawRequest.mockResolvedValue(
-        mockResponse({ accessToken: "tok", tenantId: "city_a", availableTenants: tenants }),
+        mockResponse({ accessToken: "tok", availableTenants: tenants, user: loginUser("city_a")}),
       );
       const program = makeProgram();
       await runCommand(program, ["auth", "login"]);


### PR DESCRIPTION
## Summary
- 単一メンバーシップで auth login --tenant / --tenant-id が黙って無視されていたのを、再ログイン body に載せてサーバー検証するよう修正した (closes #217)
- --tenant は NAME_REGEX で name/id を振り分け、明示フラグのみを対象にし、LoginResponse.user.tenantId を読む

## 原因
本体は memberships.length > 1 のときだけ availableTenants を返す。CLI はそれが無いとフラグ分岐に入らず、primary トークンを保存して成功表示していた。length === 1 分岐は到達不能だった。

## 修正内容
- フラグあり × availableTenants 無し → tenantName / tenantId 付きで再ログイン（案 A）
- マルチテナント時の既存突き合わせは維持
- フラグ未指定・config.service back-fill では新経路に入らない

## Test plan
- [x] unit: availableTenants 無し × 誤 --tenant → 失敗 / 正 --tenant → 成功
- [x] --tenant UUID → tenantId で送信
- [x] config.service back-fill のみでは再ログインしない
- [x] 変異注入（常に tenantName / globalOpts.service / top-level tenantId）でテストが赤になることを確認
- [x] npm run lint && npm run typecheck && npm run build && npm test
- [ ] npm run test:e2e（未実行・CI に委ねる）

Closes #217


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **機能改善**
  * 単一テナントのアカウントでも、`--tenant` または `--tenant-id` で指定したテナントを検証できるようになりました。
  * テナント名・IDの指定に対応し、無効な指定時はサーバーのエラー内容を表示します。
  * ログイン成功時に、適用されたテナント情報を正しく表示・保存します。

* **ドキュメント**
  * 上記の認証動作に関する変更を変更履歴へ追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->