### PR TITLE
release: v0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## [Unreleased]
 
+## [0.26.0] - 2026-08-18
+
 ### 2026-08-18
 - **Fix**: geonicdb 0.17.0 の too-wide query 検証に合わせ、セレクタ無しの E2E `entities list` / `temporal entities list` に `--local` を付与し、devDependency の geonicdb ピンを 0.17.0 (`d278cba`) へ更新した (closes #212) (#223)
 - **Fix**: 週次互換性チェックの issue 起票 heredoc でバックティックがコマンド置換されるのをエスケープした (#212) (#223)
@@ -419,7 +421,8 @@
 ### 2026-02-26
 - **Docs**: README にインストール手順・使い方・コマンドリファレンスを追加 (#1)
 
-[Unreleased]: https://github.com/geolonia/geonicdb-cli/compare/v0.25.0...HEAD
+[Unreleased]: https://github.com/geolonia/geonicdb-cli/compare/v0.26.0...HEAD
+[0.26.0]: https://github.com/geolonia/geonicdb-cli/compare/v0.25.0...v0.26.0
 [0.25.0]: https://github.com/geolonia/geonicdb-cli/compare/v0.24.0...v0.25.0
 [0.24.0]: https://github.com/geolonia/geonicdb-cli/compare/v0.23.0...v0.24.0
 [0.23.0]: https://github.com/geolonia/geonicdb-cli/compare/v0.22.1...v0.23.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolonia/geonicdb-cli",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolonia/geonicdb-cli",
-      "version": "0.25.0",
+      "version": "0.26.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolonia/geonicdb-cli",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "description": "A CLI client for the GeonicDB",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## 概要

geonicdb-cli v0.26.0 のリリース。

- `package.json` / `package-lock.json` を 0.26.0 へ
- `CHANGELOG.md` の `[Unreleased]` を `[0.26.0] - 2026-08-18` へ確定し、比較リンクを追加

## 含まれる変更 (issue #212-#217 の 6 本)

| issue | 内容 | PR |
|---|---|---|
| #213 | `auth login` が `config.service` にテナント名を保存する（UUID 保存で全コマンドが 400 になっていた本丸） | #218 |
| #214 | `entities list` に `--local` | #219 |
| #215 | マルチテナント login の対話ピッカー廃止（フラグ必須） | #220 |
| #216 | `temporal entities list` に `--local` | #221 |
| #217 | 単一メンバーシップで `--tenant` が黙って無視されるのを fail-loud に | #222 |
| #212 | geonicdb 0.17.0 の too-wide query に E2E を追従 + `--last-n` ヘルプの既定値 100→10 | #223 |

## バージョンの根拠

`entities list` / `temporal entities list` に新オプション `--local` が増えており、また #215 でマルチテナント `auth login` の対話挙動が変わる（フラグ未指定はエラー終了）ため、パッチではなくマイナーを上げる。

## テスト

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test`（45 files / 1103 tests）
- [ ] `npm run test:e2e`（ローカル未実行。CI に委ねる）

リリース内容のコード自体は各 PR で CI 全緑・CodeRabbit approve 済み。本 PR はバージョンと CHANGELOG のみ。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リリース**
  * バージョンを **0.26.0** に更新しました。
  * 変更履歴に **0.26.0（2026年8月18日）** のリリース情報を追加しました。
  * 最新リリース間の比較リンクを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->